### PR TITLE
fix: Unsubscribed False omits field from json issue.

### DIFF
--- a/contacts.go
+++ b/contacts.go
@@ -43,6 +43,11 @@ type UpdateContactRequest struct {
 	unsubscribedSet bool `json:"-"`
 }
 
+// Temporary setter for the `unsubscribed` field. This is here
+// as a backwards compatible way to set the unsubscribed field as false, since the
+// default zero value for a bool is false with omitempty, and setting as false
+// would omit the field from the JSON representation.
+// Proper fix for this is coming in v3.
 func (r *UpdateContactRequest) SetUnsubscribed(val bool) {
 	r.Unsubscribed = val
 	r.unsubscribedSet = true

--- a/examples/contacts.go
+++ b/examples/contacts.go
@@ -77,7 +77,7 @@ func contactsExample() {
 	removed, err := client.Contacts.RemoveWithContext(ctx, audienceId, contact.Id)
 
 	// Remove by email
-	// removed, err = client.Contacts.RemoveWithContext(ctx, audienceId, "hi@example.com")
+	// removed, err := client.Contacts.RemoveWithContext(ctx, audienceId, "hi@example.com")
 	if err != nil {
 		panic(err)
 	}

--- a/examples/contacts.go
+++ b/examples/contacts.go
@@ -20,10 +20,11 @@ func contactsExample() {
 
 	// Create Contact params
 	params := &resend.CreateContactRequest{
-		Email:      contactEmail,
-		AudienceId: audienceId,
-		FirstName:  "Steve",
-		LastName:   "Woz",
+		Email:        contactEmail,
+		AudienceId:   audienceId,
+		FirstName:    "Steve",
+		LastName:     "Woz",
+		Unsubscribed: true,
 	}
 
 	contact, err := client.Contacts.CreateWithContext(ctx, params)
@@ -34,12 +35,15 @@ func contactsExample() {
 
 	// Update
 	updateParams := &resend.UpdateContactRequest{
-		AudienceId:   audienceId,
-		Id:           contact.Id,
-		FirstName:    "Updated First Name",
-		LastName:     "Updated Last Name",
-		Unsubscribed: true,
+		AudienceId: audienceId,
+		Id:         "88ffbe62-9bd6-4a39-9ddc-4d51053e172a",
+		FirstName:  "new Updated First Name",
+		LastName:   "new Updated Last Name",
 	}
+
+	// Set unsubscribed to false
+	updateParams.SetUnsubscribed(false)
+
 	_, err = client.Contacts.UpdateWithContext(ctx, updateParams)
 	if err != nil {
 		panic(err)
@@ -73,7 +77,7 @@ func contactsExample() {
 	removed, err := client.Contacts.RemoveWithContext(ctx, audienceId, contact.Id)
 
 	// Remove by email
-	// removed, err := client.Contacts.RemoveWithContext(ctx, audienceId, "hi@example.com")
+	// removed, err = client.Contacts.RemoveWithContext(ctx, audienceId, "hi@example.com")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
 Currently users are unable to set `Unsubscribed: false` because the `UpdateContactRequest` struct has `Unsubscribed` as a bool with the `omitempty` json tag.

Unfortunately this breaks the unsubscription behaviour, because:

1. When using `omitempty`, a boolean value when set to `false` gets omitted, when the user expects the false value to be sent.
2. If we removed the `omitempty` tag, when the `Unsubscribed` is not set at all (user do not set the attribute on the request struct), it gets defaulted to `false` which breaks the behaviour as well.

A proper fix for this would be to use a Bool pointer, but that would change the type of the Request struct causing a breaking change, so I marked this to be fixed as part of the v3 release.

The fix for this PR consists of a new function `SetUnsubscribed` plus a custom `MarshalJSON` function for the `UpdateRequestParams` struct.

temporarily closes #67 