### PR TITLE
feat: Add support for Idempotency Key 

### DIFF
--- a/emails_test.go
+++ b/emails_test.go
@@ -2,6 +2,7 @@ package resend
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -184,6 +185,28 @@ func TestCancelScheduledEmail(t *testing.T) {
 	}
 	assert.Equal(t, resp.Id, "dacf4072-4119-4d88-932f-6202748ac7c8")
 	assert.Equal(t, resp.Object, "email")
+}
+
+func TestSendEmailWithOptions(t *testing.T) {
+	ctx := context.TODO()
+	client := NewClient("123")
+	params := &SendEmailRequest{
+		To: []string{"email@example.com", "email2@example.com"},
+	}
+	options := &SendEmailOptions{
+		IdempotencyKey: "unique-idempotency-key",
+	}
+
+	req, err := client.NewRequestWithOptions(ctx, "POST", "/emails/", params, options)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, req.Header["Accept"][0], "application/json")
+	assert.Equal(t, req.Header["Content-Type"][0], "application/json")
+	assert.Equal(t, req.Method, http.MethodPost)
+	assert.Equal(t, req.URL.String(), "https://api.resend.com/emails/")
+	assert.Equal(t, req.Header["Authorization"][0], "Bearer 123")
+	assert.Equal(t, req.Header["Idempotency-Key"][0], "unique-idempotency-key")
 }
 
 func testMethod(t *testing.T, r *http.Request, expected string) {

--- a/examples/send_email.go
+++ b/examples/send_email.go
@@ -14,7 +14,7 @@ func sendEmailExample() {
 
 	client := resend.NewClient(apiKey)
 
-	// Send
+	// Send params
 	params := &resend.SendEmailRequest{
 		To:      []string{"delivered@resend.dev"},
 		From:    "onboarding@resend.dev",
@@ -29,13 +29,23 @@ func sendEmailExample() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println(sent.Id)
+	fmt.Printf("Sent basic email: %s\n", sent.Id)
 
-	// Get
+	// Sending with IdempotencyKey
+	options := &resend.SendEmailOptions{
+		IdempotencyKey: "unique-idempotency-key",
+	}
+
+	sent, err = client.Emails.SendWithOptions(ctx, params, options)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Sent email with idempotency key: %s\n", sent.Id)
+
+	// Get Email
 	email, err := client.Emails.GetWithContext(ctx, sent.Id)
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("%v\n", email)
-
 }

--- a/resend_test.go
+++ b/resend_test.go
@@ -32,6 +32,9 @@ func TestResendRequestHeaders(t *testing.T) {
 	assert.Equal(t, req.Method, http.MethodPost)
 	assert.Equal(t, req.URL.String(), "https://api.resend.com/emails/")
 	assert.Equal(t, req.Header["Authorization"][0], "Bearer 123")
+
+	_, ok := req.Header["Idempotency-Key"]
+	assert.False(t, ok, "expected 'Idempotency-Key' header to be absent")
 }
 
 func TestResendRequestShouldReturnErrorIfContextIsCancelled(t *testing.T) {


### PR DESCRIPTION
- added a new `.SendWithOptions` method on the Emails wrapper for backwards compatibility, this will converge into a single Send method in a `v3` release