### PR TITLE
Cleaning attachment handling, send int array instead of strings

### DIFF
--- a/examples/with_attachments.go
+++ b/examples/with_attachments.go
@@ -26,7 +26,7 @@ func withAttachments() {
 
 	// Create attachments objects
 	pdfAttachmentFromLocalFile := &resend.Attachment{
-		Content:  string(f),
+		Content:  f,
 		Filename: "invoice1.pdf",
 	}
 
@@ -41,7 +41,7 @@ func withAttachments() {
 		Text:        "email with attachments !!",
 		Html:        "<strong>email with attachments !!</strong>",
 		Subject:     "Email with attachment",
-		Attachments: []resend.Attachment{*pdfAttachmentFromLocalFile, *pdfAttachmentFromRemotePath},
+		Attachments: []*resend.Attachment{pdfAttachmentFromLocalFile, pdfAttachmentFromRemotePath},
 	}
 
 	sent, err := client.Emails.Send(params)

--- a/utils.go
+++ b/utils.go
@@ -1,16 +1,13 @@
 package resend
 
-import "strconv"
-
-// ByteArrayToStringArray converts a byte array to string array
-// ie: []byte{44,45,46} becomes []string{44,45,46}
+// BytesToIntArray converts a byte array to rune array
+// ie: []byte(`hello`) becomes []int{104,101,108,108,111}
 // which will then be properly marshalled into JSON
 // in the way Resend supports
-func ByteArrayToStringArray(a []byte) []string {
-	res := []string{}
-	for _, v := range a {
-		v := strconv.Itoa(int(v))
-		res = append(res, v)
+func BytesToIntArray(a []byte) []int {
+	res := make([]int, len(a))
+	for i, v := range a {
+		res[i] = int(v)
 	}
 	return res
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -6,6 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestByteArrayToArrayString(t *testing.T) {
-	assert.Equal(t, ByteArrayToStringArray([]byte{44, 45, 46}), []string{"44", "45", "46"})
+func TestBytesToIntArray(t *testing.T) {
+	assert.Equal(t, BytesToIntArray([]byte{44, 45, 46}), []int{44, 45, 46})
 }


### PR DESCRIPTION
* Refactoring attachment handling to ensure content sent as integer array.
* Attachment content expect to be binary data instead of strings.
* `SendEmailRequest` will no longer send empty fields.
* Using pointers to more complex structs for consistency with regular Go (this will break the API for some users, although super easy to fix)
