### PR TITLE
feat: impl contacts properties and contact topics

### DIFF
--- a/contact_properties.go
+++ b/contact_properties.go
@@ -1,0 +1,240 @@
+package resend
+
+import (
+	"context"
+	"errors"
+	"net/http"
+)
+
+type ContactPropertiesSvc interface {
+	CreateWithContext(ctx context.Context, params *CreateContactPropertyRequest) (CreateContactPropertyResponse, error)
+	Create(params *CreateContactPropertyRequest) (CreateContactPropertyResponse, error)
+	ListWithOptions(ctx context.Context, options *ListOptions) (ListContactPropertiesResponse, error)
+	ListWithContext(ctx context.Context) (ListContactPropertiesResponse, error)
+	List() (ListContactPropertiesResponse, error)
+	GetWithContext(ctx context.Context, id string) (ContactProperty, error)
+	Get(id string) (ContactProperty, error)
+	UpdateWithContext(ctx context.Context, params *UpdateContactPropertyRequest) (UpdateContactPropertyResponse, error)
+	Update(params *UpdateContactPropertyRequest) (UpdateContactPropertyResponse, error)
+	RemoveWithContext(ctx context.Context, id string) (RemoveContactPropertyResponse, error)
+	Remove(id string) (RemoveContactPropertyResponse, error)
+}
+
+type ContactPropertiesSvcImpl struct {
+	client *Client
+}
+
+type ContactProperty struct {
+	Id            string      `json:"id"`
+	Key           string      `json:"key"`
+	Object        string      `json:"object"`
+	CreatedAt     string      `json:"created_at"`
+	Type          string      `json:"type"`
+	FallbackValue interface{} `json:"fallback_value"`
+}
+
+type CreateContactPropertyRequest struct {
+	Key           string      `json:"key"`
+	Type          string      `json:"type"`
+	FallbackValue interface{} `json:"fallback_value"`
+}
+
+type CreateContactPropertyResponse struct {
+	Id     string `json:"id"`
+	Object string `json:"object"`
+}
+
+type UpdateContactPropertyRequest struct {
+	Id            string      `json:"-"`
+	FallbackValue interface{} `json:"fallback_value"`
+}
+
+type UpdateContactPropertyResponse struct {
+	Id     string `json:"id"`
+	Object string `json:"object"`
+}
+
+type RemoveContactPropertyResponse struct {
+	Id      string `json:"id"`
+	Object  string `json:"object"`
+	Deleted bool   `json:"deleted"`
+}
+
+type ListContactPropertiesResponse struct {
+	Object  string            `json:"object"`
+	Data    []ContactProperty `json:"data"`
+	HasMore bool              `json:"has_more"`
+}
+
+// CreateWithContext creates a new contact property based on the given params
+// https://resend.com/docs/api-reference/contact-properties/create-contact-property
+func (s *ContactPropertiesSvcImpl) CreateWithContext(ctx context.Context, params *CreateContactPropertyRequest) (CreateContactPropertyResponse, error) {
+	if params.Key == "" {
+		return CreateContactPropertyResponse{}, errors.New("[ERROR]: Key is missing")
+	}
+
+	if params.Type == "" {
+		return CreateContactPropertyResponse{}, errors.New("[ERROR]: Type is missing")
+	}
+
+	path := "contact-properties"
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, params)
+	if err != nil {
+		return CreateContactPropertyResponse{}, errors.New("[ERROR]: Failed to create ContactProperties.Create request")
+	}
+
+	// Build response object
+	propertyResp := new(CreateContactPropertyResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, propertyResp)
+
+	if err != nil {
+		return CreateContactPropertyResponse{}, err
+	}
+
+	return *propertyResp, nil
+}
+
+// Create creates a new contact property based on the given params
+// https://resend.com/docs/api-reference/contact-properties/create-contact-property
+func (s *ContactPropertiesSvcImpl) Create(params *CreateContactPropertyRequest) (CreateContactPropertyResponse, error) {
+	return s.CreateWithContext(context.Background(), params)
+}
+
+// ListWithOptions returns the list of all contact properties with pagination options
+// https://resend.com/docs/api-reference/contact-properties/list-contact-properties
+func (s *ContactPropertiesSvcImpl) ListWithOptions(ctx context.Context, options *ListOptions) (ListContactPropertiesResponse, error) {
+	path := "contact-properties" + buildPaginationQuery(options)
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return ListContactPropertiesResponse{}, errors.New("[ERROR]: Failed to create ContactProperties.List request")
+	}
+
+	properties := new(ListContactPropertiesResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, properties)
+
+	if err != nil {
+		return ListContactPropertiesResponse{}, err
+	}
+
+	return *properties, nil
+}
+
+// ListWithContext returns the list of all contact properties
+// https://resend.com/docs/api-reference/contact-properties/list-contact-properties
+func (s *ContactPropertiesSvcImpl) ListWithContext(ctx context.Context) (ListContactPropertiesResponse, error) {
+	return s.ListWithOptions(ctx, nil)
+}
+
+// List returns the list of all contact properties
+// https://resend.com/docs/api-reference/contact-properties/list-contact-properties
+func (s *ContactPropertiesSvcImpl) List() (ListContactPropertiesResponse, error) {
+	return s.ListWithContext(context.Background())
+}
+
+// GetWithContext retrieves a single contact property by ID
+// https://resend.com/docs/api-reference/contact-properties/get-contact-property
+func (s *ContactPropertiesSvcImpl) GetWithContext(ctx context.Context, id string) (ContactProperty, error) {
+	if id == "" {
+		return ContactProperty{}, errors.New("[ERROR]: ID is missing")
+	}
+
+	path := "contact-properties/" + id
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return ContactProperty{}, errors.New("[ERROR]: Failed to create ContactProperties.Get request")
+	}
+
+	property := new(ContactProperty)
+
+	// Send Request
+	_, err = s.client.Perform(req, property)
+
+	if err != nil {
+		return ContactProperty{}, err
+	}
+
+	return *property, nil
+}
+
+// Get retrieves a single contact property by ID
+// https://resend.com/docs/api-reference/contact-properties/get-contact-property
+func (s *ContactPropertiesSvcImpl) Get(id string) (ContactProperty, error) {
+	return s.GetWithContext(context.Background(), id)
+}
+
+// UpdateWithContext updates an existing contact property based on the given params
+// https://resend.com/docs/api-reference/contact-properties/update-contact-property
+func (s *ContactPropertiesSvcImpl) UpdateWithContext(ctx context.Context, params *UpdateContactPropertyRequest) (UpdateContactPropertyResponse, error) {
+	if params.Id == "" {
+		return UpdateContactPropertyResponse{}, errors.New("[ERROR]: ID is missing")
+	}
+
+	path := "contact-properties/" + params.Id
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, params)
+	if err != nil {
+		return UpdateContactPropertyResponse{}, errors.New("[ERROR]: Failed to create ContactProperties.Update request")
+	}
+
+	// Build response object
+	propertyResp := new(UpdateContactPropertyResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, propertyResp)
+
+	if err != nil {
+		return UpdateContactPropertyResponse{}, err
+	}
+
+	return *propertyResp, nil
+}
+
+// Update updates an existing contact property based on the given params
+// https://resend.com/docs/api-reference/contact-properties/update-contact-property
+func (s *ContactPropertiesSvcImpl) Update(params *UpdateContactPropertyRequest) (UpdateContactPropertyResponse, error) {
+	return s.UpdateWithContext(context.Background(), params)
+}
+
+// RemoveWithContext removes a contact property by ID
+// https://resend.com/docs/api-reference/contact-properties/delete-contact-property
+func (s *ContactPropertiesSvcImpl) RemoveWithContext(ctx context.Context, id string) (RemoveContactPropertyResponse, error) {
+	if id == "" {
+		return RemoveContactPropertyResponse{}, errors.New("[ERROR]: ID is missing")
+	}
+
+	path := "contact-properties/" + id
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return RemoveContactPropertyResponse{}, errors.New("[ERROR]: Failed to create ContactProperties.Remove request")
+	}
+
+	resp := new(RemoveContactPropertyResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, resp)
+
+	if err != nil {
+		return RemoveContactPropertyResponse{}, err
+	}
+
+	return *resp, nil
+}
+
+// Remove removes a contact property by ID
+// https://resend.com/docs/api-reference/contact-properties/delete-contact-property
+func (s *ContactPropertiesSvcImpl) Remove(id string) (RemoveContactPropertyResponse, error) {
+	return s.RemoveWithContext(context.Background(), id)
+}

--- a/contact_properties_test.go
+++ b/contact_properties_test.go
@@ -1,0 +1,265 @@
+package resend
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateContactProperty(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/contact-properties", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		ret := `
+		{
+			"object": "contact_property",
+			"id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	req := &CreateContactPropertyRequest{
+		Key:           "age",
+		Type:          "number",
+		FallbackValue: 0,
+	}
+	resp, err := client.ContactProperties.Create(req)
+	if err != nil {
+		t.Errorf("ContactProperties.Create returned error: %v", err)
+	}
+	assert.Equal(t, "contact_property", resp.Object)
+	assert.Equal(t, "a1b2c3d4-e5f6-7890-abcd-ef1234567890", resp.Id)
+}
+
+func TestCreateContactPropertyKeyMissing(t *testing.T) {
+	setup()
+	defer teardown()
+
+	req := &CreateContactPropertyRequest{
+		Type:          "string",
+		FallbackValue: "default",
+	}
+	resp, err := client.ContactProperties.Create(req)
+
+	assert.Error(t, err)
+	assert.Equal(t, CreateContactPropertyResponse{}, resp)
+	assert.Contains(t, err.Error(), "[ERROR]: Key is missing")
+}
+
+func TestCreateContactPropertyTypeMissing(t *testing.T) {
+	setup()
+	defer teardown()
+
+	req := &CreateContactPropertyRequest{
+		Key:           "age",
+		FallbackValue: 0,
+	}
+	resp, err := client.ContactProperties.Create(req)
+
+	assert.Error(t, err)
+	assert.Equal(t, CreateContactPropertyResponse{}, resp)
+	assert.Contains(t, err.Error(), "[ERROR]: Type is missing")
+}
+
+func TestListContactProperties(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/contact-properties", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "list",
+			"data": [
+				{
+					"id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+					"key": "age",
+					"object": "contact_property",
+					"created_at": "2025-10-22T15:30:00.000Z",
+					"type": "number",
+					"fallback_value": 0
+				},
+				{
+					"id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+					"key": "country",
+					"object": "contact_property",
+					"created_at": "2025-10-22T15:31:00.000Z",
+					"type": "string",
+					"fallback_value": "US"
+				}
+			],
+			"has_more": false
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	properties, err := client.ContactProperties.List()
+	if err != nil {
+		t.Errorf("ContactProperties.List returned error: %v", err)
+	}
+
+	assert.Equal(t, "list", properties.Object)
+	assert.Equal(t, 2, len(properties.Data))
+	assert.False(t, properties.HasMore)
+
+	// Check first property
+	assert.Equal(t, "a1b2c3d4-e5f6-7890-abcd-ef1234567890", properties.Data[0].Id)
+	assert.Equal(t, "age", properties.Data[0].Key)
+	assert.Equal(t, "contact_property", properties.Data[0].Object)
+	assert.Equal(t, "number", properties.Data[0].Type)
+	assert.Equal(t, float64(0), properties.Data[0].FallbackValue)
+	assert.Equal(t, "2025-10-22T15:30:00.000Z", properties.Data[0].CreatedAt)
+
+	// Check second property
+	assert.Equal(t, "b2c3d4e5-f6a7-8901-bcde-f12345678901", properties.Data[1].Id)
+	assert.Equal(t, "country", properties.Data[1].Key)
+	assert.Equal(t, "string", properties.Data[1].Type)
+	assert.Equal(t, "US", properties.Data[1].FallbackValue)
+}
+
+func TestGetContactProperty(t *testing.T) {
+	setup()
+	defer teardown()
+
+	propertyId := "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+	mux.HandleFunc("/contact-properties/"+propertyId, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+			"key": "age",
+			"object": "contact_property",
+			"created_at": "2025-10-22T15:30:00.000Z",
+			"type": "number",
+			"fallback_value": 0
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	property, err := client.ContactProperties.Get(propertyId)
+	if err != nil {
+		t.Errorf("ContactProperties.Get returned error: %v", err)
+	}
+
+	assert.Equal(t, propertyId, property.Id)
+	assert.Equal(t, "age", property.Key)
+	assert.Equal(t, "contact_property", property.Object)
+	assert.Equal(t, "number", property.Type)
+	assert.Equal(t, float64(0), property.FallbackValue)
+	assert.Equal(t, "2025-10-22T15:30:00.000Z", property.CreatedAt)
+}
+
+func TestGetContactPropertyIdMissing(t *testing.T) {
+	setup()
+	defer teardown()
+
+	property, err := client.ContactProperties.Get("")
+
+	assert.Error(t, err)
+	assert.Equal(t, ContactProperty{}, property)
+	assert.Contains(t, err.Error(), "[ERROR]: ID is missing")
+}
+
+func TestUpdateContactProperty(t *testing.T) {
+	setup()
+	defer teardown()
+
+	propertyId := "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+	mux.HandleFunc("/contact-properties/"+propertyId, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+			"object": "contact_property"
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	req := &UpdateContactPropertyRequest{
+		Id:            propertyId,
+		FallbackValue: 25,
+	}
+	resp, err := client.ContactProperties.Update(req)
+	if err != nil {
+		t.Errorf("ContactProperties.Update returned error: %v", err)
+	}
+
+	assert.Equal(t, propertyId, resp.Id)
+	assert.Equal(t, "contact_property", resp.Object)
+}
+
+func TestUpdateContactPropertyIdMissing(t *testing.T) {
+	setup()
+	defer teardown()
+
+	req := &UpdateContactPropertyRequest{
+		FallbackValue: "new value",
+	}
+	resp, err := client.ContactProperties.Update(req)
+
+	assert.Error(t, err)
+	assert.Equal(t, UpdateContactPropertyResponse{}, resp)
+	assert.Contains(t, err.Error(), "[ERROR]: ID is missing")
+}
+
+func TestRemoveContactProperty(t *testing.T) {
+	setup()
+	defer teardown()
+
+	propertyId := "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+	mux.HandleFunc("/contact-properties/"+propertyId, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "contact_property",
+			"id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+			"deleted": true
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	deleted, err := client.ContactProperties.Remove(propertyId)
+	if err != nil {
+		t.Errorf("ContactProperties.Remove returned error: %v", err)
+	}
+
+	assert.Equal(t, propertyId, deleted.Id)
+	assert.Equal(t, "contact_property", deleted.Object)
+	assert.True(t, deleted.Deleted)
+}
+
+func TestRemoveContactPropertyIdMissing(t *testing.T) {
+	setup()
+	defer teardown()
+
+	deleted, err := client.ContactProperties.Remove("")
+
+	assert.Error(t, err)
+	assert.Equal(t, RemoveContactPropertyResponse{}, deleted)
+	assert.Contains(t, err.Error(), "[ERROR]: ID is missing")
+}

--- a/contact_topics.go
+++ b/contact_topics.go
@@ -1,0 +1,142 @@
+package resend
+
+import (
+	"context"
+	"errors"
+	"net/http"
+)
+
+// ContactTopic represents a topic subscription for a contact
+type ContactTopic struct {
+	Id           string `json:"id"`
+	Name         string `json:"name"`
+	Description  string `json:"description"`
+	Subscription string `json:"subscription"`
+}
+
+// ListContactTopicsResponse is the response from listing contact topics
+type ListContactTopicsResponse struct {
+	Object  string         `json:"object"`
+	HasMore bool           `json:"has_more"`
+	Data    []ContactTopic `json:"data"`
+}
+
+// TopicSubscriptionUpdate represents a single topic subscription update
+type TopicSubscriptionUpdate struct {
+	Id           string `json:"id"`
+	Subscription string `json:"subscription"`
+}
+
+// UpdateContactTopicsRequest is the request for updating contact topics
+type UpdateContactTopicsRequest struct {
+	Id     string                    `json:"-"`
+	Email  string                    `json:"-"`
+	Topics []TopicSubscriptionUpdate `json:"topics"`
+}
+
+// UpdateContactTopicsResponse is the response from updating contact topics
+type UpdateContactTopicsResponse struct {
+	Id string `json:"id"`
+}
+
+// ContactTopicsSvc handles operations for contact topics
+type ContactTopicsSvc interface {
+	ListWithOptions(ctx context.Context, id string, options *ListOptions) (ListContactTopicsResponse, error)
+	ListWithContext(ctx context.Context, id string) (ListContactTopicsResponse, error)
+	List(id string) (ListContactTopicsResponse, error)
+	UpdateWithContext(ctx context.Context, params *UpdateContactTopicsRequest) (UpdateContactTopicsResponse, error)
+	Update(params *UpdateContactTopicsRequest) (UpdateContactTopicsResponse, error)
+}
+
+// ContactTopicsSvcImpl is the implementation of ContactTopicsSvc
+type ContactTopicsSvcImpl struct {
+	client *Client
+}
+
+// ListWithOptions retrieves a list of topics subscriptions for a contact with pagination options.
+// The id parameter can be either a contact ID or email address.
+// https://resend.com/docs/api-reference/contacts/get-contact-topics
+func (s *ContactTopicsSvcImpl) ListWithOptions(ctx context.Context, id string, options *ListOptions) (ListContactTopicsResponse, error) {
+	if id == "" {
+		return ListContactTopicsResponse{}, errors.New("[ERROR]: Contact ID or email is missing")
+	}
+
+	path := "contacts/" + id + "/topics" + buildPaginationQuery(options)
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return ListContactTopicsResponse{}, errors.New("[ERROR]: Failed to create ContactTopics.List request")
+	}
+
+	topics := new(ListContactTopicsResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, topics)
+
+	if err != nil {
+		return ListContactTopicsResponse{}, err
+	}
+
+	return *topics, nil
+}
+
+// ListWithContext retrieves a list of topics subscriptions for a contact.
+// The id parameter can be either a contact ID or email address.
+// https://resend.com/docs/api-reference/contacts/get-contact-topics
+func (s *ContactTopicsSvcImpl) ListWithContext(ctx context.Context, id string) (ListContactTopicsResponse, error) {
+	return s.ListWithOptions(ctx, id, nil)
+}
+
+// List retrieves a list of topics subscriptions for a contact.
+// The id parameter can be either a contact ID or email address.
+// https://resend.com/docs/api-reference/contacts/get-contact-topics
+func (s *ContactTopicsSvcImpl) List(id string) (ListContactTopicsResponse, error) {
+	return s.ListWithContext(context.Background(), id)
+}
+
+// UpdateWithContext updates topic subscriptions for a contact.
+// Either Id or Email must be provided in the params.
+// https://resend.com/docs/api-reference/contacts/update-contact-topics
+func (s *ContactTopicsSvcImpl) UpdateWithContext(ctx context.Context, params *UpdateContactTopicsRequest) (UpdateContactTopicsResponse, error) {
+	if params.Id == "" && params.Email == "" {
+		return UpdateContactTopicsResponse{}, errors.New("[ERROR]: Contact ID or email is missing")
+	}
+
+	if len(params.Topics) == 0 {
+		return UpdateContactTopicsResponse{}, errors.New("[ERROR]: Topics array is empty")
+	}
+
+	var identifier string
+	if params.Id != "" {
+		identifier = params.Id
+	} else {
+		identifier = params.Email
+	}
+
+	path := "contacts/" + identifier + "/topics"
+
+	// Prepare request - send only the topics array as body
+	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, params.Topics)
+	if err != nil {
+		return UpdateContactTopicsResponse{}, errors.New("[ERROR]: Failed to create ContactTopics.Update request")
+	}
+
+	resp := new(UpdateContactTopicsResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, resp)
+
+	if err != nil {
+		return UpdateContactTopicsResponse{}, err
+	}
+
+	return *resp, nil
+}
+
+// Update updates topic subscriptions for a contact.
+// Either Id or Email must be provided in the params.
+// https://resend.com/docs/api-reference/contacts/update-contact-topics
+func (s *ContactTopicsSvcImpl) Update(params *UpdateContactTopicsRequest) (UpdateContactTopicsResponse, error) {
+	return s.UpdateWithContext(context.Background(), params)
+}

--- a/contact_topics_test.go
+++ b/contact_topics_test.go
@@ -1,0 +1,228 @@
+package resend
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListContactTopics(t *testing.T) {
+	setup()
+	defer teardown()
+
+	contactId := "e169aa45-1ecf-4183-9955-b1499d5701d3"
+
+	mux.HandleFunc("/contacts/"+contactId+"/topics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "list",
+			"has_more": false,
+			"data": [
+				{
+					"id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+					"name": "Product Updates",
+					"description": "New features, and latest announcements.",
+					"subscription": "opt_in"
+				},
+				{
+					"id": "07d84122-7224-4881-9c31-1c048e204602",
+					"name": "Newsletter",
+					"description": "Weekly newsletter with tips and tricks.",
+					"subscription": "opt_out"
+				}
+			]
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	topics, err := client.Contacts.Topics.List(contactId)
+	if err != nil {
+		t.Errorf("ContactTopics.List returned error: %v", err)
+	}
+
+	assert.Equal(t, "list", topics.Object)
+	assert.False(t, topics.HasMore)
+	assert.Equal(t, 2, len(topics.Data))
+
+	// Check first topic
+	assert.Equal(t, "b6d24b8e-af0b-4c3c-be0c-359bbd97381e", topics.Data[0].Id)
+	assert.Equal(t, "Product Updates", topics.Data[0].Name)
+	assert.Equal(t, "New features, and latest announcements.", topics.Data[0].Description)
+	assert.Equal(t, "opt_in", topics.Data[0].Subscription)
+
+	// Check second topic
+	assert.Equal(t, "07d84122-7224-4881-9c31-1c048e204602", topics.Data[1].Id)
+	assert.Equal(t, "Newsletter", topics.Data[1].Name)
+	assert.Equal(t, "opt_out", topics.Data[1].Subscription)
+}
+
+func TestListContactTopicsByEmail(t *testing.T) {
+	setup()
+	defer teardown()
+
+	contactEmail := "steve.wozniak@gmail.com"
+
+	mux.HandleFunc("/contacts/"+contactEmail+"/topics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "list",
+			"has_more": false,
+			"data": [
+				{
+					"id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+					"name": "Product Updates",
+					"description": "New features, and latest announcements.",
+					"subscription": "opt_in"
+				}
+			]
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	topics, err := client.Contacts.Topics.List(contactEmail)
+	if err != nil {
+		t.Errorf("ContactTopics.List returned error: %v", err)
+	}
+
+	assert.Equal(t, "list", topics.Object)
+	assert.False(t, topics.HasMore)
+	assert.Equal(t, 1, len(topics.Data))
+	assert.Equal(t, "b6d24b8e-af0b-4c3c-be0c-359bbd97381e", topics.Data[0].Id)
+}
+
+func TestListContactTopicsIdMissing(t *testing.T) {
+	setup()
+	defer teardown()
+
+	topics, err := client.Contacts.Topics.List("")
+
+	assert.Error(t, err)
+	assert.Equal(t, ListContactTopicsResponse{}, topics)
+	assert.Contains(t, err.Error(), "[ERROR]: Contact ID or email is missing")
+}
+
+func TestUpdateContactTopicsById(t *testing.T) {
+	setup()
+	defer teardown()
+
+	contactId := "e169aa45-1ecf-4183-9955-b1499d5701d3"
+
+	mux.HandleFunc("/contacts/"+contactId+"/topics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"id": "e169aa45-1ecf-4183-9955-b1499d5701d3"
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	params := &UpdateContactTopicsRequest{
+		Id: contactId,
+		Topics: []TopicSubscriptionUpdate{
+			{
+				Id:           "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+				Subscription: "opt_out",
+			},
+			{
+				Id:           "07d84122-7224-4881-9c31-1c048e204602",
+				Subscription: "opt_in",
+			},
+		},
+	}
+
+	resp, err := client.Contacts.Topics.Update(params)
+	if err != nil {
+		t.Errorf("ContactTopics.Update returned error: %v", err)
+	}
+
+	assert.Equal(t, contactId, resp.Id)
+}
+
+func TestUpdateContactTopicsByEmail(t *testing.T) {
+	setup()
+	defer teardown()
+
+	contactEmail := "steve.wozniak@gmail.com"
+
+	mux.HandleFunc("/contacts/"+contactEmail+"/topics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"id": "e169aa45-1ecf-4183-9955-b1499d5701d3"
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	params := &UpdateContactTopicsRequest{
+		Email: contactEmail,
+		Topics: []TopicSubscriptionUpdate{
+			{
+				Id:           "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+				Subscription: "opt_in",
+			},
+		},
+	}
+
+	resp, err := client.Contacts.Topics.Update(params)
+	if err != nil {
+		t.Errorf("ContactTopics.Update returned error: %v", err)
+	}
+
+	assert.Equal(t, "e169aa45-1ecf-4183-9955-b1499d5701d3", resp.Id)
+}
+
+func TestUpdateContactTopicsIdMissing(t *testing.T) {
+	setup()
+	defer teardown()
+
+	params := &UpdateContactTopicsRequest{
+		Topics: []TopicSubscriptionUpdate{
+			{
+				Id:           "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+				Subscription: "opt_in",
+			},
+		},
+	}
+
+	resp, err := client.Contacts.Topics.Update(params)
+
+	assert.Error(t, err)
+	assert.Equal(t, UpdateContactTopicsResponse{}, resp)
+	assert.Contains(t, err.Error(), "[ERROR]: Contact ID or email is missing")
+}
+
+func TestUpdateContactTopicsEmptyArray(t *testing.T) {
+	setup()
+	defer teardown()
+
+	params := &UpdateContactTopicsRequest{
+		Id:     "e169aa45-1ecf-4183-9955-b1499d5701d3",
+		Topics: []TopicSubscriptionUpdate{},
+	}
+
+	resp, err := client.Contacts.Topics.Update(params)
+
+	assert.Error(t, err)
+	assert.Equal(t, UpdateContactTopicsResponse{}, resp)
+	assert.Contains(t, err.Error(), "[ERROR]: Topics array is empty")
+}

--- a/contacts.go
+++ b/contacts.go
@@ -23,6 +23,7 @@ type ContactsSvc interface {
 
 type ContactsSvcImpl struct {
 	client *Client
+	Topics ContactTopicsSvc
 }
 
 type CreateContactRequest struct {
@@ -288,7 +289,7 @@ func (r UpdateContactRequest) MarshalJSON() ([]byte, error) {
 	return json.Marshal(aux)
 }
 
-// UpdateWithContext updates an existing Contact based on the given params
+// Update updates an existing Contact based on the given params
 // https://resend.com/docs/api-reference/contacts/update-contact
 func (s *ContactsSvcImpl) Update(params *UpdateContactRequest) (UpdateContactResponse, error) {
 	return s.UpdateWithContext(context.Background(), params)

--- a/examples/contact_properties.go
+++ b/examples/contact_properties.go
@@ -1,0 +1,79 @@
+package examples
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/resend/resend-go/v2"
+)
+
+func contactPropertiesExample() {
+
+	ctx := context.TODO()
+	apiKey := os.Getenv("RESEND_API_KEY")
+
+	client := resend.NewClient(apiKey)
+
+	// Create Contact Property with number type
+	createParams := &resend.CreateContactPropertyRequest{
+		Key:           "age",
+		Type:          "number",
+		FallbackValue: 0,
+	}
+
+	property, err := client.ContactProperties.CreateWithContext(ctx, createParams)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Created contact property with ID: " + property.Id)
+
+	// Create another property with string type
+	createStringProperty := &resend.CreateContactPropertyRequest{
+		Key:           "country",
+		Type:          "string",
+		FallbackValue: "US",
+	}
+
+	stringProperty, err := client.ContactProperties.CreateWithContext(ctx, createStringProperty)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Created contact property with ID: " + stringProperty.Id)
+
+	// Get by ID
+	retrievedProperty, err := client.ContactProperties.GetWithContext(ctx, property.Id)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("\nRetrieved contact property by ID: %v\n", retrievedProperty)
+
+	// List all contact properties
+	properties, err := client.ContactProperties.ListWithContext(ctx)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("\nYou have %d contact properties\n", len(properties.Data))
+	for _, p := range properties.Data {
+		fmt.Printf("Property: %s (type: %s, fallback: %v)\n", p.Key, p.Type, p.FallbackValue)
+	}
+
+	// Update contact property
+	updateParams := &resend.UpdateContactPropertyRequest{
+		Id:            property.Id,
+		FallbackValue: 25,
+	}
+
+	updated, err := client.ContactProperties.UpdateWithContext(ctx, updateParams)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("\nUpdated contact property: %s\n", updated.Id)
+
+	// Remove contact property
+	removed, err := client.ContactProperties.RemoveWithContext(ctx, property.Id)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Deleted contact property: %s (deleted: %v)\n", removed.Id, removed.Deleted)
+}

--- a/resend.go
+++ b/resend.go
@@ -50,16 +50,17 @@ type Client struct {
 	headers map[string]string
 
 	// Services
-	Emails     *EmailsSvcImpl
-	Batch      BatchSvc
-	ApiKeys    ApiKeysSvc
-	Domains    DomainsSvc
-	Audiences  AudiencesSvc
-	Contacts   ContactsSvc
-	Broadcasts BroadcastsSvc
-	Templates  TemplatesSvc
-	Topics     TopicsSvc
-	Webhooks   WebhooksSvc
+	Emails            *EmailsSvcImpl
+	Batch             BatchSvc
+	ApiKeys           ApiKeysSvc
+	Domains           DomainsSvc
+	Audiences         AudiencesSvc
+	Contacts          *ContactsSvcImpl
+	ContactProperties ContactPropertiesSvc
+	Broadcasts        BroadcastsSvc
+	Templates         TemplatesSvc
+	Topics            TopicsSvc
+	Webhooks          WebhooksSvc
 }
 
 // NewClient is the default client constructor
@@ -82,11 +83,15 @@ func NewCustomClient(httpClient *http.Client, apiKey string) *Client {
 	emailsSvc.Receiving = &ReceivingSvcImpl{client: c}
 	c.Emails = emailsSvc
 
+	contactsSvc := &ContactsSvcImpl{client: c}
+	contactsSvc.Topics = &ContactTopicsSvcImpl{client: c}
+	c.Contacts = contactsSvc
+
 	c.Batch = &BatchSvcImpl{client: c}
 	c.ApiKeys = &ApiKeysSvcImpl{client: c}
 	c.Domains = &DomainsSvcImpl{client: c}
 	c.Audiences = &AudiencesSvcImpl{client: c}
-	c.Contacts = &ContactsSvcImpl{client: c}
+	c.ContactProperties = &ContactPropertiesSvcImpl{client: c}
 	c.Broadcasts = &BroadcastsSvcImpl{client: c}
 	c.Templates = &TemplatesSvcImpl{client: c}
 	c.Topics = &TopicsSvcImpl{client: c}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Contact Properties and Contact Topics APIs to the Go SDK. You can now manage custom contact fields and topic subscriptions, and access them via new client services.

- New Features
  - Contact Properties: create, list (with pagination), get, update (fallback_value), delete.
  - Contact Topics: list a contact’s topic subscriptions and update subscriptions by contact ID or email.
  - Client wiring: client.ContactProperties and client.Contacts.Topics now available.
  - Examples added for contact properties and topics usage.

- Migration
  - Client.Contacts is now a concrete type (*ContactsSvcImpl) to expose the Topics sub-service. If you relied on the Contacts field being an interface, update references to the concrete type; existing methods are unchanged.

<!-- End of auto-generated description by cubic. -->

