### PR TITLE
chore: bump to v2.28.0

### DIFF
--- a/resend.go
+++ b/resend.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version     = "2.27.0"
+	version     = "2.28.0"
 	userAgent   = "resend-go/" + version
 	contentType = "application/json"
 )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumped the Go SDK version to v2.28.0 so the user agent reports the latest release.

<!-- End of auto-generated description by cubic. -->

