### PR TITLE
refactor: err typing for better client assertion

### DIFF
--- a/api_keys.go
+++ b/api_keys.go
@@ -1,7 +1,6 @@
 package resend
 
 import (
-	"errors"
 	"net/http"
 )
 
@@ -44,7 +43,7 @@ func (s *ApiKeysSvcImpl) Create(params *CreateApiKeyRequest) (CreateApiKeyRespon
 	// Prepare request
 	req, err := s.client.NewRequest(http.MethodPost, path, params)
 	if err != nil {
-		return CreateApiKeyResponse{}, errors.New("[ERROR]: Failed to create ApiKeys.Create request")
+		return CreateApiKeyResponse{}, ErrFailedToCreateApiKeysCreateRequest
 	}
 
 	// Build response recipient obj
@@ -60,7 +59,7 @@ func (s *ApiKeysSvcImpl) Create(params *CreateApiKeyRequest) (CreateApiKeyRespon
 	return *apiKeysResp, nil
 }
 
-// List list all API Keys in the project
+// List all API Keys in the project
 // https://resend.com/docs/api-reference/api-keys/list-api-keys
 func (s *ApiKeysSvcImpl) List() (ListApiKeysResponse, error) {
 	path := "api-keys"
@@ -68,7 +67,7 @@ func (s *ApiKeysSvcImpl) List() (ListApiKeysResponse, error) {
 	// Prepare request
 	req, err := s.client.NewRequest(http.MethodGet, path, nil)
 	if err != nil {
-		return ListApiKeysResponse{}, errors.New("[ERROR]: Failed to create ApiKeys.List request")
+		return ListApiKeysResponse{}, ErrFailedToCreateApiKeysListRequest
 	}
 
 	// Build response recipient obj
@@ -92,7 +91,7 @@ func (s *ApiKeysSvcImpl) Remove(apiKeyId string) (bool, error) {
 	// Prepare request
 	req, err := s.client.NewRequest(http.MethodDelete, path, nil)
 	if err != nil {
-		return false, errors.New("[ERROR]: Failed to create ApiKeys.List request")
+		return false, ErrFailedToCreateApiKeysRemoveRequest
 	}
 
 	// Send Request

--- a/emails.go
+++ b/emails.go
@@ -2,7 +2,6 @@ package resend
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http"
 )
 
@@ -97,7 +96,7 @@ func (s *EmailsSvcImpl) Send(params *SendEmailRequest) (*SendEmailResponse, erro
 	// Prepare request
 	req, err := s.client.NewRequest(http.MethodPost, path, params)
 	if err != nil {
-		return nil, errors.New("[ERROR]: Failed to create SendEmail request")
+		return nil, ErrFailedToCreateEmailsSendRequest
 	}
 
 	// Build response recipient obj
@@ -121,7 +120,7 @@ func (s *EmailsSvcImpl) Get(emailID string) (*Email, error) {
 	// Prepare request
 	req, err := s.client.NewRequest(http.MethodGet, path, nil)
 	if err != nil {
-		return nil, errors.New("[ERROR]: Failed to create GetEmail request")
+		return nil, ErrFailedToCreateEmailsGetRequest
 	}
 
 	// Build response recipient obj

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,17 @@
+package resend
+
+import "errors"
+
+// ApiKeySvc errors
+var (
+	ErrFailedToCreateApiKeysCreateRequest = errors.New("[ERROR]: Failed to create ApiKeys.Create request")
+	ErrFailedToCreateApiKeysListRequest   = errors.New("[ERROR]: Failed to create ApiKeys.List request")
+	ErrFailedToCreateApiKeysRemoveRequest = errors.New("[ERROR]: Failed to create ApiKeys.Remove request")
+)
+
+// EmailsSvc errors
+
+var (
+	ErrFailedToCreateEmailsSendRequest = errors.New("[ERROR]: Failed to create SendEmail request")
+	ErrFailedToCreateEmailsGetRequest  = errors.New("[ERROR]: Failed to create GetEmail request")
+)


### PR DESCRIPTION
Refactoring the error returns to be set in a set of Errors.

That way is easier for the client application to check with errors.is(...) and do a better treatment of what happened. 