### PR TITLE
feat: Inbound support

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -67,3 +67,9 @@ var (
 	ErrFailedToCreateEmailsGetRequest   = errors.New("[ERROR]: Failed to create GetEmail request")
 	ErrFailedToCreateEmailsListRequest  = errors.New("[ERROR]: Failed to create ListEmails request")
 )
+
+// ReceivingSvc errors
+var (
+	ErrFailedToCreateReceivingGetRequest  = errors.New("[ERROR]: Failed to create Receiving.Get request")
+	ErrFailedToCreateReceivingListRequest = errors.New("[ERROR]: Failed to create Receiving.List request")
+)

--- a/errors.go
+++ b/errors.go
@@ -70,6 +70,8 @@ var (
 
 // ReceivingSvc errors
 var (
-	ErrFailedToCreateReceivingGetRequest  = errors.New("[ERROR]: Failed to create Receiving.Get request")
-	ErrFailedToCreateReceivingListRequest = errors.New("[ERROR]: Failed to create Receiving.List request")
+	ErrFailedToCreateReceivingGetRequest            = errors.New("[ERROR]: Failed to create Receiving.Get request")
+	ErrFailedToCreateReceivingListRequest           = errors.New("[ERROR]: Failed to create Receiving.List request")
+	ErrFailedToCreateReceivingGetAttachmentRequest  = errors.New("[ERROR]: Failed to create Receiving.GetAttachment request")
+	ErrFailedToCreateReceivingListAttachmentsRequest = errors.New("[ERROR]: Failed to create Receiving.ListAttachments request")
 )

--- a/examples/receiving.go
+++ b/examples/receiving.go
@@ -1,0 +1,45 @@
+package examples
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/resend/resend-go/v2"
+)
+
+func receivingExample() {
+	ctx := context.TODO()
+	apiKey := os.Getenv("RESEND_API_KEY")
+
+	client := resend.NewClient(apiKey)
+
+	// Get a single received email
+	email, err := client.Receiving.GetWithContext(ctx, "8136d3fb-0439-4b09-b939-b8436a3524b6")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Retrieved received email: %s\n", email.Subject)
+	fmt.Printf("From: %s\n", email.From)
+	fmt.Printf("To: %v\n", email.To)
+	fmt.Printf("Has %d attachments\n", len(email.Attachments))
+
+	// List received emails
+	emails, err := client.Receiving.ListWithContext(ctx)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("\nYou have %d received emails\n", len(emails.Data))
+	fmt.Printf("Has more: %v\n", emails.HasMore)
+
+	// List with pagination
+	limit := 10
+	listOptions := &resend.ListOptions{
+		Limit: &limit,
+	}
+	paginatedEmails, err := client.Receiving.ListWithOptions(ctx, listOptions)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("\nPaginated list returned %d emails\n", len(paginatedEmails.Data))
+}

--- a/examples/receiving.go
+++ b/examples/receiving.go
@@ -42,4 +42,46 @@ func receivingExample() {
 		panic(err)
 	}
 	fmt.Printf("\nPaginated list returned %d emails\n", len(paginatedEmails.Data))
+
+	// Get email with attachments
+	emailWithAttachments, err := client.Receiving.GetWithContext(ctx, "006e2796-ff6a-4436-91ad-0429e600bf8a")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("\nEmail '%s' has %d attachments\n", emailWithAttachments.Subject, len(emailWithAttachments.Attachments))
+
+	// Get each attachment's full details including download URLs
+	for _, att := range emailWithAttachments.Attachments {
+		attachment, err := client.Receiving.GetAttachmentWithContext(ctx, emailWithAttachments.Id, att.Id)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("\nAttachment #%s:\n", att.Id)
+		fmt.Printf("  Filename: %s\n", attachment.Filename)
+		fmt.Printf("  Content Type: %s\n", attachment.ContentType)
+		fmt.Printf("  Download URL: %s\n", attachment.DownloadUrl)
+		fmt.Printf("  Expires At: %s\n", attachment.ExpiresAt)
+	}
+
+	// List all attachments for a received email
+	attachmentsList, err := client.Receiving.ListAttachmentsWithContext(ctx, "006e2796-ff6a-4436-91ad-0429e600bf8a")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("\nEmail has %d attachments\n", len(attachmentsList.Data))
+	fmt.Printf("Has more: %v\n", attachmentsList.HasMore)
+
+	// List attachments with pagination
+	attachmentsLimit := 5
+	attachmentsOptions := &resend.ListOptions{
+		Limit: &attachmentsLimit,
+	}
+	paginatedAttachments, err := client.Receiving.ListAttachmentsWithOptions(ctx, "006e2796-ff6a-4436-91ad-0429e600bf8a", attachmentsOptions)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("\nPaginated attachments list returned %d attachments\n", len(paginatedAttachments.Data))
+	for _, att := range paginatedAttachments.Data {
+		fmt.Printf("  - %s (%s)\n", att.Filename, att.ContentType)
+	}
 }

--- a/receiving.go
+++ b/receiving.go
@@ -139,7 +139,6 @@ func (s *ReceivingSvcImpl) ListWithOptions(ctx context.Context, options *ListOpt
 	// Build response recipient obj
 	listEmailsResponse := new(ListReceivedEmailsResponse)
 
-	// Send Request
 	_, err = s.client.Perform(req, listEmailsResponse)
 
 	if err != nil {

--- a/receiving.go
+++ b/receiving.go
@@ -106,7 +106,6 @@ func (s *ReceivingSvcImpl) GetWithContext(ctx context.Context, emailID string) (
 		return nil, ErrFailedToCreateReceivingGetRequest
 	}
 
-	// Build response recipient obj
 	emailResponse := new(ReceivedEmail)
 
 	// Send Request

--- a/receiving.go
+++ b/receiving.go
@@ -1,0 +1,133 @@
+package resend
+
+import (
+	"context"
+	"net/http"
+)
+
+// ReceivedEmail provides the structure for the response from the Receiving.Get call.
+type ReceivedEmail struct {
+	Id          string               `json:"id"`
+	Object      string               `json:"object"` // Always "inbound" for received emails
+	To          []string             `json:"to"`
+	From        string               `json:"from"`
+	CreatedAt   string               `json:"created_at"`
+	Subject     string               `json:"subject"`
+	Html        string               `json:"html"`
+	Text        string               `json:"text"`
+	Bcc         []string             `json:"bcc"`
+	Cc          []string             `json:"cc"`
+	ReplyTo     []string             `json:"reply_to"`
+	Headers     map[string]string    `json:"headers"`
+	Attachments []ReceivedAttachment `json:"attachments"`
+}
+
+// ListReceivedEmail provides the structure for items in the Receiving.List call.
+// It omits html, text, and headers fields compared to ReceivedEmail.
+type ListReceivedEmail struct {
+	Id          string               `json:"id"`
+	To          []string             `json:"to"`
+	From        string               `json:"from"`
+	CreatedAt   string               `json:"created_at"`
+	Subject     string               `json:"subject"`
+	Bcc         []string             `json:"bcc"`
+	Cc          []string             `json:"cc"`
+	ReplyTo     []string             `json:"reply_to"`
+	Attachments []ReceivedAttachment `json:"attachments"`
+}
+
+// ListReceivedEmailsResponse is the response from the Receiving.List call.
+type ListReceivedEmailsResponse struct {
+	Object  string              `json:"object"`
+	HasMore bool                `json:"has_more"`
+	Data    []ListReceivedEmail `json:"data"`
+}
+
+// ReceivedAttachment represents an attachment in a received email
+type ReceivedAttachment struct {
+	Id                 string `json:"id"`
+	Filename           string `json:"filename"`
+	ContentType        string `json:"content_type"`
+	ContentDisposition string `json:"content_disposition"`
+	ContentId          string `json:"content_id"`
+}
+
+// ReceivingSvc handles operations for received/inbound emails
+type ReceivingSvc interface {
+	GetWithContext(ctx context.Context, emailID string) (*ReceivedEmail, error)
+	Get(emailID string) (*ReceivedEmail, error)
+	ListWithOptions(ctx context.Context, options *ListOptions) (ListReceivedEmailsResponse, error)
+	ListWithContext(ctx context.Context) (ListReceivedEmailsResponse, error)
+	List() (ListReceivedEmailsResponse, error)
+}
+
+// ReceivingSvcImpl is the implementation of the ReceivingSvc interface
+type ReceivingSvcImpl struct {
+	client *Client
+}
+
+// GetWithContext retrieves a received email with the given emailID
+// https://resend.com/docs/api-reference/emails/retrieve-received-email
+func (s *ReceivingSvcImpl) GetWithContext(ctx context.Context, emailID string) (*ReceivedEmail, error) {
+	path := "emails/receiving/" + emailID
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, ErrFailedToCreateReceivingGetRequest
+	}
+
+	// Build response recipient obj
+	emailResponse := new(ReceivedEmail)
+
+	// Send Request
+	_, err = s.client.Perform(req, emailResponse)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return emailResponse, nil
+}
+
+// Get retrieves a received email with the given emailID
+// https://resend.com/docs/api-reference/emails/retrieve-received-email
+func (s *ReceivingSvcImpl) Get(emailID string) (*ReceivedEmail, error) {
+	return s.GetWithContext(context.Background(), emailID)
+}
+
+// ListWithOptions retrieves a list of received emails with pagination options
+// https://resend.com/docs/api-reference/emails/retrieve-received-email
+func (s *ReceivingSvcImpl) ListWithOptions(ctx context.Context, options *ListOptions) (ListReceivedEmailsResponse, error) {
+	path := "emails/receiving" + buildPaginationQuery(options)
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return ListReceivedEmailsResponse{}, ErrFailedToCreateReceivingListRequest
+	}
+
+	// Build response recipient obj
+	listEmailsResponse := new(ListReceivedEmailsResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, listEmailsResponse)
+
+	if err != nil {
+		return ListReceivedEmailsResponse{}, err
+	}
+
+	return *listEmailsResponse, nil
+}
+
+// ListWithContext retrieves a list of received emails
+// https://resend.com/docs/api-reference/emails/retrieve-received-email
+func (s *ReceivingSvcImpl) ListWithContext(ctx context.Context) (ListReceivedEmailsResponse, error) {
+	return s.ListWithOptions(ctx, nil)
+}
+
+// List retrieves a list of received emails
+// https://resend.com/docs/api-reference/emails/retrieve-received-email
+func (s *ReceivingSvcImpl) List() (ListReceivedEmailsResponse, error) {
+	return s.ListWithContext(context.Background())
+}

--- a/receiving.go
+++ b/receiving.go
@@ -136,7 +136,6 @@ func (s *ReceivingSvcImpl) ListWithOptions(ctx context.Context, options *ListOpt
 		return ListReceivedEmailsResponse{}, ErrFailedToCreateReceivingListRequest
 	}
 
-	// Build response recipient obj
 	listEmailsResponse := new(ListReceivedEmailsResponse)
 
 	_, err = s.client.Perform(req, listEmailsResponse)

--- a/receiving.go
+++ b/receiving.go
@@ -129,7 +129,6 @@ func (s *ReceivingSvcImpl) Get(emailID string) (*ReceivedEmail, error) {
 func (s *ReceivingSvcImpl) ListWithOptions(ctx context.Context, options *ListOptions) (ListReceivedEmailsResponse, error) {
 	path := "emails/receiving" + buildPaginationQuery(options)
 
-	// Prepare request
 	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return ListReceivedEmailsResponse{}, ErrFailedToCreateReceivingListRequest

--- a/receiving_test.go
+++ b/receiving_test.go
@@ -1,0 +1,270 @@
+package resend
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetReceivedEmail(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/emails/receiving/8136d3fb-0439-4b09-b939-b8436a3524b6", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "inbound",
+			"id": "8136d3fb-0439-4b09-b939-b8436a3524b6",
+			"to": ["delivered@resend.dev"],
+			"from": "Acme <onboarding@resend.dev>",
+			"created_at": "2023-04-03T22:13:42.674981+00:00",
+			"subject": "Hello World",
+			"html": "Congrats on sending your <strong>first email</strong>!",
+			"text": "Congrats on sending your first email!",
+			"bcc": [],
+			"cc": ["cc@example.com"],
+			"reply_to": ["reply@example.com"],
+			"headers": {
+				"X-Custom-Header": "value"
+			},
+			"attachments": [
+				{
+					"id": "2a0c9ce0-3112-4728-976e-47ddcd16a318",
+					"filename": "avatar.png",
+					"content_type": "image/png",
+					"content_disposition": "inline",
+					"content_id": "img001"
+				}
+			]
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	resp, err := client.Receiving.Get("8136d3fb-0439-4b09-b939-b8436a3524b6")
+	if err != nil {
+		t.Errorf("Receiving.Get returned error: %v", err)
+	}
+	assert.Equal(t, "8136d3fb-0439-4b09-b939-b8436a3524b6", resp.Id)
+	assert.Equal(t, "inbound", resp.Object)
+	assert.Equal(t, "Acme <onboarding@resend.dev>", resp.From)
+	assert.Equal(t, "Hello World", resp.Subject)
+	assert.Equal(t, "Congrats on sending your <strong>first email</strong>!", resp.Html)
+	assert.Equal(t, "Congrats on sending your first email!", resp.Text)
+	assert.Equal(t, 1, len(resp.To))
+	assert.Equal(t, "delivered@resend.dev", resp.To[0])
+	assert.Equal(t, 1, len(resp.Cc))
+	assert.Equal(t, "cc@example.com", resp.Cc[0])
+	assert.Equal(t, 1, len(resp.ReplyTo))
+	assert.Equal(t, "reply@example.com", resp.ReplyTo[0])
+	assert.Equal(t, 1, len(resp.Headers))
+	assert.Equal(t, "value", resp.Headers["X-Custom-Header"])
+	assert.Equal(t, 1, len(resp.Attachments))
+	assert.Equal(t, "2a0c9ce0-3112-4728-976e-47ddcd16a318", resp.Attachments[0].Id)
+	assert.Equal(t, "avatar.png", resp.Attachments[0].Filename)
+	assert.Equal(t, "image/png", resp.Attachments[0].ContentType)
+	assert.Equal(t, "inline", resp.Attachments[0].ContentDisposition)
+	assert.Equal(t, "img001", resp.Attachments[0].ContentId)
+}
+
+func TestGetReceivedEmailWithNullFields(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/emails/receiving/null-fields-id", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "inbound",
+			"id": "null-fields-id",
+			"to": ["delivered@resend.dev"],
+			"from": "sender@example.com",
+			"created_at": "2023-04-03T22:13:42.674981+00:00",
+			"subject": "Test Subject",
+			"html": "",
+			"text": "",
+			"bcc": [],
+			"cc": [],
+			"reply_to": [],
+			"headers": {},
+			"attachments": []
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	resp, err := client.Receiving.Get("null-fields-id")
+	if err != nil {
+		t.Errorf("Receiving.Get returned error: %v", err)
+	}
+	assert.Equal(t, "null-fields-id", resp.Id)
+	assert.Equal(t, "", resp.Html)
+	assert.Equal(t, "", resp.Text)
+	assert.Equal(t, 0, len(resp.Bcc))
+	assert.Equal(t, 0, len(resp.Cc))
+	assert.Equal(t, 0, len(resp.ReplyTo))
+	assert.Equal(t, 0, len(resp.Headers))
+	assert.Equal(t, 0, len(resp.Attachments))
+}
+
+func TestListReceivedEmails(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/emails/receiving", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := &ListReceivedEmailsResponse{
+			Object:  "list",
+			HasMore: true,
+			Data: []ListReceivedEmail{
+				{
+					Id:        "1",
+					To:        []string{"recipient@example.com"},
+					From:      "sender@example.com",
+					CreatedAt: "2024-01-01T00:00:00Z",
+					Subject:   "Test Email 1",
+					Bcc:       []string{},
+					Cc:        []string{"cc@example.com"},
+					ReplyTo:   []string{},
+					Attachments: []ReceivedAttachment{
+						{
+							Id:                 "att1",
+							Filename:           "file.pdf",
+							ContentType:        "application/pdf",
+							ContentDisposition: "attachment",
+							ContentId:          "cid1",
+						},
+					},
+				},
+				{
+					Id:          "2",
+					To:          []string{"recipient2@example.com"},
+					From:        "sender2@example.com",
+					CreatedAt:   "2024-01-02T00:00:00Z",
+					Subject:     "Test Email 2",
+					Bcc:         []string{},
+					Cc:          []string{},
+					ReplyTo:     []string{},
+					Attachments: []ReceivedAttachment{},
+				},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(ret); err != nil {
+			panic(err)
+		}
+	})
+
+	resp, err := client.Receiving.List()
+	if err != nil {
+		t.Errorf("Receiving.List returned error: %v", err)
+	}
+
+	assert.Equal(t, "list", resp.Object)
+	assert.Equal(t, true, resp.HasMore)
+	assert.Equal(t, 2, len(resp.Data))
+	assert.Equal(t, "1", resp.Data[0].Id)
+	assert.Equal(t, "sender@example.com", resp.Data[0].From)
+	assert.Equal(t, "Test Email 1", resp.Data[0].Subject)
+	assert.Equal(t, 1, len(resp.Data[0].Attachments))
+	assert.Equal(t, "att1", resp.Data[0].Attachments[0].Id)
+	assert.Equal(t, "2", resp.Data[1].Id)
+}
+
+func TestListReceivedEmailsWithParameters(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/emails/receiving", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+
+		// Verify query parameters
+		query := r.URL.Query()
+		assert.Equal(t, "10", query.Get("limit"))
+		assert.Equal(t, "cursor123", query.Get("after"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := &ListReceivedEmailsResponse{
+			Object:  "list",
+			HasMore: false,
+			Data: []ListReceivedEmail{
+				{
+					Id:          "1",
+					To:          []string{"recipient@example.com"},
+					From:        "sender@example.com",
+					CreatedAt:   "2024-01-01T00:00:00Z",
+					Subject:     "Test Email 1",
+					Bcc:         []string{},
+					Cc:          []string{},
+					ReplyTo:     []string{},
+					Attachments: []ReceivedAttachment{},
+				},
+			},
+		}
+
+		if err := json.NewEncoder(w).Encode(ret); err != nil {
+			panic(err)
+		}
+	})
+
+	limit := 10
+	after := "cursor123"
+	options := &ListOptions{
+		Limit: &limit,
+		After: &after,
+	}
+
+	resp, err := client.Receiving.ListWithOptions(context.Background(), options)
+	if err != nil {
+		t.Errorf("Receiving.ListWithOptions returned error: %v", err)
+	}
+
+	assert.Equal(t, "list", resp.Object)
+	assert.Equal(t, false, resp.HasMore)
+	assert.Equal(t, 1, len(resp.Data))
+}
+
+func TestListReceivedEmailsEmpty(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/emails/receiving", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := &ListReceivedEmailsResponse{
+			Object:  "list",
+			HasMore: false,
+			Data:    []ListReceivedEmail{},
+		}
+
+		if err := json.NewEncoder(w).Encode(ret); err != nil {
+			panic(err)
+		}
+	})
+
+	resp, err := client.Receiving.List()
+	if err != nil {
+		t.Errorf("Receiving.List returned error: %v", err)
+	}
+
+	assert.Equal(t, "list", resp.Object)
+	assert.Equal(t, false, resp.HasMore)
+	assert.Equal(t, 0, len(resp.Data))
+}

--- a/receiving_test.go
+++ b/receiving_test.go
@@ -273,10 +273,10 @@ func TestGetReceivedEmailAttachment(t *testing.T) {
 	setup()
 	defer teardown()
 
-	emailID := "4ef9a417-02e9-4d39-ad75-9611e0fcc33c"
-	attachmentID := "2a0c9ce0-3112-4728-976e-47ddcd16a318"
+	emailId := "4ef9a417-02e9-4d39-ad75-9611e0fcc33c"
+	attachmentId := "2a0c9ce0-3112-4728-976e-47ddcd16a318"
 
-	mux.HandleFunc(fmt.Sprintf("/emails/receiving/%s/attachments/%s", emailID, attachmentID), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/emails/receiving/%s/attachments/%s", emailId, attachmentId), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -297,7 +297,7 @@ func TestGetReceivedEmailAttachment(t *testing.T) {
 		fmt.Fprintf(w, ret)
 	})
 
-	resp, err := client.Receiving.GetAttachment(emailID, attachmentID)
+	resp, err := client.Receiving.GetAttachment(emailId, attachmentId)
 	if err != nil {
 		t.Errorf("Receiving.GetAttachment returned error: %v", err)
 	}
@@ -314,10 +314,10 @@ func TestGetReceivedEmailAttachmentWithContext(t *testing.T) {
 	setup()
 	defer teardown()
 
-	emailID := "test-email-id"
-	attachmentID := "test-attachment-id"
+	emailId := "test-email-id"
+	attachmentId := "test-attachment-id"
 
-	mux.HandleFunc(fmt.Sprintf("/emails/receiving/%s/attachments/%s", emailID, attachmentID), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/emails/receiving/%s/attachments/%s", emailId, attachmentId), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -339,7 +339,7 @@ func TestGetReceivedEmailAttachmentWithContext(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	resp, err := client.Receiving.GetAttachmentWithContext(ctx, emailID, attachmentID)
+	resp, err := client.Receiving.GetAttachmentWithContext(ctx, emailId, attachmentId)
 	if err != nil {
 		t.Errorf("Receiving.GetAttachmentWithContext returned error: %v", err)
 	}
@@ -356,9 +356,9 @@ func TestListReceivedEmailAttachments(t *testing.T) {
 	setup()
 	defer teardown()
 
-	emailID := "4ef9a417-02e9-4d39-ad75-9611e0fcc33c"
+	emailId := "4ef9a417-02e9-4d39-ad75-9611e0fcc33c"
 
-	mux.HandleFunc(fmt.Sprintf("/emails/receiving/%s/attachments", emailID), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/emails/receiving/%s/attachments", emailId), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -393,7 +393,7 @@ func TestListReceivedEmailAttachments(t *testing.T) {
 		}
 	})
 
-	resp, err := client.Receiving.ListAttachments(emailID)
+	resp, err := client.Receiving.ListAttachments(emailId)
 	if err != nil {
 		t.Errorf("Receiving.ListAttachments returned error: %v", err)
 	}
@@ -415,9 +415,9 @@ func TestListReceivedEmailAttachmentsWithParameters(t *testing.T) {
 	setup()
 	defer teardown()
 
-	emailID := "test-email-id"
+	emailId := "test-email-id"
 
-	mux.HandleFunc(fmt.Sprintf("/emails/receiving/%s/attachments", emailID), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/emails/receiving/%s/attachments", emailId), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 
 		// Verify query parameters
@@ -456,7 +456,7 @@ func TestListReceivedEmailAttachmentsWithParameters(t *testing.T) {
 		After: &after,
 	}
 
-	resp, err := client.Receiving.ListAttachmentsWithOptions(context.Background(), emailID, options)
+	resp, err := client.Receiving.ListAttachmentsWithOptions(context.Background(), emailId, options)
 	if err != nil {
 		t.Errorf("Receiving.ListAttachmentsWithOptions returned error: %v", err)
 	}
@@ -471,9 +471,9 @@ func TestListReceivedEmailAttachmentsEmpty(t *testing.T) {
 	setup()
 	defer teardown()
 
-	emailID := "email-no-attachments"
+	emailId := "email-no-attachments"
 
-	mux.HandleFunc(fmt.Sprintf("/emails/receiving/%s/attachments", emailID), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/emails/receiving/%s/attachments", emailId), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -489,7 +489,7 @@ func TestListReceivedEmailAttachmentsEmpty(t *testing.T) {
 		}
 	})
 
-	resp, err := client.Receiving.ListAttachments(emailID)
+	resp, err := client.Receiving.ListAttachments(emailId)
 	if err != nil {
 		t.Errorf("Receiving.ListAttachments returned error: %v", err)
 	}
@@ -503,9 +503,9 @@ func TestListReceivedEmailAttachmentsWithContext(t *testing.T) {
 	setup()
 	defer teardown()
 
-	emailID := "context-test-id"
+	emailId := "context-test-id"
 
-	mux.HandleFunc(fmt.Sprintf("/emails/receiving/%s/attachments", emailID), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/emails/receiving/%s/attachments", emailId), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -532,7 +532,7 @@ func TestListReceivedEmailAttachmentsWithContext(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	resp, err := client.Receiving.ListAttachmentsWithContext(ctx, emailID)
+	resp, err := client.Receiving.ListAttachmentsWithContext(ctx, emailId)
 	if err != nil {
 		t.Errorf("Receiving.ListAttachmentsWithContext returned error: %v", err)
 	}

--- a/receiving_test.go
+++ b/receiving_test.go
@@ -268,3 +268,277 @@ func TestListReceivedEmailsEmpty(t *testing.T) {
 	assert.Equal(t, false, resp.HasMore)
 	assert.Equal(t, 0, len(resp.Data))
 }
+
+func TestGetReceivedEmailAttachment(t *testing.T) {
+	setup()
+	defer teardown()
+
+	emailID := "4ef9a417-02e9-4d39-ad75-9611e0fcc33c"
+	attachmentID := "2a0c9ce0-3112-4728-976e-47ddcd16a318"
+
+	mux.HandleFunc(fmt.Sprintf("/emails/receiving/%s/attachments/%s", emailID, attachmentID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "attachment",
+			"data": {
+				"id": "2a0c9ce0-3112-4728-976e-47ddcd16a318",
+				"filename": "avatar.png",
+				"content_type": "image/png",
+				"content_disposition": "inline",
+				"content_id": "img001",
+				"download_url": "https://inbound-cdn.resend.com/4ef9a417-02e9-4d39-ad75-9611e0fcc33c/attachments/2a0c9ce0-3112-4728-976e-47ddcd16a318?some-params=example&signature=sig-123",
+				"expires_at": "2025-10-17T14:29:41.521Z"
+			}
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	resp, err := client.Receiving.GetAttachment(emailID, attachmentID)
+	if err != nil {
+		t.Errorf("Receiving.GetAttachment returned error: %v", err)
+	}
+	assert.Equal(t, "2a0c9ce0-3112-4728-976e-47ddcd16a318", resp.Id)
+	assert.Equal(t, "avatar.png", resp.Filename)
+	assert.Equal(t, "image/png", resp.ContentType)
+	assert.Equal(t, "inline", resp.ContentDisposition)
+	assert.Equal(t, "img001", resp.ContentId)
+	assert.Equal(t, "https://inbound-cdn.resend.com/4ef9a417-02e9-4d39-ad75-9611e0fcc33c/attachments/2a0c9ce0-3112-4728-976e-47ddcd16a318?some-params=example&signature=sig-123", resp.DownloadUrl)
+	assert.Equal(t, "2025-10-17T14:29:41.521Z", resp.ExpiresAt)
+}
+
+func TestGetReceivedEmailAttachmentWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	emailID := "test-email-id"
+	attachmentID := "test-attachment-id"
+
+	mux.HandleFunc(fmt.Sprintf("/emails/receiving/%s/attachments/%s", emailID, attachmentID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "attachment",
+			"data": {
+				"id": "test-attachment-id",
+				"filename": "document.pdf",
+				"content_type": "application/pdf",
+				"content_disposition": "attachment",
+				"content_id": "doc001",
+				"download_url": "https://inbound-cdn.resend.com/test-email-id/attachments/test-attachment-id",
+				"expires_at": "2025-10-18T12:00:00.000Z"
+			}
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	ctx := context.Background()
+	resp, err := client.Receiving.GetAttachmentWithContext(ctx, emailID, attachmentID)
+	if err != nil {
+		t.Errorf("Receiving.GetAttachmentWithContext returned error: %v", err)
+	}
+	assert.Equal(t, "test-attachment-id", resp.Id)
+	assert.Equal(t, "document.pdf", resp.Filename)
+	assert.Equal(t, "application/pdf", resp.ContentType)
+	assert.Equal(t, "attachment", resp.ContentDisposition)
+	assert.Equal(t, "doc001", resp.ContentId)
+	assert.NotEmpty(t, resp.DownloadUrl)
+	assert.NotEmpty(t, resp.ExpiresAt)
+}
+
+func TestListReceivedEmailAttachments(t *testing.T) {
+	setup()
+	defer teardown()
+
+	emailID := "4ef9a417-02e9-4d39-ad75-9611e0fcc33c"
+
+	mux.HandleFunc(fmt.Sprintf("/emails/receiving/%s/attachments", emailID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := &ListReceivedEmailAttachmentsResponse{
+			Object:  "list",
+			HasMore: false,
+			Data: []ReceivedEmailAttachment{
+				{
+					Id:                 "2a0c9ce0-3112-4728-976e-47ddcd16a318",
+					Filename:           "avatar.png",
+					ContentType:        "image/png",
+					ContentDisposition: "inline",
+					ContentId:          "img001",
+					DownloadUrl:        "https://inbound-cdn.resend.com/4ef9a417-02e9-4d39-ad75-9611e0fcc33c/attachments/2a0c9ce0-3112-4728-976e-47ddcd16a318?some-params=example&signature=sig-123",
+					ExpiresAt:          "2025-10-17T14:29:41.521Z",
+				},
+				{
+					Id:                 "3b1d0df1-4223-5839-a87f-58eedd17b429",
+					Filename:           "document.pdf",
+					ContentType:        "application/pdf",
+					ContentDisposition: "attachment",
+					ContentId:          "doc001",
+					DownloadUrl:        "https://inbound-cdn.resend.com/4ef9a417-02e9-4d39-ad75-9611e0fcc33c/attachments/3b1d0df1-4223-5839-a87f-58eedd17b429?some-params=example&signature=sig-456",
+					ExpiresAt:          "2025-10-17T14:29:41.521Z",
+				},
+			},
+		}
+
+		if err := json.NewEncoder(w).Encode(ret); err != nil {
+			panic(err)
+		}
+	})
+
+	resp, err := client.Receiving.ListAttachments(emailID)
+	if err != nil {
+		t.Errorf("Receiving.ListAttachments returned error: %v", err)
+	}
+
+	assert.Equal(t, "list", resp.Object)
+	assert.Equal(t, false, resp.HasMore)
+	assert.Equal(t, 2, len(resp.Data))
+	assert.Equal(t, "2a0c9ce0-3112-4728-976e-47ddcd16a318", resp.Data[0].Id)
+	assert.Equal(t, "avatar.png", resp.Data[0].Filename)
+	assert.Equal(t, "image/png", resp.Data[0].ContentType)
+	assert.Equal(t, "inline", resp.Data[0].ContentDisposition)
+	assert.Equal(t, "img001", resp.Data[0].ContentId)
+	assert.NotEmpty(t, resp.Data[0].DownloadUrl)
+	assert.NotEmpty(t, resp.Data[0].ExpiresAt)
+	assert.Equal(t, "3b1d0df1-4223-5839-a87f-58eedd17b429", resp.Data[1].Id)
+}
+
+func TestListReceivedEmailAttachmentsWithParameters(t *testing.T) {
+	setup()
+	defer teardown()
+
+	emailID := "test-email-id"
+
+	mux.HandleFunc(fmt.Sprintf("/emails/receiving/%s/attachments", emailID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+
+		// Verify query parameters
+		query := r.URL.Query()
+		assert.Equal(t, "5", query.Get("limit"))
+		assert.Equal(t, "cursor456", query.Get("after"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := &ListReceivedEmailAttachmentsResponse{
+			Object:  "list",
+			HasMore: true,
+			Data: []ReceivedEmailAttachment{
+				{
+					Id:                 "attachment-1",
+					Filename:           "file1.jpg",
+					ContentType:        "image/jpeg",
+					ContentDisposition: "attachment",
+					ContentId:          "img1",
+					DownloadUrl:        "https://example.com/file1.jpg",
+					ExpiresAt:          "2025-10-18T12:00:00.000Z",
+				},
+			},
+		}
+
+		if err := json.NewEncoder(w).Encode(ret); err != nil {
+			panic(err)
+		}
+	})
+
+	limit := 5
+	after := "cursor456"
+	options := &ListOptions{
+		Limit: &limit,
+		After: &after,
+	}
+
+	resp, err := client.Receiving.ListAttachmentsWithOptions(context.Background(), emailID, options)
+	if err != nil {
+		t.Errorf("Receiving.ListAttachmentsWithOptions returned error: %v", err)
+	}
+
+	assert.Equal(t, "list", resp.Object)
+	assert.Equal(t, true, resp.HasMore)
+	assert.Equal(t, 1, len(resp.Data))
+	assert.Equal(t, "attachment-1", resp.Data[0].Id)
+}
+
+func TestListReceivedEmailAttachmentsEmpty(t *testing.T) {
+	setup()
+	defer teardown()
+
+	emailID := "email-no-attachments"
+
+	mux.HandleFunc(fmt.Sprintf("/emails/receiving/%s/attachments", emailID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := &ListReceivedEmailAttachmentsResponse{
+			Object:  "list",
+			HasMore: false,
+			Data:    []ReceivedEmailAttachment{},
+		}
+
+		if err := json.NewEncoder(w).Encode(ret); err != nil {
+			panic(err)
+		}
+	})
+
+	resp, err := client.Receiving.ListAttachments(emailID)
+	if err != nil {
+		t.Errorf("Receiving.ListAttachments returned error: %v", err)
+	}
+
+	assert.Equal(t, "list", resp.Object)
+	assert.Equal(t, false, resp.HasMore)
+	assert.Equal(t, 0, len(resp.Data))
+}
+
+func TestListReceivedEmailAttachmentsWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	emailID := "context-test-id"
+
+	mux.HandleFunc(fmt.Sprintf("/emails/receiving/%s/attachments", emailID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := &ListReceivedEmailAttachmentsResponse{
+			Object:  "list",
+			HasMore: false,
+			Data: []ReceivedEmailAttachment{
+				{
+					Id:                 "ctx-att-1",
+					Filename:           "context-test.txt",
+					ContentType:        "text/plain",
+					ContentDisposition: "attachment",
+					ContentId:          "txt1",
+					DownloadUrl:        "https://example.com/context-test.txt",
+					ExpiresAt:          "2025-10-18T12:00:00.000Z",
+				},
+			},
+		}
+
+		if err := json.NewEncoder(w).Encode(ret); err != nil {
+			panic(err)
+		}
+	})
+
+	ctx := context.Background()
+	resp, err := client.Receiving.ListAttachmentsWithContext(ctx, emailID)
+	if err != nil {
+		t.Errorf("Receiving.ListAttachmentsWithContext returned error: %v", err)
+	}
+
+	assert.Equal(t, "list", resp.Object)
+	assert.Equal(t, 1, len(resp.Data))
+	assert.Equal(t, "ctx-att-1", resp.Data[0].Id)
+	assert.Equal(t, "context-test.txt", resp.Data[0].Filename)
+}

--- a/resend.go
+++ b/resend.go
@@ -57,6 +57,7 @@ type Client struct {
 	Audiences  AudiencesSvc
 	Contacts   ContactsSvc
 	Broadcasts BroadcastsSvc
+	Receiving  ReceivingSvc
 }
 
 // NewClient is the default client constructor
@@ -82,6 +83,7 @@ func NewCustomClient(httpClient *http.Client, apiKey string) *Client {
 	c.Audiences = &AudiencesSvcImpl{client: c}
 	c.Contacts = &ContactsSvcImpl{client: c}
 	c.Broadcasts = &BroadcastsSvcImpl{client: c}
+	c.Receiving = &ReceivingSvcImpl{client: c}
 
 	c.ApiKey = apiKey
 	c.headers = make(map[string]string)

--- a/resend.go
+++ b/resend.go
@@ -84,11 +84,8 @@ func NewCustomClient(httpClient *http.Client, apiKey string) *Client {
 	c.Audiences = &AudiencesSvcImpl{client: c}
 	c.Contacts = &ContactsSvcImpl{client: c}
 	c.Broadcasts = &BroadcastsSvcImpl{client: c}
-<<<<<<< HEAD
 	c.Receiving = &ReceivingSvcImpl{client: c}
-=======
 	c.Topics = &TopicsSvcImpl{client: c}
->>>>>>> b9ca8ad66ee9661941ff3d46e85654da77ca4e86
 
 	c.ApiKey = apiKey
 	c.headers = make(map[string]string)


### PR DESCRIPTION
- impl: receiving emails Get, List
- impl : receiving attachments Get, List
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds inbound email support with a new Receiving service to fetch received emails and their attachments, including pagination and context-aware methods. This enables retrieving individual inbound messages, listing inbox items, and accessing attachment download URLs.

- **New Features**
  - New client.Receiving service for inbound email APIs.
  - Emails: Get and List (supports pagination via ListOptions and WithContext variants).
  - Attachments: Get (includes download URL and expiry) and List (pagination supported).
  - New models for received emails and attachments, plus specific error types.
  - Added example usage and comprehensive tests.

<!-- End of auto-generated description by cubic. -->

