### PR TITLE
feat: Initial topics implementation

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -67,3 +67,23 @@ var (
 	ErrFailedToCreateEmailsGetRequest   = errors.New("[ERROR]: Failed to create GetEmail request")
 	ErrFailedToCreateEmailsListRequest  = errors.New("[ERROR]: Failed to create ListEmails request")
 )
+<<<<<<< Updated upstream
+=======
+
+// TemplatesSvc errors
+var (
+	ErrFailedToCreateTemplateCreateRequest    = errors.New("[ERROR]: Failed to create Templates.Create request")
+	ErrFailedToCreateTemplateGetRequest       = errors.New("[ERROR]: Failed to create Templates.Get request")
+	ErrFailedToCreateTemplateListRequest      = errors.New("[ERROR]: Failed to create Templates.List request")
+	ErrFailedToCreateTemplateUpdateRequest    = errors.New("[ERROR]: Failed to create Templates.Update request")
+	ErrFailedToCreateTemplatePublishRequest   = errors.New("[ERROR]: Failed to create Templates.Publish request")
+	ErrFailedToCreateTemplateDuplicateRequest = errors.New("[ERROR]: Failed to create Templates.Duplicate request")
+	ErrFailedToCreateTemplateRemoveRequest    = errors.New("[ERROR]: Failed to create Templates.Remove request")
+)
+
+// TopicsSvc errors
+var (
+	ErrFailedToCreateTopicCreateRequest = errors.New("[ERROR]: Failed to create Topics.Create request")
+	ErrFailedToCreateTopicGetRequest    = errors.New("[ERROR]: Failed to create Topics.Get request")
+)
+>>>>>>> Stashed changes

--- a/errors.go
+++ b/errors.go
@@ -67,23 +67,12 @@ var (
 	ErrFailedToCreateEmailsGetRequest   = errors.New("[ERROR]: Failed to create GetEmail request")
 	ErrFailedToCreateEmailsListRequest  = errors.New("[ERROR]: Failed to create ListEmails request")
 )
-<<<<<<< Updated upstream
-=======
-
-// TemplatesSvc errors
-var (
-	ErrFailedToCreateTemplateCreateRequest    = errors.New("[ERROR]: Failed to create Templates.Create request")
-	ErrFailedToCreateTemplateGetRequest       = errors.New("[ERROR]: Failed to create Templates.Get request")
-	ErrFailedToCreateTemplateListRequest      = errors.New("[ERROR]: Failed to create Templates.List request")
-	ErrFailedToCreateTemplateUpdateRequest    = errors.New("[ERROR]: Failed to create Templates.Update request")
-	ErrFailedToCreateTemplatePublishRequest   = errors.New("[ERROR]: Failed to create Templates.Publish request")
-	ErrFailedToCreateTemplateDuplicateRequest = errors.New("[ERROR]: Failed to create Templates.Duplicate request")
-	ErrFailedToCreateTemplateRemoveRequest    = errors.New("[ERROR]: Failed to create Templates.Remove request")
-)
 
 // TopicsSvc errors
 var (
 	ErrFailedToCreateTopicCreateRequest = errors.New("[ERROR]: Failed to create Topics.Create request")
 	ErrFailedToCreateTopicGetRequest    = errors.New("[ERROR]: Failed to create Topics.Get request")
+	ErrFailedToCreateTopicListRequest   = errors.New("[ERROR]: Failed to create Topics.List request")
+	ErrFailedToCreateTopicUpdateRequest = errors.New("[ERROR]: Failed to create Topics.Update request")
+	ErrFailedToCreateTopicRemoveRequest = errors.New("[ERROR]: Failed to create Topics.Remove request")
 )
->>>>>>> Stashed changes

--- a/examples/topics.go
+++ b/examples/topics.go
@@ -58,4 +58,71 @@ func topicsExample() {
 	fmt.Printf("  Description: %s\n", retrievedTopic.Description)
 	fmt.Printf("  DefaultSubscription: %s\n", retrievedTopic.DefaultSubscription)
 	fmt.Printf("  CreatedAt: %s\n", retrievedTopic.CreatedAt)
+
+	// List topics with pagination
+	// By default, the API will return the most recent 20 topics
+	// You can use limit, after, or before parameters to control pagination
+	limit := 2
+	listResponse, err := client.Topics.ListWithContext(ctx, &resend.ListOptions{
+		Limit: &limit,
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("\nListed topics:\n")
+	fmt.Printf("  Object: %s\n", listResponse.Object)
+	fmt.Printf("  HasMore: %t\n", listResponse.HasMore)
+	fmt.Printf("  Topics count: %d\n", len(listResponse.Data))
+	for i, t := range listResponse.Data {
+		fmt.Printf("\n  Topic %d:\n", i+1)
+		fmt.Printf("    Id: %s\n", t.Id)
+		fmt.Printf("    Name: %s\n", t.Name)
+		fmt.Printf("    Description: %s\n", t.Description)
+		fmt.Printf("    DefaultSubscription: %s\n", t.DefaultSubscription)
+		fmt.Printf("    CreatedAt: %s\n", t.CreatedAt)
+	}
+
+	// List topics with pagination using after parameter
+	if listResponse.HasMore && len(listResponse.Data) > 0 {
+		lastId := listResponse.Data[len(listResponse.Data)-1].Id
+		nextPage, err := client.Topics.List(&resend.ListOptions{
+			Limit: &limit,
+			After: &lastId,
+		})
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("\nNext page topics count: %d\n", len(nextPage.Data))
+	}
+
+	// Update a topic
+	// Note: default_subscription cannot be changed after creation
+	updatedTopic, err := client.Topics.UpdateWithContext(ctx, topic.Id, &resend.UpdateTopicRequest{
+		Name:        "Weekly Newsletter - Updated",
+		Description: "Updated weekly newsletter for our valued subscribers",
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("\nUpdated topic: %s\n", updatedTopic.Id)
+
+	// Verify the update by getting the topic again
+	verifyTopic, err := client.Topics.Get(updatedTopic.Id)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Verified updated topic:\n")
+	fmt.Printf("  Name: %s\n", verifyTopic.Name)
+	fmt.Printf("  Description: %s\n", verifyTopic.Description)
+
+	// Remove a topic
+	// Note: This permanently deletes the topic
+	removedTopic, err := client.Topics.RemoveWithContext(ctx, optOutTopic.Id)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("\nRemoved topic:\n")
+	fmt.Printf("  Object: %s\n", removedTopic.Object)
+	fmt.Printf("  Id: %s\n", removedTopic.Id)
+	fmt.Printf("  Deleted: %t\n", removedTopic.Deleted)
 }

--- a/examples/topics.go
+++ b/examples/topics.go
@@ -1,0 +1,61 @@
+package examples
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/resend/resend-go/v2"
+)
+
+func topicsExample() {
+	ctx := context.TODO()
+	apiKey := os.Getenv("RESEND_API_KEY")
+
+	client := resend.NewClient(apiKey)
+
+	// Create a topic with opt_in default subscription
+	// Note: default_subscription cannot be changed after creation
+	topic, err := client.Topics.CreateWithContext(ctx, &resend.CreateTopicRequest{
+		Name:                "Weekly Newsletter",
+		DefaultSubscription: resend.DefaultSubscriptionOptIn,
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created topic: %s\n", topic.Id)
+
+	// Create a topic with opt_out default subscription
+	optOutTopic, err := client.Topics.Create(&resend.CreateTopicRequest{
+		Name:                "Product Updates",
+		DefaultSubscription: resend.DefaultSubscriptionOptOut,
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created opt-out topic: %s\n", optOutTopic.Id)
+
+	// Create a topic with description
+	// Note: name max length is 50 characters, description max length is 200 characters
+	topicWithDescription, err := client.Topics.Create(&resend.CreateTopicRequest{
+		Name:                "Monthly Summary",
+		DefaultSubscription: resend.DefaultSubscriptionOptIn,
+		Description:         "Monthly summary of your account activity and updates",
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created topic with description: %s\n", topicWithDescription.Id)
+
+	// Get a topic by ID
+	retrievedTopic, err := client.Topics.GetWithContext(ctx, topic.Id)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("\nRetrieved topic:\n")
+	fmt.Printf("  Id: %s\n", retrievedTopic.Id)
+	fmt.Printf("  Name: %s\n", retrievedTopic.Name)
+	fmt.Printf("  Description: %s\n", retrievedTopic.Description)
+	fmt.Printf("  DefaultSubscription: %s\n", retrievedTopic.DefaultSubscription)
+	fmt.Printf("  CreatedAt: %s\n", retrievedTopic.CreatedAt)
+}

--- a/resend.go
+++ b/resend.go
@@ -57,6 +57,11 @@ type Client struct {
 	Audiences  AudiencesSvc
 	Contacts   ContactsSvc
 	Broadcasts BroadcastsSvc
+<<<<<<< Updated upstream
+=======
+	Templates  TemplatesSvc
+	Topics     TopicsSvc
+>>>>>>> Stashed changes
 }
 
 // NewClient is the default client constructor
@@ -82,6 +87,11 @@ func NewCustomClient(httpClient *http.Client, apiKey string) *Client {
 	c.Audiences = &AudiencesSvcImpl{client: c}
 	c.Contacts = &ContactsSvcImpl{client: c}
 	c.Broadcasts = &BroadcastsSvcImpl{client: c}
+<<<<<<< Updated upstream
+=======
+	c.Templates = &TemplatesSvcImpl{client: c}
+	c.Topics = &TopicsSvcImpl{client: c}
+>>>>>>> Stashed changes
 
 	c.ApiKey = apiKey
 	c.headers = make(map[string]string)

--- a/resend.go
+++ b/resend.go
@@ -57,11 +57,7 @@ type Client struct {
 	Audiences  AudiencesSvc
 	Contacts   ContactsSvc
 	Broadcasts BroadcastsSvc
-<<<<<<< Updated upstream
-=======
-	Templates  TemplatesSvc
 	Topics     TopicsSvc
->>>>>>> Stashed changes
 }
 
 // NewClient is the default client constructor
@@ -87,11 +83,7 @@ func NewCustomClient(httpClient *http.Client, apiKey string) *Client {
 	c.Audiences = &AudiencesSvcImpl{client: c}
 	c.Contacts = &ContactsSvcImpl{client: c}
 	c.Broadcasts = &BroadcastsSvcImpl{client: c}
-<<<<<<< Updated upstream
-=======
-	c.Templates = &TemplatesSvcImpl{client: c}
 	c.Topics = &TopicsSvcImpl{client: c}
->>>>>>> Stashed changes
 
 	c.ApiKey = apiKey
 	c.headers = make(map[string]string)

--- a/topics.go
+++ b/topics.go
@@ -1,0 +1,108 @@
+package resend
+
+import (
+	"context"
+	"net/http"
+)
+
+// DefaultSubscription represents the default subscription preference for new contacts
+type DefaultSubscription string
+
+const (
+	DefaultSubscriptionOptIn  DefaultSubscription = "opt_in"
+	DefaultSubscriptionOptOut DefaultSubscription = "opt_out"
+)
+
+// CreateTopicRequest is the request payload for creating a topic
+type CreateTopicRequest struct {
+	Name                string              `json:"name"`
+	DefaultSubscription DefaultSubscription `json:"default_subscription"`
+	Description         string              `json:"description,omitempty"`
+}
+
+// CreateTopicResponse is the response from creating a topic
+type CreateTopicResponse struct {
+	Id string `json:"id"`
+}
+
+// Topic represents a full topic object
+type Topic struct {
+	Id                  string              `json:"id"`
+	Name                string              `json:"name"`
+	Description         string              `json:"description"`
+	DefaultSubscription DefaultSubscription `json:"default_subscription"`
+	CreatedAt           string              `json:"created_at"`
+}
+
+// TopicsSvc handles operations for topics
+type TopicsSvc interface {
+	CreateWithContext(ctx context.Context, params *CreateTopicRequest) (*CreateTopicResponse, error)
+	Create(params *CreateTopicRequest) (*CreateTopicResponse, error)
+	GetWithContext(ctx context.Context, topicId string) (*Topic, error)
+	Get(topicId string) (*Topic, error)
+}
+
+// TopicsSvcImpl is the implementation of the TopicsSvc interface
+type TopicsSvcImpl struct {
+	client *Client
+}
+
+// CreateWithContext creates a new topic with the given parameters
+// https://resend.com/docs/api-reference/topics/create-topic
+func (s *TopicsSvcImpl) CreateWithContext(ctx context.Context, params *CreateTopicRequest) (*CreateTopicResponse, error) {
+	path := "topics"
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, params)
+	if err != nil {
+		return nil, ErrFailedToCreateTopicCreateRequest
+	}
+
+	// Build response recipient obj
+	topicResponse := new(CreateTopicResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, topicResponse)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return topicResponse, nil
+}
+
+// Create creates a new topic with the given parameters
+// https://resend.com/docs/api-reference/topics/create-topic
+func (s *TopicsSvcImpl) Create(params *CreateTopicRequest) (*CreateTopicResponse, error) {
+	return s.CreateWithContext(context.Background(), params)
+}
+
+// GetWithContext retrieves a topic by ID
+// https://resend.com/docs/api-reference/topics/get-topic
+func (s *TopicsSvcImpl) GetWithContext(ctx context.Context, topicId string) (*Topic, error) {
+	path := "topics/" + topicId
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, ErrFailedToCreateTopicGetRequest
+	}
+
+	// Build response recipient obj
+	topicResponse := new(Topic)
+
+	// Send Request
+	_, err = s.client.Perform(req, topicResponse)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return topicResponse, nil
+}
+
+// Get retrieves a topic by ID
+// https://resend.com/docs/api-reference/topics/get-topic
+func (s *TopicsSvcImpl) Get(topicId string) (*Topic, error) {
+	return s.GetWithContext(context.Background(), topicId)
+}

--- a/topics_test.go
+++ b/topics_test.go
@@ -151,9 +151,9 @@ func TestGetTopic(t *testing.T) {
 	setup()
 	defer teardown()
 
-	topicID := "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
+	topicId := "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
 
-	mux.HandleFunc(fmt.Sprintf("/topics/%s", topicID), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/topics/%s", topicId), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -169,7 +169,7 @@ func TestGetTopic(t *testing.T) {
 		fmt.Fprintf(w, ret)
 	})
 
-	resp, err := client.Topics.Get(topicID)
+	resp, err := client.Topics.Get(topicId)
 	if err != nil {
 		t.Errorf("Topics.Get returned error: %v", err)
 	}
@@ -184,9 +184,9 @@ func TestGetTopicWithOptOut(t *testing.T) {
 	setup()
 	defer teardown()
 
-	topicID := "opt-out-topic-id"
+	topicId := "opt-out-topic-id"
 
-	mux.HandleFunc(fmt.Sprintf("/topics/%s", topicID), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/topics/%s", topicId), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -202,7 +202,7 @@ func TestGetTopicWithOptOut(t *testing.T) {
 		fmt.Fprintf(w, ret)
 	})
 
-	resp, err := client.Topics.Get(topicID)
+	resp, err := client.Topics.Get(topicId)
 	if err != nil {
 		t.Errorf("Topics.Get returned error: %v", err)
 	}
@@ -217,9 +217,9 @@ func TestGetTopicWithContext(t *testing.T) {
 	setup()
 	defer teardown()
 
-	topicID := "context-topic-id"
+	topicId := "context-topic-id"
 
-	mux.HandleFunc(fmt.Sprintf("/topics/%s", topicID), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/topics/%s", topicId), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodGet)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -236,7 +236,7 @@ func TestGetTopicWithContext(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	resp, err := client.Topics.GetWithContext(ctx, topicID)
+	resp, err := client.Topics.GetWithContext(ctx, topicId)
 	if err != nil {
 		t.Errorf("Topics.GetWithContext returned error: %v", err)
 	}
@@ -484,9 +484,9 @@ func TestUpdateTopic(t *testing.T) {
 	setup()
 	defer teardown()
 
-	topicID := "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
+	topicId := "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
 
-	mux.HandleFunc(fmt.Sprintf("/topics/%s", topicID), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/topics/%s", topicId), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPatch)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -508,7 +508,7 @@ func TestUpdateTopic(t *testing.T) {
 		fmt.Fprintf(w, ret)
 	})
 
-	resp, err := client.Topics.Update(topicID, &UpdateTopicRequest{
+	resp, err := client.Topics.Update(topicId, &UpdateTopicRequest{
 		Name:        "Weekly Newsletter - Updated",
 		Description: "Updated description",
 	})
@@ -522,9 +522,9 @@ func TestUpdateTopicNameOnly(t *testing.T) {
 	setup()
 	defer teardown()
 
-	topicID := "topic-name-only-id"
+	topicId := "topic-name-only-id"
 
-	mux.HandleFunc(fmt.Sprintf("/topics/%s", topicID), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/topics/%s", topicId), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPatch)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -546,7 +546,7 @@ func TestUpdateTopicNameOnly(t *testing.T) {
 		fmt.Fprintf(w, ret)
 	})
 
-	resp, err := client.Topics.Update(topicID, &UpdateTopicRequest{
+	resp, err := client.Topics.Update(topicId, &UpdateTopicRequest{
 		Name: "New Name",
 	})
 	if err != nil {
@@ -559,9 +559,9 @@ func TestUpdateTopicDescriptionOnly(t *testing.T) {
 	setup()
 	defer teardown()
 
-	topicID := "topic-description-only-id"
+	topicId := "topic-description-only-id"
 
-	mux.HandleFunc(fmt.Sprintf("/topics/%s", topicID), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/topics/%s", topicId), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPatch)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -583,7 +583,7 @@ func TestUpdateTopicDescriptionOnly(t *testing.T) {
 		fmt.Fprintf(w, ret)
 	})
 
-	resp, err := client.Topics.Update(topicID, &UpdateTopicRequest{
+	resp, err := client.Topics.Update(topicId, &UpdateTopicRequest{
 		Description: "New description only",
 	})
 	if err != nil {
@@ -596,9 +596,9 @@ func TestUpdateTopicWithContext(t *testing.T) {
 	setup()
 	defer teardown()
 
-	topicID := "context-update-id"
+	topicId := "context-update-id"
 
-	mux.HandleFunc(fmt.Sprintf("/topics/%s", topicID), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/topics/%s", topicId), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPatch)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -611,7 +611,7 @@ func TestUpdateTopicWithContext(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	resp, err := client.Topics.UpdateWithContext(ctx, topicID, &UpdateTopicRequest{
+	resp, err := client.Topics.UpdateWithContext(ctx, topicId, &UpdateTopicRequest{
 		Name:        "Context Update",
 		Description: "Updated with context",
 	})
@@ -625,9 +625,9 @@ func TestRemoveTopic(t *testing.T) {
 	setup()
 	defer teardown()
 
-	topicID := "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
+	topicId := "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
 
-	mux.HandleFunc(fmt.Sprintf("/topics/%s", topicID), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/topics/%s", topicId), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -641,7 +641,7 @@ func TestRemoveTopic(t *testing.T) {
 		fmt.Fprintf(w, ret)
 	})
 
-	resp, err := client.Topics.Remove(topicID)
+	resp, err := client.Topics.Remove(topicId)
 	if err != nil {
 		t.Errorf("Topics.Remove returned error: %v", err)
 	}
@@ -654,9 +654,9 @@ func TestRemoveTopicWithContext(t *testing.T) {
 	setup()
 	defer teardown()
 
-	topicID := "context-remove-id"
+	topicId := "context-remove-id"
 
-	mux.HandleFunc(fmt.Sprintf("/topics/%s", topicID), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/topics/%s", topicId), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodDelete)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -671,7 +671,7 @@ func TestRemoveTopicWithContext(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	resp, err := client.Topics.RemoveWithContext(ctx, topicID)
+	resp, err := client.Topics.RemoveWithContext(ctx, topicId)
 	if err != nil {
 		t.Errorf("Topics.RemoveWithContext returned error: %v", err)
 	}

--- a/topics_test.go
+++ b/topics_test.go
@@ -1,0 +1,248 @@
+package resend
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateTopic(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/topics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		// Decode request body to verify it
+		var req CreateTopicRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		if err != nil {
+			t.Errorf("Failed to decode request body: %v", err)
+		}
+
+		assert.Equal(t, "Weekly Newsletter", req.Name)
+		assert.Equal(t, DefaultSubscriptionOptIn, req.DefaultSubscription)
+
+		ret := `
+		{
+			"id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	resp, err := client.Topics.Create(&CreateTopicRequest{
+		Name:                "Weekly Newsletter",
+		DefaultSubscription: DefaultSubscriptionOptIn,
+	})
+	if err != nil {
+		t.Errorf("Topics.Create returned error: %v", err)
+	}
+	assert.Equal(t, "b6d24b8e-af0b-4c3c-be0c-359bbd97381e", resp.Id)
+}
+
+func TestCreateTopicWithOptOut(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/topics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		// Decode request body to verify it
+		var req CreateTopicRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		if err != nil {
+			t.Errorf("Failed to decode request body: %v", err)
+		}
+
+		assert.Equal(t, "Product Updates", req.Name)
+		assert.Equal(t, DefaultSubscriptionOptOut, req.DefaultSubscription)
+
+		ret := `
+		{
+			"id": "opt-out-topic-id"
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	resp, err := client.Topics.Create(&CreateTopicRequest{
+		Name:                "Product Updates",
+		DefaultSubscription: DefaultSubscriptionOptOut,
+	})
+	if err != nil {
+		t.Errorf("Topics.Create returned error: %v", err)
+	}
+	assert.Equal(t, "opt-out-topic-id", resp.Id)
+}
+
+func TestCreateTopicWithDescription(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/topics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		// Decode request body to verify it
+		var req CreateTopicRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		if err != nil {
+			t.Errorf("Failed to decode request body: %v", err)
+		}
+
+		assert.Equal(t, "Monthly Summary", req.Name)
+		assert.Equal(t, DefaultSubscriptionOptIn, req.DefaultSubscription)
+		assert.Equal(t, "Monthly summary of your account activity", req.Description)
+
+		ret := `
+		{
+			"id": "topic-with-description-id"
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	resp, err := client.Topics.Create(&CreateTopicRequest{
+		Name:                "Monthly Summary",
+		DefaultSubscription: DefaultSubscriptionOptIn,
+		Description:         "Monthly summary of your account activity",
+	})
+	if err != nil {
+		t.Errorf("Topics.Create returned error: %v", err)
+	}
+	assert.Equal(t, "topic-with-description-id", resp.Id)
+}
+
+func TestCreateTopicWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/topics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"id": "context-topic-id"
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	ctx := context.Background()
+	resp, err := client.Topics.CreateWithContext(ctx, &CreateTopicRequest{
+		Name:                "Context Topic",
+		DefaultSubscription: DefaultSubscriptionOptIn,
+	})
+	if err != nil {
+		t.Errorf("Topics.CreateWithContext returned error: %v", err)
+	}
+	assert.Equal(t, "context-topic-id", resp.Id)
+}
+
+func TestGetTopic(t *testing.T) {
+	setup()
+	defer teardown()
+
+	topicID := "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
+
+	mux.HandleFunc(fmt.Sprintf("/topics/%s", topicID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+			"name": "Weekly Newsletter",
+			"description": "Weekly newsletter for our subscribers",
+			"default_subscription": "opt_in",
+			"created_at": "2023-04-08T00:11:13.110779+00:00"
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	resp, err := client.Topics.Get(topicID)
+	if err != nil {
+		t.Errorf("Topics.Get returned error: %v", err)
+	}
+	assert.Equal(t, "b6d24b8e-af0b-4c3c-be0c-359bbd97381e", resp.Id)
+	assert.Equal(t, "Weekly Newsletter", resp.Name)
+	assert.Equal(t, "Weekly newsletter for our subscribers", resp.Description)
+	assert.Equal(t, DefaultSubscriptionOptIn, resp.DefaultSubscription)
+	assert.Equal(t, "2023-04-08T00:11:13.110779+00:00", resp.CreatedAt)
+}
+
+func TestGetTopicWithOptOut(t *testing.T) {
+	setup()
+	defer teardown()
+
+	topicID := "opt-out-topic-id"
+
+	mux.HandleFunc(fmt.Sprintf("/topics/%s", topicID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"id": "opt-out-topic-id",
+			"name": "Product Updates",
+			"description": "",
+			"default_subscription": "opt_out",
+			"created_at": "2023-04-08T00:11:13.110779+00:00"
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	resp, err := client.Topics.Get(topicID)
+	if err != nil {
+		t.Errorf("Topics.Get returned error: %v", err)
+	}
+	assert.Equal(t, "opt-out-topic-id", resp.Id)
+	assert.Equal(t, "Product Updates", resp.Name)
+	assert.Equal(t, "", resp.Description)
+	assert.Equal(t, DefaultSubscriptionOptOut, resp.DefaultSubscription)
+	assert.Equal(t, "2023-04-08T00:11:13.110779+00:00", resp.CreatedAt)
+}
+
+func TestGetTopicWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	topicID := "context-topic-id"
+
+	mux.HandleFunc(fmt.Sprintf("/topics/%s", topicID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"id": "context-topic-id",
+			"name": "Context Topic",
+			"description": "Test topic with context",
+			"default_subscription": "opt_in",
+			"created_at": "2023-04-08T00:11:13.110779+00:00"
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	ctx := context.Background()
+	resp, err := client.Topics.GetWithContext(ctx, topicID)
+	if err != nil {
+		t.Errorf("Topics.GetWithContext returned error: %v", err)
+	}
+	assert.Equal(t, "context-topic-id", resp.Id)
+	assert.Equal(t, "Context Topic", resp.Name)
+	assert.Equal(t, "Test topic with context", resp.Description)
+	assert.Equal(t, DefaultSubscriptionOptIn, resp.DefaultSubscription)
+	assert.Equal(t, "2023-04-08T00:11:13.110779+00:00", resp.CreatedAt)
+}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a Topics service to the Go client to manage messaging topics with opt-in/opt-out defaults. Wires Topics into the client and includes examples and tests.

- **New Features**
  - TopicsSvc with Create, Get, List (limit/after/before), Update, and Remove, plus context variants.
  - DefaultSubscription enum and topic request/response models.
  - Topic-specific errors added to errors.go; Client.Topics initialized; new usage example and comprehensive tests.

<!-- End of auto-generated description by cubic. -->

