### PR TITLE
feat: Handle rate limit error more gracefully

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -14,6 +14,38 @@ func (e *MissingRequiredFieldsError) Error() string {
 	return fmt.Sprintf("%s", e.message)
 }
 
+// ErrRateLimit is a sentinel error for rate limit detection with errors.Is
+var ErrRateLimit = errors.New("rate limit exceeded")
+
+// RateLimitError represents a rate limit error with metadata from response headers
+type RateLimitError struct {
+	// Message is the error message from the API
+	Message string
+
+	// Limit is the maximum number of requests allowed in the current window (raw header value)
+	Limit string
+
+	// Remaining is the number of requests remaining in the current window (raw header value)
+	Remaining string
+
+	// Reset is the time when the rate limit will reset in seconds (raw header value)
+	Reset string
+
+	// RetryAfter is the recommended wait time before retrying in seconds (raw header value)
+	RetryAfter string
+}
+
+// Error implements the error interface
+func (e *RateLimitError) Error() string {
+	return fmt.Sprintf("rate limit exceeded: %s (limit: %s, remaining: %s, reset: %s, retry after: %s)",
+		e.Message, e.Limit, e.Remaining, e.Reset, e.RetryAfter)
+}
+
+// Is implements errors.Is support for detecting rate limit errors
+func (e *RateLimitError) Is(target error) bool {
+	return target == ErrRateLimit
+}
+
 // BroadcastsSvc errors
 var (
 	ErrFailedToCreateBroadcastUpdateRequest = errors.New("[ERROR]: Failed to create Broadcasts.Update request")

--- a/examples/handle_rate_limit.go
+++ b/examples/handle_rate_limit.go
@@ -1,0 +1,63 @@
+package examples
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/resend/resend-go/v2"
+)
+
+func handleRateLimitExample() {
+	ctx := context.TODO()
+	apiKey := os.Getenv("RESEND_API_KEY")
+
+	client := resend.NewClient(apiKey)
+
+	params := &resend.SendEmailRequest{
+		To:      []string{"delivered@resend.dev"},
+		From:    "onboarding@resend.dev",
+		Text:    "hello world",
+		Subject: "Hello from Golang",
+	}
+
+	sent, err := client.Emails.SendWithContext(ctx, params)
+	if err != nil {
+		// Check if it's a rate limit error using errors.Is
+		if errors.Is(err, resend.ErrRateLimit) {
+			fmt.Println("Rate limit exceeded!")
+
+			// Extract detailed rate limit information
+			var rateLimitErr *resend.RateLimitError
+			if errors.As(err, &rateLimitErr) {
+				fmt.Printf("Message: %s\n", rateLimitErr.Message)
+				fmt.Printf("Limit: %s requests\n", rateLimitErr.Limit)
+				fmt.Printf("Remaining: %s requests\n", rateLimitErr.Remaining)
+				fmt.Printf("Reset in: %s seconds\n", rateLimitErr.Reset)
+				fmt.Printf("Retry after: %s seconds\n", rateLimitErr.RetryAfter)
+
+				// Implement retry logic
+				if retryAfter, err := strconv.Atoi(rateLimitErr.RetryAfter); err == nil {
+					fmt.Printf("Waiting %d seconds before retry...\n", retryAfter)
+					time.Sleep(time.Duration(retryAfter) * time.Second)
+
+					// Retry the request
+					sent, err = client.Emails.SendWithContext(ctx, params)
+					if err != nil {
+						panic(err)
+					}
+					fmt.Printf("Successfully sent after retry: %s\n", sent.Id)
+				}
+			}
+			return
+		}
+
+		// Handle other errors
+		panic(err)
+	}
+
+	fmt.Printf("Email sent successfully: %s\n", sent.Id)
+}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Gracefully handle 429 responses by returning a typed RateLimitError with header metadata, enabling errors.Is/As detection and simple retry logic.

- **New Features**
  - Add ErrRateLimit sentinel and RateLimitError with limit, remaining, reset, and retry-after data.
  - Update handleError to parse 429 JSON message and headers, returning RateLimitError.
  - Include example showing errors.Is/As usage and retry based on Retry-After.
  - Add tests covering 429 handling, errors.Is, and errors.As.

<!-- End of auto-generated description by cubic. -->

