### PR TITLE
feat: webhooks API support

### DIFF
--- a/examples/webhook_receiver.go
+++ b/examples/webhook_receiver.go
@@ -1,0 +1,81 @@
+package examples
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/resend/resend-go/v2"
+)
+
+// Demonstrates how to receive and verify webhooks
+// This example creates an HTTP server that listens for webhook POST requests
+// and verifies them using HMAC-SHA256 signature validation
+func webhookReceiverExample() {
+	webhookSecret := "whsec_1234567890abcdefghijklmnopqrstuvwxyz"
+	apiKey := "re_1234567890abcdefghijklmnopqrstuvwxyz"
+
+	client := resend.NewClient(apiKey)
+
+	http.HandleFunc("/webhook", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		// Read the raw body (must be raw for signature verification)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			log.Printf("Error reading body: %v", err)
+			http.Error(w, "Failed to read request body", http.StatusBadRequest)
+			return
+		}
+		defer r.Body.Close()
+
+		// Extract Svix headers
+		headers := resend.WebhookHeaders{
+			Id:        r.Header.Get("svix-id"),
+			Timestamp: r.Header.Get("svix-timestamp"),
+			Signature: r.Header.Get("svix-signature"),
+		}
+
+		// Verify the webhook
+		err = client.Webhooks.Verify(&resend.VerifyWebhookOptions{
+			Payload:       string(body),
+			Headers:       headers,
+			WebhookSecret: webhookSecret,
+		})
+
+		if err != nil {
+			log.Printf("Webhook verification failed: %v", err)
+			http.Error(w, "Webhook verification failed", http.StatusBadRequest)
+			return
+		}
+
+		// Parse the verified payload
+		var payload map[string]interface{}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			log.Printf("Error parsing JSON: %v", err)
+			http.Error(w, "Invalid JSON payload", http.StatusBadRequest)
+			return
+		}
+
+		log.Printf("✓ Webhook verified successfully!")
+		log.Printf("Event Type: %v", payload["type"])
+		log.Printf("Payload: %v", payload)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]bool{"success": true})
+	})
+
+	port := ":5000"
+	fmt.Printf("🚀 Webhook receiver listening on http://localhost%s/webhook\n", port)
+	fmt.Println("Send a POST request with Resend webhook headers to test verification")
+
+	if err := http.ListenAndServe(port, nil); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/examples/webhooks.go
+++ b/examples/webhooks.go
@@ -1,0 +1,81 @@
+package examples
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/resend/resend-go/v2"
+)
+
+func webhooksExample() {
+	ctx := context.TODO()
+	apiKey := os.Getenv("RESEND_API_KEY")
+
+	client := resend.NewClient(apiKey)
+
+	// Create Webhook
+	createParams := &resend.CreateWebhookRequest{
+		Endpoint: "https://webhook.example.com/handler",
+		Events:   []string{"email.sent", "email.delivered", "email.bounced"},
+	}
+
+	created, err := client.Webhooks.CreateWithContext(ctx, createParams)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Created Webhook ID: " + created.Id)
+	fmt.Println("Signing Secret: " + created.SigningSecret)
+
+	// Get Webhook
+	webhook, err := client.Webhooks.GetWithContext(ctx, created.Id)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Webhook Status: %s\n", webhook.Status)
+	fmt.Printf("Webhook Endpoint: %s\n", webhook.Endpoint)
+	fmt.Printf("Webhook Events: %v\n", webhook.Events)
+
+	// Update Webhook
+	newEndpoint := "https://new-webhook.example.com/handler"
+	newStatus := "disabled"
+	updateParams := &resend.UpdateWebhookRequest{
+		Endpoint: &newEndpoint,
+		Events:   []string{"email.sent", "email.delivered"},
+		Status:   &newStatus,
+	}
+
+	updated, err := client.Webhooks.UpdateWithContext(ctx, created.Id, updateParams)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Updated Webhook ID: " + updated.Id)
+
+	// List Webhooks
+	webhooks, err := client.Webhooks.ListWithContext(ctx)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("You have %d webhooks in your project\n", len(webhooks.Data))
+	for i, wh := range webhooks.Data {
+		fmt.Printf("  [%d] ID: %s, Status: %s, Endpoint: %s\n", i+1, wh.Id, wh.Status, wh.Endpoint)
+	}
+
+	// List Webhooks with Pagination
+	limit := 10
+	listOptions := &resend.ListOptions{
+		Limit: &limit,
+	}
+	paginatedWebhooks, err := client.Webhooks.ListWithOptions(ctx, listOptions)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Fetched %d webhooks (has_more: %v)\n", len(paginatedWebhooks.Data), paginatedWebhooks.HasMore)
+
+	// Delete Webhook
+	deleted, err := client.Webhooks.RemoveWithContext(ctx, created.Id)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Deleted Webhook ID: %s (deleted: %v)\n", deleted.Id, deleted.Deleted)
+}

--- a/resend.go
+++ b/resend.go
@@ -58,6 +58,7 @@ type Client struct {
 	Contacts   ContactsSvc
 	Broadcasts BroadcastsSvc
 	Topics     TopicsSvc
+	Webhooks   WebhooksSvc
 }
 
 // NewClient is the default client constructor
@@ -84,6 +85,7 @@ func NewCustomClient(httpClient *http.Client, apiKey string) *Client {
 	c.Contacts = &ContactsSvcImpl{client: c}
 	c.Broadcasts = &BroadcastsSvcImpl{client: c}
 	c.Topics = &TopicsSvcImpl{client: c}
+	c.Webhooks = &WebhooksSvcImpl{client: c}
 
 	c.ApiKey = apiKey
 	c.headers = make(map[string]string)

--- a/webhooks.go
+++ b/webhooks.go
@@ -1,0 +1,231 @@
+package resend
+
+import (
+	"context"
+	"net/http"
+)
+
+// CreateWebhookRequest represents the parameters for creating a webhook
+type CreateWebhookRequest struct {
+	Endpoint string   `json:"endpoint"`
+	Events   []string `json:"events"`
+}
+
+// CreateWebhookResponse represents the response from creating a webhook
+type CreateWebhookResponse struct {
+	Object        string `json:"object"`
+	Id            string `json:"id"`
+	SigningSecret string `json:"signing_secret"`
+}
+
+// Webhook represents a webhook object
+type Webhook struct {
+	Object        string   `json:"object"`
+	Id            string   `json:"id"`
+	CreatedAt     string   `json:"created_at,omitempty"`
+	Status        string   `json:"status,omitempty"`
+	Endpoint      string   `json:"endpoint,omitempty"`
+	Events        []string `json:"events,omitempty"`
+	SigningSecret string   `json:"signing_secret,omitempty"`
+}
+
+// UpdateWebhookRequest represents the parameters for updating a webhook
+type UpdateWebhookRequest struct {
+	Endpoint *string  `json:"endpoint,omitempty"`
+	Events   []string `json:"events,omitempty"`
+	Status   *string  `json:"status,omitempty"`
+}
+
+// UpdateWebhookResponse represents the response from updating a webhook
+type UpdateWebhookResponse struct {
+	Object string `json:"object"`
+	Id     string `json:"id"`
+}
+
+// ListWebhooksResponse represents the response from listing webhooks
+type ListWebhooksResponse struct {
+	Object  string          `json:"object"`
+	HasMore bool            `json:"has_more"`
+	Data    []WebhookInList `json:"data"`
+}
+
+// WebhookInList represents a webhook in the list response
+type WebhookInList struct {
+	Id        string   `json:"id"`
+	CreatedAt string   `json:"created_at"`
+	Status    string   `json:"status"`
+	Endpoint  string   `json:"endpoint"`
+	Events    []string `json:"events"`
+}
+
+// DeleteWebhookResponse represents the response from deleting a webhook
+type DeleteWebhookResponse struct {
+	Object  string `json:"object"`
+	Id      string `json:"id"`
+	Deleted bool   `json:"deleted"`
+}
+
+// WebhooksSvc defines the interface for webhook operations
+type WebhooksSvc interface {
+	CreateWithContext(ctx context.Context, params *CreateWebhookRequest) (*CreateWebhookResponse, error)
+	Create(params *CreateWebhookRequest) (*CreateWebhookResponse, error)
+	GetWithContext(ctx context.Context, webhookId string) (*Webhook, error)
+	Get(webhookId string) (*Webhook, error)
+	UpdateWithContext(ctx context.Context, webhookId string, params *UpdateWebhookRequest) (*UpdateWebhookResponse, error)
+	Update(webhookId string, params *UpdateWebhookRequest) (*UpdateWebhookResponse, error)
+	ListWithOptions(ctx context.Context, options *ListOptions) (*ListWebhooksResponse, error)
+	ListWithContext(ctx context.Context) (*ListWebhooksResponse, error)
+	List() (*ListWebhooksResponse, error)
+	RemoveWithContext(ctx context.Context, webhookId string) (*DeleteWebhookResponse, error)
+	Remove(webhookId string) (*DeleteWebhookResponse, error)
+}
+
+// WebhooksSvcImpl implements the WebhooksSvc interface
+type WebhooksSvcImpl struct {
+	client *Client
+}
+
+// CreateWithContext creates a new webhook with the given context
+// https://resend.com/docs/api-reference/webhooks/create-webhook
+func (s *WebhooksSvcImpl) CreateWithContext(ctx context.Context, params *CreateWebhookRequest) (*CreateWebhookResponse, error) {
+	path := "webhooks"
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, params)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build response object
+	webhookResp := new(CreateWebhookResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, webhookResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return webhookResp, nil
+}
+
+// Create creates a new webhook
+func (s *WebhooksSvcImpl) Create(params *CreateWebhookRequest) (*CreateWebhookResponse, error) {
+	return s.CreateWithContext(context.Background(), params)
+}
+
+// GetWithContext retrieves a webhook by ID with the given context
+// https://resend.com/docs/api-reference/webhooks/get-webhook
+func (s *WebhooksSvcImpl) GetWithContext(ctx context.Context, webhookId string) (*Webhook, error) {
+	path := "webhooks/" + webhookId
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build response object
+	webhookResp := new(Webhook)
+
+	// Send Request
+	_, err = s.client.Perform(req, webhookResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return webhookResp, nil
+}
+
+// Get retrieves a webhook by ID
+func (s *WebhooksSvcImpl) Get(webhookId string) (*Webhook, error) {
+	return s.GetWithContext(context.Background(), webhookId)
+}
+
+// UpdateWithContext updates a webhook with the given context
+// https://resend.com/docs/api-reference/webhooks/update-webhook
+func (s *WebhooksSvcImpl) UpdateWithContext(ctx context.Context, webhookId string, params *UpdateWebhookRequest) (*UpdateWebhookResponse, error) {
+	path := "webhooks/" + webhookId
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, params)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build response object
+	webhookResp := new(UpdateWebhookResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, webhookResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return webhookResp, nil
+}
+
+// Update updates a webhook
+func (s *WebhooksSvcImpl) Update(webhookId string, params *UpdateWebhookRequest) (*UpdateWebhookResponse, error) {
+	return s.UpdateWithContext(context.Background(), webhookId, params)
+}
+
+// ListWithOptions lists all webhooks with pagination options
+// https://resend.com/docs/api-reference/webhooks/list-webhooks
+func (s *WebhooksSvcImpl) ListWithOptions(ctx context.Context, options *ListOptions) (*ListWebhooksResponse, error) {
+	path := "webhooks" + buildPaginationQuery(options)
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build response object
+	webhooksResp := new(ListWebhooksResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, webhooksResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return webhooksResp, nil
+}
+
+// ListWithContext lists all webhooks with the given context
+func (s *WebhooksSvcImpl) ListWithContext(ctx context.Context) (*ListWebhooksResponse, error) {
+	return s.ListWithOptions(ctx, nil)
+}
+
+// List lists all webhooks
+func (s *WebhooksSvcImpl) List() (*ListWebhooksResponse, error) {
+	return s.ListWithContext(context.Background())
+}
+
+// RemoveWithContext deletes a webhook by ID with the given context
+// https://resend.com/docs/api-reference/webhooks/delete-webhook
+func (s *WebhooksSvcImpl) RemoveWithContext(ctx context.Context, webhookId string) (*DeleteWebhookResponse, error) {
+	path := "webhooks/" + webhookId
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build response object
+	webhookResp := new(DeleteWebhookResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, webhookResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return webhookResp, nil
+}
+
+// Remove deletes a webhook by ID
+func (s *WebhooksSvcImpl) Remove(webhookId string) (*DeleteWebhookResponse, error) {
+	return s.RemoveWithContext(context.Background(), webhookId)
+}

--- a/webhooks.go
+++ b/webhooks.go
@@ -118,7 +118,6 @@ func (s *WebhooksSvcImpl) Create(params *CreateWebhookRequest) (*CreateWebhookRe
 func (s *WebhooksSvcImpl) GetWithContext(ctx context.Context, webhookId string) (*Webhook, error) {
 	path := "webhooks/" + webhookId
 
-	// Prepare request
 	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err

--- a/webhooks.go
+++ b/webhooks.go
@@ -90,7 +90,6 @@ type WebhooksSvcImpl struct {
 func (s *WebhooksSvcImpl) CreateWithContext(ctx context.Context, params *CreateWebhookRequest) (*CreateWebhookResponse, error) {
 	path := "webhooks"
 
-	// Prepare request
 	req, err := s.client.NewRequest(ctx, http.MethodPost, path, params)
 	if err != nil {
 		return nil, err

--- a/webhooks.go
+++ b/webhooks.go
@@ -96,7 +96,6 @@ func (s *WebhooksSvcImpl) CreateWithContext(ctx context.Context, params *CreateW
 		return nil, err
 	}
 
-	// Build response object
 	webhookResp := new(CreateWebhookResponse)
 
 	_, err = s.client.Perform(req, webhookResp)

--- a/webhooks.go
+++ b/webhooks.go
@@ -2,8 +2,30 @@ package resend
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
+	"time"
 )
+
+const (
+	EventEmailSent            = "email.sent"
+	EventEmailDelivered       = "email.delivered"
+	EventEmailDeliveryDelayed = "email.delivery_delayed"
+	EventEmailComplained      = "email.complained"
+	EventEmailBounced         = "email.bounced"
+	EventEmailOpened          = "email.opened"
+	EventEmailClicked         = "email.clicked"
+)
+
+// Default tolerance for timestamp validation (5 minutes)
+const DefaultWebhookToleranceSeconds = 300
 
 // CreateWebhookRequest represents the parameters for creating a webhook
 type CreateWebhookRequest struct {
@@ -65,6 +87,20 @@ type DeleteWebhookResponse struct {
 	Deleted bool   `json:"deleted"`
 }
 
+// WebhookHeaders represents the webhook verification headers
+type WebhookHeaders struct {
+	Id        string // svix-id header
+	Timestamp string // svix-timestamp header
+	Signature string // svix-signature header
+}
+
+// VerifyWebhookOptions represents the parameters for webhook verification
+type VerifyWebhookOptions struct {
+	Payload       string         // Raw webhook payload body
+	Headers       WebhookHeaders // Webhook headers from the request
+	WebhookSecret string         // Signing secret (from webhook creation response)
+}
+
 // WebhooksSvc defines the interface for webhook operations
 type WebhooksSvc interface {
 	CreateWithContext(ctx context.Context, params *CreateWebhookRequest) (*CreateWebhookResponse, error)
@@ -78,6 +114,7 @@ type WebhooksSvc interface {
 	List() (*ListWebhooksResponse, error)
 	RemoveWithContext(ctx context.Context, webhookId string) (*DeleteWebhookResponse, error)
 	Remove(webhookId string) (*DeleteWebhookResponse, error)
+	Verify(options *VerifyWebhookOptions) error
 }
 
 // WebhooksSvcImpl implements the WebhooksSvc interface
@@ -224,4 +261,84 @@ func (s *WebhooksSvcImpl) RemoveWithContext(ctx context.Context, webhookId strin
 // Remove deletes a webhook by ID
 func (s *WebhooksSvcImpl) Remove(webhookId string) (*DeleteWebhookResponse, error) {
 	return s.RemoveWithContext(context.Background(), webhookId)
+}
+
+// Verify validates a webhook payload using HMAC-SHA256 signature verification
+// This implements manual verification without external dependencies
+// https://docs.svix.com/receiving/verifying-payloads/how-manual
+func (s *WebhooksSvcImpl) Verify(options *VerifyWebhookOptions) error {
+	if options == nil {
+		return errors.New("options cannot be nil")
+	}
+
+	if options.Payload == "" {
+		return errors.New("payload cannot be empty")
+	}
+
+	if options.WebhookSecret == "" {
+		return errors.New("webhook secret cannot be empty")
+	}
+
+	if options.Headers.Id == "" {
+		return errors.New("svix-id header is required")
+	}
+
+	if options.Headers.Timestamp == "" {
+		return errors.New("svix-timestamp header is required")
+	}
+
+	if options.Headers.Signature == "" {
+		return errors.New("svix-signature header is required")
+	}
+
+	// Step 1: Validate timestamp to prevent replay attacks
+	timestamp, err := strconv.ParseInt(options.Headers.Timestamp, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid timestamp format: %w", err)
+	}
+
+	now := time.Now().Unix()
+	diff := now - timestamp
+	if diff > DefaultWebhookToleranceSeconds || diff < -DefaultWebhookToleranceSeconds {
+		return fmt.Errorf("timestamp outside tolerance window: difference of %d seconds", diff)
+	}
+
+	// Step 2: Construct signed content: {id}.{timestamp}.{payload}
+	signedContent := fmt.Sprintf("%s.%s.%s", options.Headers.Id, options.Headers.Timestamp, options.Payload)
+
+	// Step 3: Decode the signing secret (strip whsec_ prefix and base64 decode)
+	secret := strings.TrimPrefix(options.WebhookSecret, "whsec_")
+	decodedSecret, err := base64.StdEncoding.DecodeString(secret)
+	if err != nil {
+		return fmt.Errorf("failed to decode webhook secret: %w", err)
+	}
+
+	// Step 4: Calculate expected signature using HMAC-SHA256
+	expectedSignature := generateSignature(decodedSecret, []byte(signedContent))
+
+	// Step 5: Compare signatures using constant-time comparison
+	// The signature header contains space-separated signatures with version prefixes (e.g., "v1,sig1 v1,sig2")
+	signatures := strings.Split(options.Headers.Signature, " ")
+	for _, sig := range signatures {
+		// Strip version prefix (e.g., "v1,")
+		parts := strings.SplitN(sig, ",", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		receivedSignature := parts[1]
+		if subtle.ConstantTimeCompare([]byte(expectedSignature), []byte(receivedSignature)) == 1 {
+			return nil // Signature matches
+		}
+	}
+
+	return errors.New("no matching signature found")
+}
+
+// generateSignature creates an HMAC-SHA256 signature and returns it as base64
+func generateSignature(secret, content []byte) string {
+	h := hmac.New(sha256.New, secret)
+	h.Write(content)
+	signature := h.Sum(nil)
+	return base64.StdEncoding.EncodeToString(signature)
 }

--- a/webhooks.go
+++ b/webhooks.go
@@ -99,7 +99,6 @@ func (s *WebhooksSvcImpl) CreateWithContext(ctx context.Context, params *CreateW
 	// Build response object
 	webhookResp := new(CreateWebhookResponse)
 
-	// Send Request
 	_, err = s.client.Perform(req, webhookResp)
 	if err != nil {
 		return nil, err

--- a/webhooks.go
+++ b/webhooks.go
@@ -15,6 +15,7 @@ import (
 )
 
 const (
+	// Email events
 	EventEmailSent            = "email.sent"
 	EventEmailDelivered       = "email.delivered"
 	EventEmailDeliveryDelayed = "email.delivery_delayed"
@@ -22,6 +23,18 @@ const (
 	EventEmailBounced         = "email.bounced"
 	EventEmailOpened          = "email.opened"
 	EventEmailClicked         = "email.clicked"
+	EventEmailReceived        = "email.received"
+	EventEmailFailed          = "email.failed"
+
+	// Contact events
+	EventContactCreated = "contact.created"
+	EventContactUpdated = "contact.updated"
+	EventContactDeleted = "contact.deleted"
+
+	// Domain events
+	EventDomainCreated = "domain.created"
+	EventDomainUpdated = "domain.updated"
+	EventDomainDeleted = "domain.deleted"
 )
 
 // Default tolerance for timestamp validation (5 minutes)

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -1,0 +1,372 @@
+package resend
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateWebhook(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/webhooks", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "webhook",
+			"id": "4dd369bc-aa82-4ff3-97de-514ae3000ee0",
+			"signing_secret": "whsec_xxxxxxxxxx"
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	req := &CreateWebhookRequest{
+		Endpoint: "https://webhook.example.com/handler",
+		Events:   []string{"email.sent", "email.delivered", "email.bounced"},
+	}
+	resp, err := client.Webhooks.Create(req)
+	if err != nil {
+		t.Errorf("Webhooks.Create returned error: %v", err)
+	}
+	assert.Equal(t, "webhook", resp.Object)
+	assert.Equal(t, "4dd369bc-aa82-4ff3-97de-514ae3000ee0", resp.Id)
+	assert.Equal(t, "whsec_xxxxxxxxxx", resp.SigningSecret)
+}
+
+func TestCreateWebhookWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/webhooks", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "webhook",
+			"id": "test-webhook-id",
+			"signing_secret": "whsec_test_secret"
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	ctx := context.Background()
+	req := &CreateWebhookRequest{
+		Endpoint: "https://webhook.example.com/handler",
+		Events:   []string{"email.sent"},
+	}
+	resp, err := client.Webhooks.CreateWithContext(ctx, req)
+	if err != nil {
+		t.Errorf("Webhooks.CreateWithContext returned error: %v", err)
+	}
+	assert.Equal(t, "webhook", resp.Object)
+	assert.Equal(t, "test-webhook-id", resp.Id)
+	assert.Equal(t, "whsec_test_secret", resp.SigningSecret)
+}
+
+func TestGetWebhook(t *testing.T) {
+	setup()
+	defer teardown()
+
+	webhookId := "4dd369bc-aa82-4ff3-97de-514ae3000ee0"
+
+	mux.HandleFunc(fmt.Sprintf("/webhooks/%s", webhookId), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "webhook",
+			"id": "4dd369bc-aa82-4ff3-97de-514ae3000ee0",
+			"created_at": "2023-08-22T15:28:00.000Z",
+			"status": "enabled",
+			"endpoint": "https://webhook.example.com/handler",
+			"events": ["email.sent", "email.received"],
+			"signing_secret": "whsec_xxxxxxxxxx"
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	resp, err := client.Webhooks.Get(webhookId)
+	if err != nil {
+		t.Errorf("Webhooks.Get returned error: %v", err)
+	}
+	assert.Equal(t, "webhook", resp.Object)
+	assert.Equal(t, "4dd369bc-aa82-4ff3-97de-514ae3000ee0", resp.Id)
+	assert.Equal(t, "2023-08-22T15:28:00.000Z", resp.CreatedAt)
+	assert.Equal(t, "enabled", resp.Status)
+	assert.Equal(t, "https://webhook.example.com/handler", resp.Endpoint)
+	assert.Equal(t, 2, len(resp.Events))
+	assert.Equal(t, "email.sent", resp.Events[0])
+	assert.Equal(t, "email.received", resp.Events[1])
+	assert.Equal(t, "whsec_xxxxxxxxxx", resp.SigningSecret)
+}
+
+func TestGetWebhookWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	webhookId := "test-webhook-id"
+
+	mux.HandleFunc(fmt.Sprintf("/webhooks/%s", webhookId), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "webhook",
+			"id": "test-webhook-id",
+			"created_at": "2024-01-01T00:00:00.000Z",
+			"status": "enabled",
+			"endpoint": "https://test.example.com/webhook",
+			"events": ["email.delivered"],
+			"signing_secret": "whsec_test_secret"
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	ctx := context.Background()
+	resp, err := client.Webhooks.GetWithContext(ctx, webhookId)
+	if err != nil {
+		t.Errorf("Webhooks.GetWithContext returned error: %v", err)
+	}
+	assert.Equal(t, "webhook", resp.Object)
+	assert.Equal(t, "test-webhook-id", resp.Id)
+	assert.Equal(t, "2024-01-01T00:00:00.000Z", resp.CreatedAt)
+	assert.Equal(t, "enabled", resp.Status)
+	assert.Equal(t, "https://test.example.com/webhook", resp.Endpoint)
+	assert.Equal(t, 1, len(resp.Events))
+	assert.Equal(t, "email.delivered", resp.Events[0])
+	assert.Equal(t, "whsec_test_secret", resp.SigningSecret)
+}
+
+func TestUpdateWebhook(t *testing.T) {
+	setup()
+	defer teardown()
+
+	webhookId := "430eed87-632a-4ea6-90db-0aace67ec228"
+
+	mux.HandleFunc(fmt.Sprintf("/webhooks/%s", webhookId), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "webhook",
+			"id": "430eed87-632a-4ea6-90db-0aace67ec228"
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	endpoint := "https://new-webhook.example.com/handler"
+	status := "enabled"
+	req := &UpdateWebhookRequest{
+		Endpoint: &endpoint,
+		Events:   []string{"email.sent", "email.delivered"},
+		Status:   &status,
+	}
+	resp, err := client.Webhooks.Update(webhookId, req)
+	if err != nil {
+		t.Errorf("Webhooks.Update returned error: %v", err)
+	}
+	assert.Equal(t, "webhook", resp.Object)
+	assert.Equal(t, "430eed87-632a-4ea6-90db-0aace67ec228", resp.Id)
+}
+
+func TestUpdateWebhookWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	webhookId := "test-update-id"
+
+	mux.HandleFunc(fmt.Sprintf("/webhooks/%s", webhookId), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "webhook",
+			"id": "test-update-id"
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	ctx := context.Background()
+	status := "disabled"
+	req := &UpdateWebhookRequest{
+		Status: &status,
+	}
+	resp, err := client.Webhooks.UpdateWithContext(ctx, webhookId, req)
+	if err != nil {
+		t.Errorf("Webhooks.UpdateWithContext returned error: %v", err)
+	}
+	assert.Equal(t, "webhook", resp.Object)
+	assert.Equal(t, "test-update-id", resp.Id)
+}
+
+func TestListWebhooks(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/webhooks", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "list",
+			"has_more": false,
+			"data": [
+				{
+					"id": "7ab123cd-ef45-6789-abcd-ef0123456789",
+					"created_at": "2023-09-10T10:15:30.000Z",
+					"status": "disabled",
+					"endpoint": "https://first-webhook.example.com/handler",
+					"events": ["email.delivered", "email.bounced"]
+				},
+				{
+					"id": "4dd369bc-aa82-4ff3-97de-514ae3000ee0",
+					"created_at": "2023-08-22T15:28:00.000Z",
+					"status": "enabled",
+					"endpoint": "https://second-webhook.example.com/receive",
+					"events": ["email.received"]
+				}
+			]
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	resp, err := client.Webhooks.List()
+	if err != nil {
+		t.Errorf("Webhooks.List returned error: %v", err)
+	}
+	assert.Equal(t, "list", resp.Object)
+	assert.Equal(t, false, resp.HasMore)
+	assert.Equal(t, 2, len(resp.Data))
+	assert.Equal(t, "7ab123cd-ef45-6789-abcd-ef0123456789", resp.Data[0].Id)
+	assert.Equal(t, "disabled", resp.Data[0].Status)
+	assert.Equal(t, "https://first-webhook.example.com/handler", resp.Data[0].Endpoint)
+	assert.Equal(t, 2, len(resp.Data[0].Events))
+	assert.Equal(t, "4dd369bc-aa82-4ff3-97de-514ae3000ee0", resp.Data[1].Id)
+	assert.Equal(t, "enabled", resp.Data[1].Status)
+}
+
+func TestListWebhooksWithOptions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/webhooks", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+
+		// Verify query parameters
+		query := r.URL.Query()
+		assert.Equal(t, "10", query.Get("limit"))
+		assert.Equal(t, "cursor123", query.Get("after"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "list",
+			"has_more": true,
+			"data": [
+				{
+					"id": "webhook-1",
+					"created_at": "2024-01-01T00:00:00.000Z",
+					"status": "enabled",
+					"endpoint": "https://test.example.com/webhook",
+					"events": ["email.sent"]
+				}
+			]
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	limit := 10
+	after := "cursor123"
+	options := &ListOptions{
+		Limit: &limit,
+		After: &after,
+	}
+
+	resp, err := client.Webhooks.ListWithOptions(context.Background(), options)
+	if err != nil {
+		t.Errorf("Webhooks.ListWithOptions returned error: %v", err)
+	}
+	assert.Equal(t, "list", resp.Object)
+	assert.Equal(t, true, resp.HasMore)
+	assert.Equal(t, 1, len(resp.Data))
+}
+
+func TestRemoveWebhook(t *testing.T) {
+	setup()
+	defer teardown()
+
+	webhookId := "4dd369bc-aa82-4ff3-97de-514ae3000ee0"
+
+	mux.HandleFunc(fmt.Sprintf("/webhooks/%s", webhookId), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "webhook",
+			"id": "4dd369bc-aa82-4ff3-97de-514ae3000ee0",
+			"deleted": true
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	resp, err := client.Webhooks.Remove(webhookId)
+	if err != nil {
+		t.Errorf("Webhooks.Remove returned error: %v", err)
+	}
+	assert.Equal(t, "webhook", resp.Object)
+	assert.Equal(t, "4dd369bc-aa82-4ff3-97de-514ae3000ee0", resp.Id)
+	assert.Equal(t, true, resp.Deleted)
+}
+
+func TestRemoveWebhookWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	webhookId := "test-delete-id"
+
+	mux.HandleFunc(fmt.Sprintf("/webhooks/%s", webhookId), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "webhook",
+			"id": "test-delete-id",
+			"deleted": true
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	ctx := context.Background()
+	resp, err := client.Webhooks.RemoveWithContext(ctx, webhookId)
+	if err != nil {
+		t.Errorf("Webhooks.RemoveWithContext returned error: %v", err)
+	}
+	assert.Equal(t, "webhook", resp.Object)
+	assert.Equal(t, "test-delete-id", resp.Id)
+	assert.Equal(t, true, resp.Deleted)
+}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds Webhooks API support to the Go client, enabling create, get, update, list, and delete operations with pagination and context variants. Includes example usage and tests; Client now exposes a Webhooks service.

- **New Features**
  - New WebhooksSvc on Client with Create/Get/Update/List/Remove (+ WithContext variants).
  - List supports pagination via ListOptions; added request/response models for webhook operations.
  - Example (examples/webhooks.go) showing full CRUD workflow and printing signing secrets.
  - Unit tests cover all endpoints and query handling.

<!-- End of auto-generated description by cubic. -->

