### PR TITLE
feat: make new attachments API conform to updated spec

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -77,7 +77,7 @@ func TestBatchSendEmailWithErrors(t *testing.T) {
 	req := []*SendEmailRequest{
 		{To: []string{"valid1@example.com"}},
 		{To: []string{"valid2@example.com"}},
-		{To: []string{}}, // Missing 'to' field
+		{To: []string{}},                // Missing 'to' field
 		{To: []string{"invalid-email"}}, // Invalid email
 	}
 
@@ -109,7 +109,7 @@ func TestBatchSendWithOptionsEmail(t *testing.T) {
 		testMethod(t, r, http.MethodPost)
 		// Verify Idempotency-Key header is set
 		assert.Equal(t, "1234567890", r.Header.Get("Idempotency-Key"))
-		
+
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
@@ -157,7 +157,7 @@ func TestBatchSendWithValidationMode(t *testing.T) {
 		testMethod(t, r, http.MethodPost)
 		// Verify x-batch-validation header is set to permissive
 		assert.Equal(t, "permissive", r.Header.Get("x-batch-validation"))
-		
+
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
@@ -193,7 +193,7 @@ func TestBatchSendWithValidationMode(t *testing.T) {
 	// Verify successful response
 	assert.Equal(t, len(resp.Data), 1)
 	assert.Equal(t, resp.Data[0].Id, "success-1")
-	
+
 	// Verify error response
 	assert.NotNil(t, resp.Errors)
 	assert.Equal(t, len(resp.Errors), 1)

--- a/errors.go
+++ b/errors.go
@@ -62,10 +62,12 @@ var (
 
 // EmailsSvc errors
 var (
-	ErrFailedToCreateUpdateEmailRequest = errors.New("[ERROR]: Failed to create UpdateEmail request")
-	ErrFailedToCreateEmailsSendRequest  = errors.New("[ERROR]: Failed to create SendEmail request")
-	ErrFailedToCreateEmailsGetRequest   = errors.New("[ERROR]: Failed to create GetEmail request")
-	ErrFailedToCreateEmailsListRequest  = errors.New("[ERROR]: Failed to create ListEmails request")
+	ErrFailedToCreateUpdateEmailRequest           = errors.New("[ERROR]: Failed to create UpdateEmail request")
+	ErrFailedToCreateEmailsSendRequest            = errors.New("[ERROR]: Failed to create SendEmail request")
+	ErrFailedToCreateEmailsGetRequest             = errors.New("[ERROR]: Failed to create GetEmail request")
+	ErrFailedToCreateEmailsListRequest            = errors.New("[ERROR]: Failed to create ListEmails request")
+	ErrFailedToCreateEmailsGetAttachmentRequest   = errors.New("[ERROR]: Failed to create Emails.GetAttachment request")
+	ErrFailedToCreateEmailsListAttachmentsRequest = errors.New("[ERROR]: Failed to create Emails.ListAttachments request")
 )
 
 // ReceivingSvc errors

--- a/examples/receiving.go
+++ b/examples/receiving.go
@@ -15,7 +15,7 @@ func receivingExample() {
 	client := resend.NewClient(apiKey)
 
 	// Get a single received email
-	email, err := client.Receiving.GetWithContext(ctx, "8136d3fb-0439-4b09-b939-b8436a3524b6")
+	email, err := client.Emails.Receiving.GetWithContext(ctx, "8136d3fb-0439-4b09-b939-b8436a3524b6")
 	if err != nil {
 		panic(err)
 	}
@@ -25,7 +25,7 @@ func receivingExample() {
 	fmt.Printf("Has %d attachments\n", len(email.Attachments))
 
 	// List received emails
-	emails, err := client.Receiving.ListWithContext(ctx)
+	emails, err := client.Emails.Receiving.ListWithContext(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -37,14 +37,14 @@ func receivingExample() {
 	listOptions := &resend.ListOptions{
 		Limit: &limit,
 	}
-	paginatedEmails, err := client.Receiving.ListWithOptions(ctx, listOptions)
+	paginatedEmails, err := client.Emails.Receiving.ListWithOptions(ctx, listOptions)
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("\nPaginated list returned %d emails\n", len(paginatedEmails.Data))
 
 	// Get email with attachments
-	emailWithAttachments, err := client.Receiving.GetWithContext(ctx, "006e2796-ff6a-4436-91ad-0429e600bf8a")
+	emailWithAttachments, err := client.Emails.Receiving.GetWithContext(ctx, "006e2796-ff6a-4436-91ad-0429e600bf8a")
 	if err != nil {
 		panic(err)
 	}
@@ -52,7 +52,7 @@ func receivingExample() {
 
 	// Get each attachment's full details including download URLs
 	for _, att := range emailWithAttachments.Attachments {
-		attachment, err := client.Receiving.GetAttachmentWithContext(ctx, emailWithAttachments.Id, att.Id)
+		attachment, err := client.Emails.Receiving.GetAttachmentWithContext(ctx, emailWithAttachments.Id, att.Id)
 		if err != nil {
 			panic(err)
 		}
@@ -64,7 +64,7 @@ func receivingExample() {
 	}
 
 	// List all attachments for a received email
-	attachmentsList, err := client.Receiving.ListAttachmentsWithContext(ctx, "006e2796-ff6a-4436-91ad-0429e600bf8a")
+	attachmentsList, err := client.Emails.Receiving.ListAttachmentsWithContext(ctx, "006e2796-ff6a-4436-91ad-0429e600bf8a")
 	if err != nil {
 		panic(err)
 	}
@@ -76,7 +76,7 @@ func receivingExample() {
 	attachmentsOptions := &resend.ListOptions{
 		Limit: &attachmentsLimit,
 	}
-	paginatedAttachments, err := client.Receiving.ListAttachmentsWithOptions(ctx, "006e2796-ff6a-4436-91ad-0429e600bf8a", attachmentsOptions)
+	paginatedAttachments, err := client.Emails.Receiving.ListAttachmentsWithOptions(ctx, "006e2796-ff6a-4436-91ad-0429e600bf8a", attachmentsOptions)
 	if err != nil {
 		panic(err)
 	}

--- a/receiving.go
+++ b/receiving.go
@@ -43,37 +43,13 @@ type ListReceivedEmailsResponse struct {
 	Data    []ListReceivedEmail `json:"data"`
 }
 
-// ReceivedAttachment represents an attachment in a received email
+// ReceivedAttachment represents an attachment in a received email (used in list responses without download URLs)
 type ReceivedAttachment struct {
 	Id                 string `json:"id"`
 	Filename           string `json:"filename"`
 	ContentType        string `json:"content_type"`
 	ContentDisposition string `json:"content_disposition"`
 	ContentId          string `json:"content_id"`
-}
-
-// ReceivedEmailAttachment represents the full attachment details including download URL
-type ReceivedEmailAttachment struct {
-	Id                 string `json:"id"`
-	Filename           string `json:"filename"`
-	ContentType        string `json:"content_type"`
-	ContentDisposition string `json:"content_disposition"`
-	ContentId          string `json:"content_id"`
-	DownloadUrl        string `json:"download_url"`
-	ExpiresAt          string `json:"expires_at"`
-}
-
-// receivedEmailAttachmentResponse wraps the API response for a single attachment
-type receivedEmailAttachmentResponse struct {
-	Object string                   `json:"object"`
-	Data   ReceivedEmailAttachment `json:"data"`
-}
-
-// ListReceivedEmailAttachmentsResponse is the response from the Receiving.ListAttachments call.
-type ListReceivedEmailAttachmentsResponse struct {
-	Object  string                    `json:"object"`
-	HasMore bool                      `json:"has_more"`
-	Data    []ReceivedEmailAttachment `json:"data"`
 }
 
 // ReceivingSvc handles operations for received/inbound emails
@@ -83,11 +59,11 @@ type ReceivingSvc interface {
 	ListWithOptions(ctx context.Context, options *ListOptions) (ListReceivedEmailsResponse, error)
 	ListWithContext(ctx context.Context) (ListReceivedEmailsResponse, error)
 	List() (ListReceivedEmailsResponse, error)
-	GetAttachmentWithContext(ctx context.Context, emailID string, attachmentID string) (*ReceivedEmailAttachment, error)
-	GetAttachment(emailID string, attachmentID string) (*ReceivedEmailAttachment, error)
-	ListAttachmentsWithOptions(ctx context.Context, emailID string, options *ListOptions) (ListReceivedEmailAttachmentsResponse, error)
-	ListAttachmentsWithContext(ctx context.Context, emailID string) (ListReceivedEmailAttachmentsResponse, error)
-	ListAttachments(emailID string) (ListReceivedEmailAttachmentsResponse, error)
+	GetAttachmentWithContext(ctx context.Context, emailID string, attachmentID string) (*EmailAttachment, error)
+	GetAttachment(emailID string, attachmentID string) (*EmailAttachment, error)
+	ListAttachmentsWithOptions(ctx context.Context, emailID string, options *ListOptions) (ListEmailAttachmentsResponse, error)
+	ListAttachmentsWithContext(ctx context.Context, emailID string) (ListEmailAttachmentsResponse, error)
+	ListAttachments(emailID string) (ListEmailAttachmentsResponse, error)
 }
 
 // ReceivingSvcImpl is the implementation of the ReceivingSvc interface
@@ -125,7 +101,7 @@ func (s *ReceivingSvcImpl) Get(emailID string) (*ReceivedEmail, error) {
 }
 
 // ListWithOptions retrieves a list of received emails with pagination options
-// https://resend.com/docs/api-reference/emails/retrieve-received-email
+// https://resend.com/docs/api-reference/emails/list-received-emails
 func (s *ReceivingSvcImpl) ListWithOptions(ctx context.Context, options *ListOptions) (ListReceivedEmailsResponse, error) {
 	path := "emails/receiving" + buildPaginationQuery(options)
 
@@ -146,20 +122,20 @@ func (s *ReceivingSvcImpl) ListWithOptions(ctx context.Context, options *ListOpt
 }
 
 // ListWithContext retrieves a list of received emails
-// https://resend.com/docs/api-reference/emails/retrieve-received-email
+// https://resend.com/docs/api-reference/emails/list-received-emails
 func (s *ReceivingSvcImpl) ListWithContext(ctx context.Context) (ListReceivedEmailsResponse, error) {
 	return s.ListWithOptions(ctx, nil)
 }
 
 // List retrieves a list of received emails
-// https://resend.com/docs/api-reference/emails/retrieve-received-email
+// https://resend.com/docs/api-reference/emails/list-received-emails
 func (s *ReceivingSvcImpl) List() (ListReceivedEmailsResponse, error) {
 	return s.ListWithContext(context.Background())
 }
 
 // GetAttachmentWithContext retrieves a single attachment from a received email with the given emailID and attachmentID
 // https://resend.com/docs/api-reference/attachments/retrieve-received-email-attachment
-func (s *ReceivingSvcImpl) GetAttachmentWithContext(ctx context.Context, emailID string, attachmentID string) (*ReceivedEmailAttachment, error) {
+func (s *ReceivingSvcImpl) GetAttachmentWithContext(ctx context.Context, emailID string, attachmentID string) (*EmailAttachment, error) {
 	path := "emails/receiving/" + emailID + "/attachments/" + attachmentID
 
 	// Prepare request
@@ -168,44 +144,43 @@ func (s *ReceivingSvcImpl) GetAttachmentWithContext(ctx context.Context, emailID
 		return nil, ErrFailedToCreateReceivingGetAttachmentRequest
 	}
 
-	// Build response wrapper obj
-	attachmentResponse := new(receivedEmailAttachmentResponse)
+	attachment := new(EmailAttachment)
 
 	// Send Request
-	_, err = s.client.Perform(req, attachmentResponse)
+	_, err = s.client.Perform(req, attachment)
 
 	if err != nil {
 		return nil, err
 	}
 
-	return &attachmentResponse.Data, nil
+	return attachment, nil
 }
 
 // GetAttachment retrieves a single attachment from a received email with the given emailID and attachmentID
 // https://resend.com/docs/api-reference/attachments/retrieve-received-email-attachment
-func (s *ReceivingSvcImpl) GetAttachment(emailID string, attachmentID string) (*ReceivedEmailAttachment, error) {
+func (s *ReceivingSvcImpl) GetAttachment(emailID string, attachmentID string) (*EmailAttachment, error) {
 	return s.GetAttachmentWithContext(context.Background(), emailID, attachmentID)
 }
 
 // ListAttachmentsWithOptions retrieves a list of attachments for a received email with pagination options
 // https://resend.com/docs/api-reference/attachments/list-received-email-attachments
-func (s *ReceivingSvcImpl) ListAttachmentsWithOptions(ctx context.Context, emailID string, options *ListOptions) (ListReceivedEmailAttachmentsResponse, error) {
+func (s *ReceivingSvcImpl) ListAttachmentsWithOptions(ctx context.Context, emailID string, options *ListOptions) (ListEmailAttachmentsResponse, error) {
 	path := "emails/receiving/" + emailID + "/attachments" + buildPaginationQuery(options)
 
 	// Prepare request
 	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
-		return ListReceivedEmailAttachmentsResponse{}, ErrFailedToCreateReceivingListAttachmentsRequest
+		return ListEmailAttachmentsResponse{}, ErrFailedToCreateReceivingListAttachmentsRequest
 	}
 
 	// Build response recipient obj
-	listAttachmentsResponse := new(ListReceivedEmailAttachmentsResponse)
+	listAttachmentsResponse := new(ListEmailAttachmentsResponse)
 
 	// Send Request
 	_, err = s.client.Perform(req, listAttachmentsResponse)
 
 	if err != nil {
-		return ListReceivedEmailAttachmentsResponse{}, err
+		return ListEmailAttachmentsResponse{}, err
 	}
 
 	return *listAttachmentsResponse, nil
@@ -213,12 +188,12 @@ func (s *ReceivingSvcImpl) ListAttachmentsWithOptions(ctx context.Context, email
 
 // ListAttachmentsWithContext retrieves a list of attachments for a received email
 // https://resend.com/docs/api-reference/attachments/list-received-email-attachments
-func (s *ReceivingSvcImpl) ListAttachmentsWithContext(ctx context.Context, emailID string) (ListReceivedEmailAttachmentsResponse, error) {
+func (s *ReceivingSvcImpl) ListAttachmentsWithContext(ctx context.Context, emailID string) (ListEmailAttachmentsResponse, error) {
 	return s.ListAttachmentsWithOptions(ctx, emailID, nil)
 }
 
 // ListAttachments retrieves a list of attachments for a received email
 // https://resend.com/docs/api-reference/attachments/list-received-email-attachments
-func (s *ReceivingSvcImpl) ListAttachments(emailID string) (ListReceivedEmailAttachmentsResponse, error) {
+func (s *ReceivingSvcImpl) ListAttachments(emailID string) (ListEmailAttachmentsResponse, error) {
 	return s.ListAttachmentsWithContext(context.Background(), emailID)
 }

--- a/receiving_test.go
+++ b/receiving_test.go
@@ -48,9 +48,9 @@ func TestGetReceivedEmail(t *testing.T) {
 		fmt.Fprintf(w, ret)
 	})
 
-	resp, err := client.Receiving.Get("8136d3fb-0439-4b09-b939-b8436a3524b6")
+	resp, err := client.Emails.Receiving.Get("8136d3fb-0439-4b09-b939-b8436a3524b6")
 	if err != nil {
-		t.Errorf("Receiving.Get returned error: %v", err)
+		t.Errorf("Emails.Receiving.Get returned error: %v", err)
 	}
 	assert.Equal(t, "8136d3fb-0439-4b09-b939-b8436a3524b6", resp.Id)
 	assert.Equal(t, "inbound", resp.Object)
@@ -102,9 +102,9 @@ func TestGetReceivedEmailWithNullFields(t *testing.T) {
 		fmt.Fprintf(w, ret)
 	})
 
-	resp, err := client.Receiving.Get("null-fields-id")
+	resp, err := client.Emails.Receiving.Get("null-fields-id")
 	if err != nil {
-		t.Errorf("Receiving.Get returned error: %v", err)
+		t.Errorf("Emails.Receiving.Get returned error: %v", err)
 	}
 	assert.Equal(t, "null-fields-id", resp.Id)
 	assert.Equal(t, "", resp.Html)
@@ -168,9 +168,9 @@ func TestListReceivedEmails(t *testing.T) {
 		}
 	})
 
-	resp, err := client.Receiving.List()
+	resp, err := client.Emails.Receiving.List()
 	if err != nil {
-		t.Errorf("Receiving.List returned error: %v", err)
+		t.Errorf("Emails.Receiving.List returned error: %v", err)
 	}
 
 	assert.Equal(t, "list", resp.Object)
@@ -229,9 +229,9 @@ func TestListReceivedEmailsWithParameters(t *testing.T) {
 		After: &after,
 	}
 
-	resp, err := client.Receiving.ListWithOptions(context.Background(), options)
+	resp, err := client.Emails.Receiving.ListWithOptions(context.Background(), options)
 	if err != nil {
-		t.Errorf("Receiving.ListWithOptions returned error: %v", err)
+		t.Errorf("Emails.Receiving.ListWithOptions returned error: %v", err)
 	}
 
 	assert.Equal(t, "list", resp.Object)
@@ -259,9 +259,9 @@ func TestListReceivedEmailsEmpty(t *testing.T) {
 		}
 	})
 
-	resp, err := client.Receiving.List()
+	resp, err := client.Emails.Receiving.List()
 	if err != nil {
-		t.Errorf("Receiving.List returned error: %v", err)
+		t.Errorf("Emails.Receiving.List returned error: %v", err)
 	}
 
 	assert.Equal(t, "list", resp.Object)
@@ -284,22 +284,20 @@ func TestGetReceivedEmailAttachment(t *testing.T) {
 		ret := `
 		{
 			"object": "attachment",
-			"data": {
-				"id": "2a0c9ce0-3112-4728-976e-47ddcd16a318",
-				"filename": "avatar.png",
-				"content_type": "image/png",
-				"content_disposition": "inline",
-				"content_id": "img001",
-				"download_url": "https://inbound-cdn.resend.com/4ef9a417-02e9-4d39-ad75-9611e0fcc33c/attachments/2a0c9ce0-3112-4728-976e-47ddcd16a318?some-params=example&signature=sig-123",
-				"expires_at": "2025-10-17T14:29:41.521Z"
-			}
+			"id": "2a0c9ce0-3112-4728-976e-47ddcd16a318",
+			"filename": "avatar.png",
+			"content_type": "image/png",
+			"content_disposition": "inline",
+			"content_id": "img001",
+			"download_url": "https://inbound-cdn.resend.com/4ef9a417-02e9-4d39-ad75-9611e0fcc33c/attachments/2a0c9ce0-3112-4728-976e-47ddcd16a318?some-params=example&signature=sig-123",
+			"expires_at": "2025-10-17T14:29:41.521Z"
 		}`
 		fmt.Fprintf(w, ret)
 	})
 
-	resp, err := client.Receiving.GetAttachment(emailId, attachmentId)
+	resp, err := client.Emails.Receiving.GetAttachment(emailId, attachmentId)
 	if err != nil {
-		t.Errorf("Receiving.GetAttachment returned error: %v", err)
+		t.Errorf("Emails.Receiving.GetAttachment returned error: %v", err)
 	}
 	assert.Equal(t, "2a0c9ce0-3112-4728-976e-47ddcd16a318", resp.Id)
 	assert.Equal(t, "avatar.png", resp.Filename)
@@ -325,23 +323,21 @@ func TestGetReceivedEmailAttachmentWithContext(t *testing.T) {
 		ret := `
 		{
 			"object": "attachment",
-			"data": {
-				"id": "test-attachment-id",
-				"filename": "document.pdf",
-				"content_type": "application/pdf",
-				"content_disposition": "attachment",
-				"content_id": "doc001",
-				"download_url": "https://inbound-cdn.resend.com/test-email-id/attachments/test-attachment-id",
-				"expires_at": "2025-10-18T12:00:00.000Z"
-			}
+			"id": "test-attachment-id",
+			"filename": "document.pdf",
+			"content_type": "application/pdf",
+			"content_disposition": "attachment",
+			"content_id": "doc001",
+			"download_url": "https://inbound-cdn.resend.com/test-email-id/attachments/test-attachment-id",
+			"expires_at": "2025-10-18T12:00:00.000Z"
 		}`
 		fmt.Fprintf(w, ret)
 	})
 
 	ctx := context.Background()
-	resp, err := client.Receiving.GetAttachmentWithContext(ctx, emailId, attachmentId)
+	resp, err := client.Emails.Receiving.GetAttachmentWithContext(ctx, emailId, attachmentId)
 	if err != nil {
-		t.Errorf("Receiving.GetAttachmentWithContext returned error: %v", err)
+		t.Errorf("Emails.Receiving.GetAttachmentWithContext returned error: %v", err)
 	}
 	assert.Equal(t, "test-attachment-id", resp.Id)
 	assert.Equal(t, "document.pdf", resp.Filename)
@@ -363,10 +359,10 @@ func TestListReceivedEmailAttachments(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		ret := &ListReceivedEmailAttachmentsResponse{
+		ret := &ListEmailAttachmentsResponse{
 			Object:  "list",
 			HasMore: false,
-			Data: []ReceivedEmailAttachment{
+			Data: []EmailAttachment{
 				{
 					Id:                 "2a0c9ce0-3112-4728-976e-47ddcd16a318",
 					Filename:           "avatar.png",
@@ -393,9 +389,9 @@ func TestListReceivedEmailAttachments(t *testing.T) {
 		}
 	})
 
-	resp, err := client.Receiving.ListAttachments(emailId)
+	resp, err := client.Emails.Receiving.ListAttachments(emailId)
 	if err != nil {
-		t.Errorf("Receiving.ListAttachments returned error: %v", err)
+		t.Errorf("Emails.Receiving.ListAttachments returned error: %v", err)
 	}
 
 	assert.Equal(t, "list", resp.Object)
@@ -428,10 +424,10 @@ func TestListReceivedEmailAttachmentsWithParameters(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		ret := &ListReceivedEmailAttachmentsResponse{
+		ret := &ListEmailAttachmentsResponse{
 			Object:  "list",
 			HasMore: true,
-			Data: []ReceivedEmailAttachment{
+			Data: []EmailAttachment{
 				{
 					Id:                 "attachment-1",
 					Filename:           "file1.jpg",
@@ -456,9 +452,9 @@ func TestListReceivedEmailAttachmentsWithParameters(t *testing.T) {
 		After: &after,
 	}
 
-	resp, err := client.Receiving.ListAttachmentsWithOptions(context.Background(), emailId, options)
+	resp, err := client.Emails.Receiving.ListAttachmentsWithOptions(context.Background(), emailId, options)
 	if err != nil {
-		t.Errorf("Receiving.ListAttachmentsWithOptions returned error: %v", err)
+		t.Errorf("Emails.Receiving.ListAttachmentsWithOptions returned error: %v", err)
 	}
 
 	assert.Equal(t, "list", resp.Object)
@@ -478,10 +474,10 @@ func TestListReceivedEmailAttachmentsEmpty(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		ret := &ListReceivedEmailAttachmentsResponse{
+		ret := &ListEmailAttachmentsResponse{
 			Object:  "list",
 			HasMore: false,
-			Data:    []ReceivedEmailAttachment{},
+			Data:    []EmailAttachment{},
 		}
 
 		if err := json.NewEncoder(w).Encode(ret); err != nil {
@@ -489,9 +485,9 @@ func TestListReceivedEmailAttachmentsEmpty(t *testing.T) {
 		}
 	})
 
-	resp, err := client.Receiving.ListAttachments(emailId)
+	resp, err := client.Emails.Receiving.ListAttachments(emailId)
 	if err != nil {
-		t.Errorf("Receiving.ListAttachments returned error: %v", err)
+		t.Errorf("Emails.Receiving.ListAttachments returned error: %v", err)
 	}
 
 	assert.Equal(t, "list", resp.Object)
@@ -510,10 +506,10 @@ func TestListReceivedEmailAttachmentsWithContext(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		ret := &ListReceivedEmailAttachmentsResponse{
+		ret := &ListEmailAttachmentsResponse{
 			Object:  "list",
 			HasMore: false,
-			Data: []ReceivedEmailAttachment{
+			Data: []EmailAttachment{
 				{
 					Id:                 "ctx-att-1",
 					Filename:           "context-test.txt",
@@ -532,9 +528,9 @@ func TestListReceivedEmailAttachmentsWithContext(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	resp, err := client.Receiving.ListAttachmentsWithContext(ctx, emailId)
+	resp, err := client.Emails.Receiving.ListAttachmentsWithContext(ctx, emailId)
 	if err != nil {
-		t.Errorf("Receiving.ListAttachmentsWithContext returned error: %v", err)
+		t.Errorf("Emails.Receiving.ListAttachmentsWithContext returned error: %v", err)
 	}
 
 	assert.Equal(t, "list", resp.Object)

--- a/resend.go
+++ b/resend.go
@@ -58,7 +58,6 @@ type Client struct {
 	Contacts   ContactsSvc
 	Broadcasts BroadcastsSvc
 	Templates  TemplatesSvc
-	Receiving  ReceivingSvc
 	Topics     TopicsSvc
 	Webhooks   WebhooksSvc
 }
@@ -89,11 +88,7 @@ func NewCustomClient(httpClient *http.Client, apiKey string) *Client {
 	c.Audiences = &AudiencesSvcImpl{client: c}
 	c.Contacts = &ContactsSvcImpl{client: c}
 	c.Broadcasts = &BroadcastsSvcImpl{client: c}
-<<<<<<< HEAD
-=======
 	c.Templates = &TemplatesSvcImpl{client: c}
-	c.Receiving = &ReceivingSvcImpl{client: c}
->>>>>>> c17cad7868a33d30fd5018d716b009aa7e51968e
 	c.Topics = &TopicsSvcImpl{client: c}
 	c.Webhooks = &WebhooksSvcImpl{client: c}
 

--- a/resend.go
+++ b/resend.go
@@ -50,14 +50,13 @@ type Client struct {
 	headers map[string]string
 
 	// Services
-	Emails     EmailsSvc
+	Emails     *EmailsSvcImpl
 	Batch      BatchSvc
 	ApiKeys    ApiKeysSvc
 	Domains    DomainsSvc
 	Audiences  AudiencesSvc
 	Contacts   ContactsSvc
 	Broadcasts BroadcastsSvc
-	Receiving  ReceivingSvc
 	Topics     TopicsSvc
 	Webhooks   WebhooksSvc
 }
@@ -78,14 +77,16 @@ func NewCustomClient(httpClient *http.Client, apiKey string) *Client {
 
 	c := &Client{client: httpClient, BaseURL: baseURL, UserAgent: userAgent}
 
-	c.Emails = &EmailsSvcImpl{client: c}
+	emailsSvc := &EmailsSvcImpl{client: c}
+	emailsSvc.Receiving = &ReceivingSvcImpl{client: c}
+	c.Emails = emailsSvc
+
 	c.Batch = &BatchSvcImpl{client: c}
 	c.ApiKeys = &ApiKeysSvcImpl{client: c}
 	c.Domains = &DomainsSvcImpl{client: c}
 	c.Audiences = &AudiencesSvcImpl{client: c}
 	c.Contacts = &ContactsSvcImpl{client: c}
 	c.Broadcasts = &BroadcastsSvcImpl{client: c}
-	c.Receiving = &ReceivingSvcImpl{client: c}
 	c.Topics = &TopicsSvcImpl{client: c}
 	c.Webhooks = &WebhooksSvcImpl{client: c}
 


### PR DESCRIPTION
This updates the API for the inbound methods on this SDK to conform to the new specification.

Note that I also fixed an incorrect wrapping in `data`.

Finally, **also worth noticing I'm now nesting received attachments methods inside `Emails.Receiving.Attachments` to match the Node API. Please feel free to change that back to just `.Receiving` if you think that's not idiomatic**, I'll leave that up to you.

This is as per @vieiralucas message's from Monday:

> Hey folks,
> We recently changed how we are calling the methods related to attachments on the Node SDK
> resend.attachments.sending     →  resend.emails.attachments
> resend.attachments.receiving →  resend.emails.receiving.attachments
>
> If you already had implemented those in your language, you might want to check if it makes sense to adjust them.
>
> We also changed the attachment routes for sending:
> From: GET /emails/sending/:emailId/attachments
> To:   GET /emails/:emailId/attachments
>
> From: GET /emails/sending/:emailId/attachments/:attachmentId
> To:   GET /emails/:emailId/attachments/:attachmentId
>
> Basically, removed the /sending/. We're not removing the old endpoints from the API, but you must change the SDK to call the new one.

In Go, that means we now have:

```
# Attachments for sent emails (added)
sentAttachmentsList, err := client.Emails.ListAttachments
sentAttachmentsList, err := client.Emails.ListAttachmentsWithOptions
sentAttachmentsList, err := client.Emails.ListAttachmentsWithContext
sentAttachment, err := client.Emails.GetAttachment
sentAttachment, err := client.Emails.GetAttachmentWithContext

# Attachments for received emails (now nested inside `Receiving`)
client.Emails.Receiving.ListAttachments
client.Emails.Receiving.ListAttachmentsWithContext
client.Emails.Receiving.GetAttachment
client.Emails.Receiving.GetAttachmentWithContext
```

---

## What I need from you

Please review/test my changes carefully. I have already created a test file locally to test all these functions, but please do test it too.

If you need to make any changes, please go ahead and make commits to this PR.

**Once done, please let's release a new version with these changes.** I'm not sure if you have already released a version with this, but please do once you merge this (let's avoid releasing the old SDK API if it's not released yet just to avoid a major bump if possible).



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the attachments API with the updated spec. Adds sent email attachment methods, nests receiving under Emails.Receiving, unifies attachment models, switches to /emails/:emailId/attachments, and fixes a response wrapping bug.

- **New Features**
  - Added Emails.GetAttachment and Emails.ListAttachments for sent emails.
  - Receiving APIs now live under Emails.Receiving.*
  - Unified attachment model (EmailAttachment) and list response (ListEmailAttachmentsResponse).
  - SDK now calls /emails/:emailId/attachments and /emails/:emailId/attachments/:attachmentId.

- **Migration**
  - Replace client.Receiving.* with client.Emails.Receiving.*
  - Use client.Emails.GetAttachment/ListAttachments for sent email attachments.

<!-- End of auto-generated description by cubic. -->

