### PR TITLE
chore: Bump to v2.26.0

### DIFF
--- a/resend.go
+++ b/resend.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version     = "2.25.0"
+	version     = "2.26.0"
 	userAgent   = "resend-go/" + version
 	contentType = "application/json"
 )


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Bumped the SDK version to v2.26.0 to reflect the new release and update the user agent string. No functional changes.

<!-- End of auto-generated description by cubic. -->

