### PR TITLE
Minor deprecated, typo fix

### DIFF
--- a/emails.go
+++ b/emails.go
@@ -50,7 +50,7 @@ type Attachment struct {
 
 	// Filename that will appear in the email.
 	// Make sure you pick the correct extension otherwise preview
-	// make not work as expected
+	// may not work as expected
 	Filename string `json:"filename"`
 
 	// Path where the attachment file is hosted

--- a/examples/with_attachments.go
+++ b/examples/with_attachments.go
@@ -2,7 +2,6 @@ package examples
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/resendlabs/resend-go"
@@ -18,7 +17,7 @@ func withAttachments() {
 
 	// Read attachment file
 	pwd, _ := os.Getwd()
-	f, err := ioutil.ReadFile(pwd + "/resources/invoice.pdf")
+	f, err := os.ReadFile(pwd + "/resources/invoice.pdf")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
- fix: typo make -> may
- fix: use `os.ReadFile`, instead of deprecated `ioutil.ReadFile`
