### PR TITLE
feat: Creating `SendEmailRequest` using function options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,44 @@ func main() {
 }
 
 ```
+```go
+import (
+    "fmt"
+    "github.com/resend/resend-go/v2"
+)
+
+func main() {
+    apiKey := "re_123"
+
+    client := resend.NewClient(apiKey)
+    // No need to create objects manually
+    sent, err := client.Emails.Send(
+        client.Emails.SendWithOption(
+        WithSendEmailTo([]string{"to@example", "you@example.com"}),
+        WithSendEmailFrom("me@exemple.io"),
+        WithSendEmailText("hello world"),
+        WithSendEmailSubject("Hello from Golang"),
+        WithSendEmailCc([]string{"cc@example.com"}),
+        WithSendEmailBcc([]string{"cc@example.com"}),
+        WithSendEmailReplyTo("replyto@example.com"),
+        WithSendEmailScheduledAt(""),
+        WithSendEmailAttachment(
+            WithAttachmentPath("/test"),
+            WithAttachmentContent([]byte{}),
+            WithAttachmentFilename("test.txt"),
+        ),
+        WithSendEmailAttachment(
+            WithAttachmentPath("/test"),
+            WithAttachmentContent([]byte{}),
+            WithAttachmentFilename("test2.txt"),
+        ),
+        )
+    )
+    if err != nil {
+        panic(err)
+    }
+    fmt.Println(sent.Id)
+}
+```
 
 You can view all the examples in the [examples folder](https://github.com/resend/resend-go/tree/main/examples)

--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ func main() {
 
     client := resend.NewClient(apiKey)
     // No need to create objects manually
-    sent, err := client.Emails.Send(
-        client.Emails.SendWithOption(
+    sent, err := client.Emails.SendWithOption(
         WithSendEmailTo([]string{"to@example", "you@example.com"}),
         WithSendEmailFrom("me@exemple.io"),
         WithSendEmailText("hello world"),

--- a/emails_test.go
+++ b/emails_test.go
@@ -31,6 +31,26 @@ func teardown() {
 	server.Close()
 }
 
+func TestCreateRequest(t *testing.T){
+	client := NewClient("")
+	client.Emails.SendWithOption(
+		WithSendEmailTo([]string{"to@example", "you@example.com"}),
+		WithSendEmailFrom("me@exemple.io"),
+		WithSendEmailText("hello world"),
+		WithSendEmailSubject("Hello from Golang"),
+		WithSendEmailCc([]string{"cc@example.com"}),
+		WithSendEmailBcc([]string{"cc@example.com"}),
+		WithSendEmailReplyTo("replyto@example.com"),
+		WithSendEmailScheduledAt(""),
+		WithSendEmailAttachment(
+			WithAttachmentPath(""),
+			WithAttachmentContent([]byte{}),
+			WithAttachmentFilename("test.txt"),
+			WithAttachmentContentType(""),
+		),
+	)
+}
+
 func TestScheduleEmail(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
-  create `SendEmailRequest` using function option
- update README

**note**
For backward compatibility, the original Send method is retained. SendWithOption uses Function Option to automatically create objects, which can automatically prompt the corresponding fields without having to care about the entire structure field.