### PR TITLE
feat: Add html/text fields to broadcasts response object

### DIFF
--- a/broadcasts.go
+++ b/broadcasts.go
@@ -72,6 +72,8 @@ type Broadcast struct {
 	CreatedAt   string   `json:"created_at"`
 	ScheduledAt string   `json:"scheduled_at"`
 	SentAt      string   `json:"sent_at"`
+	Html        string   `json:"html"`
+	Text        string   `json:"text"`
 }
 
 type BroadcastsSvc interface {

--- a/broadcasts_test.go
+++ b/broadcasts_test.go
@@ -127,7 +127,9 @@ func TestGetBroadcast(t *testing.T) {
 			"status": "draft",
 			"created_at": "2024-12-01T19:32:22.980Z",
 			"scheduled_at": null,
-			"sent_at": null
+			"sent_at": null,
+			"html": "<h1>Hello world</h1>",
+			"text": "Hello world"
 		}`
 
 		fmt.Fprint(w, ret)

--- a/examples/broadcasts.go
+++ b/examples/broadcasts.go
@@ -45,6 +45,8 @@ func broadcastExamples() {
 	fmt.Println("Created At: " + retrievedBroadcast.CreatedAt)
 	fmt.Println("Scheduled At: " + retrievedBroadcast.ScheduledAt)
 	fmt.Println("Sent At: " + retrievedBroadcast.SentAt)
+	fmt.Println("Html: " + retrievedBroadcast.Html)
+	fmt.Println("Text: " + retrievedBroadcast.Text)
 
 	updateParams := &resend.UpdateBroadcastRequest{
 		BroadcastId: retrievedBroadcast.Id,
@@ -85,6 +87,8 @@ func broadcastExamples() {
 		fmt.Println("Created At: " + b.CreatedAt)
 		fmt.Println("Scheduled At: " + b.ScheduledAt)
 		fmt.Println("Sent At: " + b.SentAt)
+		fmt.Println("Html: " + b.Html)
+		fmt.Println("Text: " + b.Text)
 	}
 
 	// Remove Broadcast (Only Draft Broadcasts can be deleted)

--- a/resend.go
+++ b/resend.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version     = "2.26.0"
+	version     = "2.27.0"
 	userAgent   = "resend-go/" + version
 	contentType = "application/json"
 )


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Expose html and text in Broadcast API responses so clients can read the rendered content. Added Html and Text fields to Broadcast, updated tests/examples, and bumped SDK version to 2.27.0.

<!-- End of auto-generated description by cubic. -->

