### PR TITLE
release/v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.0.0 - 2025-01-30
+## 3.0.0 - 2025-10-31
 
 This is a major release with breaking changes to the Contacts API and the addition of several new APIs (Topics, Templates, Webhooks, Inbound, Segments, Contact Properties, Contact Topics). The Contacts API has been redesigned to use struct-based arguments for better ergonomics and to support global contacts.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+## 3.0.0 - 2025-01-30
+
+This is a major release with breaking changes to the Contacts API and the addition of several new APIs (Topics, Templates, Webhooks, Inbound, Segments, Contact Properties, Contact Topics). The Contacts API has been redesigned to use struct-based arguments for better ergonomics and to support global contacts.
+
+**Note:** The breaking changes are isolated to the Contacts API only. If you only use the SDK for sending emails, you can upgrade to v3.0.0 without any code changes. The Emails API remains unchanged and fully backward compatible. The Audiences API is deprecated but maintained for backward compatibility.
+
+- ⚠️ Change `Contacts.Get` to accept `*GetContactOptions` instead of positional `audienceId` and `id` parameters
+- ⚠️ Change `Contacts.GetWithContext` to accept `*GetContactOptions` instead of positional `audienceId` and `id` parameters
+- ⚠️ Change `Contacts.List` to accept `*ListContactsOptions` instead of positional `audienceId` parameter
+- ⚠️ Change `Contacts.ListWithContext` to accept `*ListContactsOptions` instead of positional `audienceId` parameter
+- ⚠️ Change `Contacts.Remove` to accept `*RemoveContactOptions` instead of positional `audienceId` and `id` parameters
+- ⚠️ Change `Contacts.RemoveWithContext` to accept `*RemoveContactOptions` instead of positional `audienceId` and `id` parameters
+- Add support for new `Topics` service for managing email topics and subscription preferences [#85](https://github.com/resend/resend-go/pull/85)
+- Add support for new `Templates` service for managing email templates [#84](https://github.com/resend/resend-go/pull/84)
+- Add support for `TemplateId` and `TemplateAlias` on `SendEmailRequest` for sending emails with templates [#84](https://github.com/resend/resend-go/pull/84)
+- Add support for new `Webhooks` service for managing webhook endpoints [#86](https://github.com/resend/resend-go/pull/86)
+- Add support for new `Receiving` service for managing inbound email handling and attachments [#83](https://github.com/resend/resend-go/pull/83)
+- Add support for new `Segments` service for organizing contacts into segments (replaces `Audiences`)
+- Add support for `SegmentId` on `CreateBroadcastRequest` and `UpdateBroadcastRequest` for targeting segments in broadcasts
+- Deprecate `Audiences` service in favor of `Segments` service (backward compatible wrapper maintained)
+- Add support for new `Contacts.Properties` sub-service for managing custom contact properties [#90](https://github.com/resend/resend-go/pull/90)
+- Add support for new `Contacts.Topics` sub-service for managing contact topic subscriptions [#90](https://github.com/resend/resend-go/pull/90)
+- Add support for global contacts by making `AudienceId` optional on `CreateContactRequest` and `UpdateContactRequest`
+- Add support for `Properties` on `CreateContactRequest`, `UpdateContactRequest`, and `Contact` for custom key-value pairs on global contacts
+- Add support for new `Contacts.Segments` sub-service for managing contact membership in segments

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 ![Build](https://github.com/resend/resend-go/actions/workflows/go.yml/badge.svg)
 ![Release](https://img.shields.io/github/release/resend/resend-go.svg?style=flat-square)
-[![Go Reference](https://pkg.go.dev/badge/github.com/resend/resend-go/v2.svg)](https://pkg.go.dev/github.com/resend/resend-go/v2)
+[![Go Reference](https://pkg.go.dev/badge/github.com/resend/resend-go/v3.svg)](https://pkg.go.dev/github.com/resend/resend-go/v3)
 ---
 
 ## Installation
@@ -11,7 +11,7 @@
 To install the Go SDK, simply execute the following command on a terminal:
 
 ```
-go get github.com/resend/resend-go/v2
+go get github.com/resend/resend-go/v3
 ```
 
 ## Setup
@@ -23,7 +23,7 @@ First, you need to get an API key, which is available in the [Resend Dashboard](
 ```go
 import (
     "fmt"
-    "github.com/resend/resend-go/v2"
+    "github.com/resend/resend-go/v3"
 )
 
 func main() {

--- a/audiences.go
+++ b/audiences.go
@@ -2,10 +2,10 @@ package resend
 
 import (
 	"context"
-	"errors"
-	"net/http"
 )
 
+// Deprecated: Use SegmentsSvc instead. Audiences have been renamed to Segments.
+// The audiences API is maintained for backward compatibility and calls the segments API internally.
 type AudiencesSvc interface {
 	CreateWithContext(ctx context.Context, params *CreateAudienceRequest) (CreateAudienceResponse, error)
 	Create(params *CreateAudienceRequest) (CreateAudienceResponse, error)
@@ -18,158 +18,87 @@ type AudiencesSvc interface {
 	Remove(audienceId string) (RemoveAudienceResponse, error)
 }
 
+// AudiencesSvcImpl wraps SegmentsSvcImpl to provide backward compatibility
+// Deprecated: Use SegmentsSvcImpl instead
 type AudiencesSvcImpl struct {
-	client *Client
+	segments *SegmentsSvcImpl
 }
 
-type CreateAudienceRequest struct {
-	Name string `json:"name"`
-}
+// Type aliases for backward compatibility
+// Deprecated: Use CreateSegmentRequest instead
+type CreateAudienceRequest = CreateSegmentRequest
 
-type CreateAudienceResponse struct {
-	Id     string `json:"id"`
-	Name   string `json:"name"`
-	Object string `json:"object"`
-}
+// Deprecated: Use CreateSegmentResponse instead
+type CreateAudienceResponse = CreateSegmentResponse
 
-type RemoveAudienceResponse struct {
-	Id      string `json:"id"`
-	Object  string `json:"object"`
-	Deleted bool   `json:"deleted"`
-}
+// Deprecated: Use RemoveSegmentResponse instead
+type RemoveAudienceResponse = RemoveSegmentResponse
 
-type ListAudiencesResponse struct {
-	Object  string     `json:"object"`
-	Data    []Audience `json:"data"`
-	HasMore bool       `json:"has_more"`
-}
+// Deprecated: Use ListSegmentsResponse instead
+type ListAudiencesResponse = ListSegmentsResponse
 
-type Audience struct {
-	Id        string `json:"id"`
-	Name      string `json:"name"`
-	Object    string `json:"object"`
-	CreatedAt string `json:"created_at"`
-}
+// Deprecated: Use Segment instead
+type Audience = Segment
 
 // CreateWithContext creates a new Audience entry based on the given params
-// https://resend.com/docs/api-reference/audiences/create-audience
+// Deprecated: Use Segments.CreateWithContext instead
+// https://resend.com/docs/api-reference/segments/create-segment
 func (s *AudiencesSvcImpl) CreateWithContext(ctx context.Context, params *CreateAudienceRequest) (CreateAudienceResponse, error) {
-	path := "audiences"
-
-	// Prepare request
-	req, err := s.client.NewRequest(ctx, http.MethodPost, path, params)
-	if err != nil {
-		return CreateAudienceResponse{}, errors.New("[ERROR]: Failed to create Audiences.Create request")
-	}
-
-	// Build response recipient obj
-	audiencesResp := new(CreateAudienceResponse)
-
-	// Send Request
-	_, err = s.client.Perform(req, audiencesResp)
-
-	if err != nil {
-		return CreateAudienceResponse{}, err
-	}
-
-	return *audiencesResp, nil
+	return s.segments.CreateWithContext(ctx, params)
 }
 
 // Create creates a new Audience entry based on the given params
-// https://resend.com/docs/api-reference/audiences/create-audience
+// Deprecated: Use Segments.Create instead
+// https://resend.com/docs/api-reference/segments/create-segment
 func (s *AudiencesSvcImpl) Create(params *CreateAudienceRequest) (CreateAudienceResponse, error) {
-	return s.CreateWithContext(context.Background(), params)
+	return s.segments.Create(params)
 }
 
 // ListWithOptions returns the list of all audiences with pagination options
-// https://resend.com/docs/api-reference/audiences/list-audiences
+// Deprecated: Use Segments.ListWithOptions instead
+// https://resend.com/docs/api-reference/segments/list-segments
 func (s *AudiencesSvcImpl) ListWithOptions(ctx context.Context, options *ListOptions) (ListAudiencesResponse, error) {
-	path := "audiences" + buildPaginationQuery(options)
-
-	// Prepare request
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return ListAudiencesResponse{}, errors.New("[ERROR]: Failed to create Audiences.List request")
-	}
-
-	audiences := new(ListAudiencesResponse)
-
-	// Send Request
-	_, err = s.client.Perform(req, audiences)
-
-	if err != nil {
-		return ListAudiencesResponse{}, err
-	}
-
-	return *audiences, nil
+	return s.segments.ListWithOptions(ctx, options)
 }
 
 // ListWithContext returns the list of all audiences
-// https://resend.com/docs/api-reference/audiences/list-audiences
+// Deprecated: Use Segments.ListWithContext instead
+// https://resend.com/docs/api-reference/segments/list-segments
 func (s *AudiencesSvcImpl) ListWithContext(ctx context.Context) (ListAudiencesResponse, error) {
-	return s.ListWithOptions(ctx, nil)
+	return s.segments.ListWithContext(ctx)
 }
 
 // List returns the list of all audiences
-// https://resend.com/docs/api-reference/audiences/list-audiences
+// Deprecated: Use Segments.List instead
+// https://resend.com/docs/api-reference/segments/list-segments
 func (s *AudiencesSvcImpl) List() (ListAudiencesResponse, error) {
-	return s.ListWithContext(context.Background())
+	return s.segments.List()
 }
 
 // RemoveWithContext removes a given audience by id
-// https://resend.com/docs/api-reference/audiences/delete-audience
+// Deprecated: Use Segments.RemoveWithContext instead
+// https://resend.com/docs/api-reference/segments/delete-segment
 func (s *AudiencesSvcImpl) RemoveWithContext(ctx context.Context, audienceId string) (RemoveAudienceResponse, error) {
-	path := "audiences/" + audienceId
-
-	// Prepare request
-	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
-	if err != nil {
-		return RemoveAudienceResponse{}, errors.New("[ERROR]: Failed to create Audience.Remove request")
-	}
-
-	resp := new(RemoveAudienceResponse)
-
-	// Send Request
-	_, err = s.client.Perform(req, resp)
-
-	if err != nil {
-		return RemoveAudienceResponse{}, err
-	}
-
-	return *resp, nil
+	return s.segments.RemoveWithContext(ctx, audienceId)
 }
 
 // Remove removes a given audience entry by id
-// https://resend.com/docs/api-reference/audiences/delete-audience
+// Deprecated: Use Segments.Remove instead
+// https://resend.com/docs/api-reference/segments/delete-segment
 func (s *AudiencesSvcImpl) Remove(audienceId string) (RemoveAudienceResponse, error) {
-	return s.RemoveWithContext(context.Background(), audienceId)
+	return s.segments.Remove(audienceId)
 }
 
 // GetWithContext Retrieve a single audience.
-// https://resend.com/docs/api-reference/audiences/get-audience
+// Deprecated: Use Segments.GetWithContext instead
+// https://resend.com/docs/api-reference/segments/get-segment
 func (s *AudiencesSvcImpl) GetWithContext(ctx context.Context, audienceId string) (Audience, error) {
-	path := "audiences/" + audienceId
-
-	// Prepare request
-	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return Audience{}, errors.New("[ERROR]: Failed to create Audience.Get request")
-	}
-
-	audience := new(Audience)
-
-	// Send Request
-	_, err = s.client.Perform(req, audience)
-
-	if err != nil {
-		return Audience{}, err
-	}
-
-	return *audience, nil
+	return s.segments.GetWithContext(ctx, audienceId)
 }
 
 // Get Retrieve a single audience.
-// https://resend.com/docs/api-reference/audiences/get-audience
+// Deprecated: Use Segments.Get instead
+// https://resend.com/docs/api-reference/segments/get-segment
 func (s *AudiencesSvcImpl) Get(audienceId string) (Audience, error) {
-	return s.GetWithContext(context.Background(), audienceId)
+	return s.segments.Get(audienceId)
 }

--- a/broadcasts.go
+++ b/broadcasts.go
@@ -15,7 +15,8 @@ type SendBroadcastRequest struct {
 }
 
 type CreateBroadcastRequest struct {
-	AudienceId string   `json:"audience_id,omitempty"`
+	SegmentId  string   `json:"segment_id,omitempty"`
+	AudienceId string   `json:"audience_id,omitempty"` // Deprecated: Use SegmentId instead
 	From       string   `json:"from,omitempty"`
 	Subject    string   `json:"subject,omitempty"`
 	ReplyTo    []string `json:"reply_to,omitempty"`
@@ -26,7 +27,8 @@ type CreateBroadcastRequest struct {
 
 type UpdateBroadcastRequest struct {
 	BroadcastId string   `json:"broadcast_id,omitempty"`
-	AudienceId  string   `json:"audience_id,omitempty"`
+	SegmentId   string   `json:"segment_id,omitempty"`
+	AudienceId  string   `json:"audience_id,omitempty"` // Deprecated: Use SegmentId instead
 	From        string   `json:"from,omitempty"`
 	Subject     string   `json:"subject,omitempty"`
 	ReplyTo     []string `json:"reply_to,omitempty"`
@@ -63,7 +65,8 @@ type Broadcast struct {
 	Object      string   `json:"object"`
 	Id          string   `json:"id"`
 	Name        string   `json:"name"`
-	AudienceId  string   `json:"audience_id"`
+	SegmentId   string   `json:"segment_id"`
+	AudienceId  string   `json:"audience_id"` // Deprecated: Use SegmentId instead
 	From        string   `json:"from"`
 	Subject     string   `json:"subject"`
 	ReplyTo     []string `json:"reply_to"`
@@ -106,8 +109,8 @@ type BroadcastsSvcImpl struct {
 func (s *BroadcastsSvcImpl) CreateWithContext(ctx context.Context, params *CreateBroadcastRequest) (CreateBroadcastResponse, error) {
 	path := "/broadcasts"
 
-	if params.AudienceId == "" {
-		return CreateBroadcastResponse{}, errors.New("[ERROR]: AudienceId cannot be empty")
+	if params.SegmentId == "" && params.AudienceId == "" {
+		return CreateBroadcastResponse{}, errors.New("[ERROR]: Either SegmentId or AudienceId must be provided")
 	}
 
 	if params.From == "" {

--- a/broadcasts_test.go
+++ b/broadcasts_test.go
@@ -89,7 +89,7 @@ func TestCreateBroadcastValidations(t *testing.T) {
 	_, err = client.Broadcasts.Create(req2)
 	assert.NotNil(t, err)
 	if err != nil {
-		assert.Equal(t, err.Error(), "[ERROR]: AudienceId cannot be empty")
+		assert.Equal(t, err.Error(), "[ERROR]: Either SegmentId or AudienceId must be provided")
 	}
 
 	req3 := &CreateBroadcastRequest{

--- a/contact_segments.go
+++ b/contact_segments.go
@@ -1,0 +1,187 @@
+package resend
+
+import (
+	"context"
+	"errors"
+	"net/http"
+)
+
+type ContactSegmentsSvc interface {
+	AddWithContext(ctx context.Context, params *AddContactSegmentRequest) (AddContactSegmentResponse, error)
+	Add(params *AddContactSegmentRequest) (AddContactSegmentResponse, error)
+	RemoveWithContext(ctx context.Context, params *RemoveContactSegmentRequest) (RemoveContactSegmentResponse, error)
+	Remove(params *RemoveContactSegmentRequest) (RemoveContactSegmentResponse, error)
+	ListWithOptions(ctx context.Context, params *ListContactSegmentsRequest, options *ListOptions) (ListContactSegmentsResponse, error)
+	ListWithContext(ctx context.Context, params *ListContactSegmentsRequest) (ListContactSegmentsResponse, error)
+	List(params *ListContactSegmentsRequest) (ListContactSegmentsResponse, error)
+}
+
+type ContactSegmentsSvcImpl struct {
+	client *Client
+}
+
+type AddContactSegmentRequest struct {
+	SegmentId string `json:"segment_id"`
+	ContactId string `json:"contact_id,omitempty"`
+	Email     string `json:"email,omitempty"`
+}
+
+type AddContactSegmentResponse struct {
+	Id     string `json:"id"`
+	Object string `json:"object"`
+}
+
+type RemoveContactSegmentRequest struct {
+	SegmentId string `json:"segment_id"`
+	ContactId string `json:"contact_id,omitempty"`
+	Email     string `json:"email,omitempty"`
+}
+
+type RemoveContactSegmentResponse struct {
+	Id      string `json:"id"`
+	Object  string `json:"object"`
+	Deleted bool   `json:"deleted"`
+}
+
+type ListContactSegmentsRequest struct {
+	ContactId string `json:"contact_id,omitempty"`
+	Email     string `json:"email,omitempty"`
+}
+
+type ListContactSegmentsResponse struct {
+	Object  string    `json:"object"`
+	Data    []Segment `json:"data"`
+	HasMore bool      `json:"has_more"`
+}
+
+// AddWithContext adds a contact to a segment
+// https://resend.com/docs/api-reference/contacts/add-contact-to-segment
+func (s *ContactSegmentsSvcImpl) AddWithContext(ctx context.Context, params *AddContactSegmentRequest) (AddContactSegmentResponse, error) {
+	if params.SegmentId == "" {
+		return AddContactSegmentResponse{}, errors.New("[ERROR]: SegmentId is required")
+	}
+
+	if params.ContactId == "" && params.Email == "" {
+		return AddContactSegmentResponse{}, errors.New("[ERROR]: Either ContactId or Email must be provided")
+	}
+
+	// Determine the identifier to use in the URL
+	identifier := params.ContactId
+	if identifier == "" {
+		identifier = params.Email
+	}
+
+	path := "contacts/" + identifier + "/segments/" + params.SegmentId
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, nil)
+	if err != nil {
+		return AddContactSegmentResponse{}, errors.New("[ERROR]: Failed to create ContactSegments.Add request")
+	}
+
+	// Build response recipient obj
+	resp := new(AddContactSegmentResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, resp)
+
+	if err != nil {
+		return AddContactSegmentResponse{}, err
+	}
+
+	return *resp, nil
+}
+
+// Add adds a contact to a segment
+// https://resend.com/docs/api-reference/contacts/add-contact-to-segment
+func (s *ContactSegmentsSvcImpl) Add(params *AddContactSegmentRequest) (AddContactSegmentResponse, error) {
+	return s.AddWithContext(context.Background(), params)
+}
+
+// RemoveWithContext removes a contact from a segment
+// https://resend.com/docs/api-reference/contacts/remove-contact-from-segment
+func (s *ContactSegmentsSvcImpl) RemoveWithContext(ctx context.Context, params *RemoveContactSegmentRequest) (RemoveContactSegmentResponse, error) {
+	if params.SegmentId == "" {
+		return RemoveContactSegmentResponse{}, errors.New("[ERROR]: SegmentId is required")
+	}
+
+	if params.ContactId == "" && params.Email == "" {
+		return RemoveContactSegmentResponse{}, errors.New("[ERROR]: Either ContactId or Email must be provided")
+	}
+
+	// Determine the identifier to use in the URL
+	identifier := params.ContactId
+	if identifier == "" {
+		identifier = params.Email
+	}
+
+	path := "contacts/" + identifier + "/segments/" + params.SegmentId
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return RemoveContactSegmentResponse{}, errors.New("[ERROR]: Failed to create ContactSegments.Remove request")
+	}
+
+	resp := new(RemoveContactSegmentResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, resp)
+
+	if err != nil {
+		return RemoveContactSegmentResponse{}, err
+	}
+
+	return *resp, nil
+}
+
+// Remove removes a contact from a segment
+// https://resend.com/docs/api-reference/contacts/remove-contact-from-segment
+func (s *ContactSegmentsSvcImpl) Remove(params *RemoveContactSegmentRequest) (RemoveContactSegmentResponse, error) {
+	return s.RemoveWithContext(context.Background(), params)
+}
+
+// ListWithOptions returns the list of all segments for a contact with pagination options
+// https://resend.com/docs/api-reference/contacts/list-contact-segments
+func (s *ContactSegmentsSvcImpl) ListWithOptions(ctx context.Context, params *ListContactSegmentsRequest, options *ListOptions) (ListContactSegmentsResponse, error) {
+	if params.ContactId == "" && params.Email == "" {
+		return ListContactSegmentsResponse{}, errors.New("[ERROR]: Either ContactId or Email must be provided")
+	}
+
+	// Determine the identifier to use in the URL
+	identifier := params.ContactId
+	if identifier == "" {
+		identifier = params.Email
+	}
+
+	path := "contacts/" + identifier + "/segments" + buildPaginationQuery(options)
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return ListContactSegmentsResponse{}, errors.New("[ERROR]: Failed to create ContactSegments.List request")
+	}
+
+	segments := new(ListContactSegmentsResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, segments)
+
+	if err != nil {
+		return ListContactSegmentsResponse{}, err
+	}
+
+	return *segments, nil
+}
+
+// ListWithContext returns the list of all segments for a contact
+// https://resend.com/docs/api-reference/contacts/list-contact-segments
+func (s *ContactSegmentsSvcImpl) ListWithContext(ctx context.Context, params *ListContactSegmentsRequest) (ListContactSegmentsResponse, error) {
+	return s.ListWithOptions(ctx, params, nil)
+}
+
+// List returns the list of all segments for a contact
+// https://resend.com/docs/api-reference/contacts/list-contact-segments
+func (s *ContactSegmentsSvcImpl) List(params *ListContactSegmentsRequest) (ListContactSegmentsResponse, error) {
+	return s.ListWithContext(context.Background(), params)
+}

--- a/contact_segments_test.go
+++ b/contact_segments_test.go
@@ -1,0 +1,236 @@
+package resend
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContactSegmentsAddWithContactId(t *testing.T) {
+	setup()
+	defer teardown()
+
+	contactId := "479e3145-dd38-476b-932c-529ceb705947"
+	segmentId := "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
+
+	mux.HandleFunc("/contacts/"+contactId+"/segments/"+segmentId, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"id": "c4a7e1e0-5f1f-4b8d-9e3a-7c2b1d8e9f0a",
+			"object": "contact_segment"
+		}`)
+	})
+
+	params := &AddContactSegmentRequest{
+		SegmentId: segmentId,
+		ContactId: contactId,
+	}
+
+	resp, err := client.Contacts.Segments.Add(params)
+	if err != nil {
+		t.Fatalf("failed to add contact to segment: %v", err)
+	}
+
+	assert.Equal(t, "c4a7e1e0-5f1f-4b8d-9e3a-7c2b1d8e9f0a", resp.Id)
+	assert.Equal(t, "contact_segment", resp.Object)
+}
+
+func TestContactSegmentsAddWithEmail(t *testing.T) {
+	setup()
+	defer teardown()
+
+	email := "user@example.com"
+	segmentId := "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
+
+	mux.HandleFunc("/contacts/"+email+"/segments/"+segmentId, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"id": "c4a7e1e0-5f1f-4b8d-9e3a-7c2b1d8e9f0a",
+			"object": "contact_segment"
+		}`)
+	})
+
+	params := &AddContactSegmentRequest{
+		SegmentId: segmentId,
+		Email:     email,
+	}
+
+	resp, err := client.Contacts.Segments.Add(params)
+	if err != nil {
+		t.Fatalf("failed to add contact to segment: %v", err)
+	}
+
+	assert.NotEmpty(t, resp.Id)
+}
+
+func TestContactSegmentsAddValidation(t *testing.T) {
+	// Test missing segment_id
+	_, err := client.Contacts.Segments.Add(&AddContactSegmentRequest{
+		ContactId: "contact_123",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "SegmentId is required")
+
+	// Test missing both ContactId and Email
+	_, err = client.Contacts.Segments.Add(&AddContactSegmentRequest{
+		SegmentId: "segment_123",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Either ContactId or Email must be provided")
+}
+
+func TestContactSegmentsRemoveWithContactId(t *testing.T) {
+	setup()
+	defer teardown()
+
+	contactId := "479e3145-dd38-476b-932c-529ceb705947"
+	segmentId := "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
+
+	mux.HandleFunc("/contacts/"+contactId+"/segments/"+segmentId, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"id": "c4a7e1e0-5f1f-4b8d-9e3a-7c2b1d8e9f0a",
+			"object": "contact_segment",
+			"deleted": true
+		}`)
+	})
+
+	params := &RemoveContactSegmentRequest{
+		SegmentId: segmentId,
+		ContactId: contactId,
+	}
+
+	resp, err := client.Contacts.Segments.Remove(params)
+	if err != nil {
+		t.Fatalf("failed to remove contact from segment: %v", err)
+	}
+
+	assert.True(t, resp.Deleted)
+	assert.Equal(t, "contact_segment", resp.Object)
+}
+
+func TestContactSegmentsListWithContactId(t *testing.T) {
+	setup()
+	defer teardown()
+
+	contactId := "479e3145-dd38-476b-932c-529ceb705947"
+
+	mux.HandleFunc("/contacts/"+contactId+"/segments", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"object": "list",
+			"data": [
+				{
+					"id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+					"name": "Test Segment",
+					"object": "segment",
+					"created_at": "2023-01-01T00:00:00.000Z"
+				}
+			],
+			"has_more": false
+		}`)
+	})
+
+	params := &ListContactSegmentsRequest{
+		ContactId: contactId,
+	}
+
+	resp, err := client.Contacts.Segments.List(params)
+	if err != nil {
+		t.Fatalf("failed to list contact segments: %v", err)
+	}
+
+	assert.Equal(t, "list", resp.Object)
+	assert.Len(t, resp.Data, 1)
+	assert.Equal(t, "Test Segment", resp.Data[0].Name)
+	assert.False(t, resp.HasMore)
+}
+
+func TestContactSegmentsListWithEmail(t *testing.T) {
+	setup()
+	defer teardown()
+
+	email := "user@example.com"
+
+	mux.HandleFunc("/contacts/"+email+"/segments", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"object": "list",
+			"data": [],
+			"has_more": false
+		}`)
+	})
+
+	params := &ListContactSegmentsRequest{
+		Email: email,
+	}
+
+	resp, err := client.Contacts.Segments.List(params)
+	if err != nil {
+		t.Fatalf("failed to list contact segments: %v", err)
+	}
+
+	assert.Equal(t, "list", resp.Object)
+	assert.Len(t, resp.Data, 0)
+}
+
+func TestContactSegmentsListWithPagination(t *testing.T) {
+	setup()
+	defer teardown()
+
+	contactId := "479e3145-dd38-476b-932c-529ceb705947"
+
+	mux.HandleFunc("/contacts/"+contactId+"/segments", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+
+		query := r.URL.Query()
+		assert.Equal(t, "10", query.Get("limit"))
+		assert.Equal(t, "cursor_123", query.Get("after"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"object": "list",
+			"data": [],
+			"has_more": true
+		}`)
+	})
+
+	limit := 10
+	after := "cursor_123"
+	params := &ListContactSegmentsRequest{
+		ContactId: contactId,
+	}
+
+	options := &ListOptions{
+		Limit: &limit,
+		After: &after,
+	}
+
+	resp, err := client.Contacts.Segments.ListWithOptions(context.Background(), params, options)
+	if err != nil {
+		t.Fatalf("failed to list contact segments with options: %v", err)
+	}
+
+	assert.True(t, resp.HasMore)
+}
+
+func TestContactSegmentsListValidation(t *testing.T) {
+	// Test missing both ContactId and Email
+	_, err := client.Contacts.Segments.List(&ListContactSegmentsRequest{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Either ContactId or Email must be provided")
+}

--- a/contacts.go
+++ b/contacts.go
@@ -8,41 +8,71 @@ import (
 )
 
 type ContactsSvc interface {
-	CreateWithContext(ctx context.Context, params *CreateContactRequest) (CreateContactResponse, error)
 	Create(params *CreateContactRequest) (CreateContactResponse, error)
-	ListWithOptions(ctx context.Context, audienceId string, options *ListOptions) (ListContactsResponse, error)
-	ListWithContext(ctx context.Context, audienceId string) (ListContactsResponse, error)
-	List(audienceId string) (ListContactsResponse, error)
-	GetWithContext(ctx context.Context, audienceId, id string) (Contact, error)
-	Get(audienceId, id string) (Contact, error)
-	RemoveWithContext(ctx context.Context, audienceId, id string) (RemoveContactResponse, error)
-	Remove(audienceId, id string) (RemoveContactResponse, error)
-	UpdateWithContext(ctx context.Context, params *UpdateContactRequest) (UpdateContactResponse, error)
+	CreateWithContext(ctx context.Context, params *CreateContactRequest) (CreateContactResponse, error)
+	Get(options *GetContactOptions) (Contact, error)
+	GetWithContext(ctx context.Context, options *GetContactOptions) (Contact, error)
+	List(options *ListContactsOptions) (ListContactsResponse, error)
+	ListWithContext(ctx context.Context, options *ListContactsOptions) (ListContactsResponse, error)
 	Update(params *UpdateContactRequest) (UpdateContactResponse, error)
+	UpdateWithContext(ctx context.Context, params *UpdateContactRequest) (UpdateContactResponse, error)
+	Remove(options *RemoveContactOptions) (RemoveContactResponse, error)
+	RemoveWithContext(ctx context.Context, options *RemoveContactOptions) (RemoveContactResponse, error)
 }
 
 type ContactsSvcImpl struct {
-	client *Client
-	Topics ContactTopicsSvc
+	client     *Client
+	Topics     ContactTopicsSvc
+	Segments   ContactSegmentsSvc
+	Properties ContactPropertiesSvc
+}
+
+// GetContactOptions contains parameters for retrieving a contact
+type GetContactOptions struct {
+	AudienceId string // Optional - omit for global contacts
+	Id         string // Required - can be contact ID or email address
+}
+
+// ListContactsOptions contains parameters for listing contacts
+type ListContactsOptions struct {
+	AudienceId string  // Optional - omit for global contacts
+	Limit      *int    // Optional - number of results to return
+	After      *string // Optional - cursor for pagination
+	Before     *string // Optional - cursor for pagination
+}
+
+// RemoveContactOptions contains parameters for removing a contact
+type RemoveContactOptions struct {
+	AudienceId string // Optional - omit for global contacts
+	Id         string // Required - can be contact ID or email address
 }
 
 type CreateContactRequest struct {
-	Email        string `json:"email"`
-	AudienceId   string `json:"audience_id"`
-	Unsubscribed bool   `json:"unsubscribed,omitempty"`
+	Email      string `json:"email"`
+	AudienceId string `json:"audience_id,omitempty"` // Deprecated: Optional, use Segments API for contact organization
+	Unsubscribed bool `json:"unsubscribed,omitempty"`
 	FirstName    string `json:"first_name,omitempty"`
 	LastName     string `json:"last_name,omitempty"`
+	// Properties are custom key-value pairs for global contacts (when audience_id is omitted).
+	// NOTE: Currently, the Resend API only accepts string values for properties.
+	// Non-string values (numbers, booleans, etc.) will be rejected by the API with a validation error.
+	// Example: Properties: map[string]interface{}{"tier": "premium", "age": "30", "active": "true"}
+	Properties map[string]interface{} `json:"properties,omitempty"`
 }
 
 type UpdateContactRequest struct {
 	Id           string `json:"id"`
 	Email        string `json:"email,omitempty"`
-	AudienceId   string `json:"audience_id"`
+	AudienceId   string `json:"audience_id,omitempty"` // Deprecated: Optional, use Segments API for contact organization
 	FirstName    string `json:"first_name,omitempty"`
 	LastName     string `json:"last_name,omitempty"`
 	Unsubscribed bool   `json:"unsubscribed,omitempty"`
-
-	unsubscribedSet bool `json:"-"`
+	// Properties are custom key-value pairs for global contacts (when audience_id is omitted).
+	// NOTE: Currently, the Resend API only accepts string values for properties.
+	// Non-string values (numbers, booleans, etc.) will be rejected by the API with a validation error.
+	// Example: Properties: map[string]interface{}{"tier": "premium", "age": "30", "active": "true"}
+	Properties      map[string]interface{} `json:"properties,omitempty"`
+	unsubscribedSet bool                   `json:"-"`
 }
 
 // Temporary setter for the `unsubscribed` field. This is here
@@ -78,23 +108,37 @@ type ListContactsResponse struct {
 }
 
 type Contact struct {
-	Id           string `json:"id"`
-	Email        string `json:"email"`
-	Object       string `json:"object"`
-	FirstName    string `json:"first_name"`
-	LastName     string `json:"last_name"`
-	CreatedAt    string `json:"created_at"`
-	Unsubscribed bool   `json:"unsubscribed"`
+	Id           string                 `json:"id"`
+	Email        string                 `json:"email"`
+	Object       string                 `json:"object"`
+	FirstName    string                 `json:"first_name"`
+	LastName     string                 `json:"last_name"`
+	CreatedAt    string                 `json:"created_at"`
+	Unsubscribed bool                   `json:"unsubscribed"`
+	Properties   map[string]interface{} `json:"properties,omitempty"` // Custom properties for global contacts (currently API only returns string values)
 }
 
-// CreateWithContext creates a new Contact based on the given params
+// Create creates a new Contact based on the given params
+// Supports both global contacts (without audience_id) and audience-specific contacts.
+// Global contacts support custom properties while audience-specific contacts do not.
+// https://resend.com/docs/api-reference/contacts/create-contact
+func (s *ContactsSvcImpl) Create(params *CreateContactRequest) (CreateContactResponse, error) {
+	return s.CreateWithContext(context.Background(), params)
+}
+
+// CreateWithContext creates a new Contact based on the given params with context
+// Supports both global contacts (without audience_id) and audience-specific contacts.
+// Global contacts support custom properties while audience-specific contacts do not.
 // https://resend.com/docs/api-reference/contacts/create-contact
 func (s *ContactsSvcImpl) CreateWithContext(ctx context.Context, params *CreateContactRequest) (CreateContactResponse, error) {
-	if params.AudienceId == "" {
-		return CreateContactResponse{}, errors.New("[ERROR]: AudienceId is missing")
+	var path string
+	if params.AudienceId != "" {
+		// Audience-specific contact (legacy path, no properties support)
+		path = "audiences/" + params.AudienceId + "/contacts"
+	} else {
+		// Global contact (supports properties)
+		path = "contacts"
 	}
-
-	path := "audiences/" + params.AudienceId + "/contacts"
 
 	// Prepare request
 	req, err := s.client.NewRequest(ctx, http.MethodPost, path, params)
@@ -115,16 +159,37 @@ func (s *ContactsSvcImpl) CreateWithContext(ctx context.Context, params *CreateC
 	return *contactsResp, nil
 }
 
-// Create creates a new Contact entry based on the given params
-// https://resend.com/docs/api-reference/contacts/create-contact
-func (s *ContactsSvcImpl) Create(params *CreateContactRequest) (CreateContactResponse, error) {
-	return s.CreateWithContext(context.Background(), params)
+// List returns the list of all contacts
+// If options.AudienceId is empty, lists global contacts. Otherwise lists audience-specific contacts.
+// https://resend.com/docs/api-reference/contacts/list-contacts
+func (s *ContactsSvcImpl) List(options *ListContactsOptions) (ListContactsResponse, error) {
+	return s.ListWithContext(context.Background(), options)
 }
 
-// ListWithOptions returns the list of all contacts in an audience with pagination options
+// ListWithContext returns the list of all contacts with context
+// If options.AudienceId is empty, lists global contacts. Otherwise lists audience-specific contacts.
 // https://resend.com/docs/api-reference/contacts/list-contacts
-func (s *ContactsSvcImpl) ListWithOptions(ctx context.Context, audienceId string, options *ListOptions) (ListContactsResponse, error) {
-	path := "audiences/" + audienceId + "/contacts" + buildPaginationQuery(options)
+func (s *ContactsSvcImpl) ListWithContext(ctx context.Context, options *ListContactsOptions) (ListContactsResponse, error) {
+	if options == nil {
+		options = &ListContactsOptions{}
+	}
+
+	var path string
+	if options.AudienceId != "" {
+		// Audience-specific contacts (legacy)
+		path = "audiences/" + options.AudienceId + "/contacts"
+	} else {
+		// Global contacts
+		path = "contacts"
+	}
+
+	// Build pagination query
+	listOpts := &ListOptions{
+		Limit:  options.Limit,
+		After:  options.After,
+		Before: options.Before,
+	}
+	path += buildPaginationQuery(listOpts)
 
 	// Prepare request
 	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
@@ -144,22 +209,31 @@ func (s *ContactsSvcImpl) ListWithOptions(ctx context.Context, audienceId string
 	return *contacts, nil
 }
 
-// ListWithContext returns the list of all contacts in an audience
-// https://resend.com/docs/api-reference/contacts/list-contacts
-func (s *ContactsSvcImpl) ListWithContext(ctx context.Context, audienceId string) (ListContactsResponse, error) {
-	return s.ListWithOptions(ctx, audienceId, nil)
-}
-
-// List returns the list of all contacts in an audience
-// https://resend.com/docs/api-reference/contacts/list-contacts
-func (s *ContactsSvcImpl) List(audienceId string) (ListContactsResponse, error) {
-	return s.ListWithContext(context.Background(), audienceId)
-}
-
-// RemoveWithContext same as Remove but with context
+// Remove removes a contact
+// If options.AudienceId is empty, removes a global contact. Otherwise removes an audience-specific contact.
+// The options.Id field can be either a contact ID or email address.
 // https://resend.com/docs/api-reference/contacts/delete-contact
-func (s *ContactsSvcImpl) RemoveWithContext(ctx context.Context, audienceId, id string) (RemoveContactResponse, error) {
-	path := "audiences/" + audienceId + "/contacts/" + id
+func (s *ContactsSvcImpl) Remove(options *RemoveContactOptions) (RemoveContactResponse, error) {
+	return s.RemoveWithContext(context.Background(), options)
+}
+
+// RemoveWithContext removes a contact with context
+// If options.AudienceId is empty, removes a global contact. Otherwise removes an audience-specific contact.
+// The options.Id field can be either a contact ID or email address.
+// https://resend.com/docs/api-reference/contacts/delete-contact
+func (s *ContactsSvcImpl) RemoveWithContext(ctx context.Context, options *RemoveContactOptions) (RemoveContactResponse, error) {
+	if options == nil || options.Id == "" {
+		return RemoveContactResponse{}, errors.New("[ERROR]: Id is required")
+	}
+
+	var path string
+	if options.AudienceId != "" {
+		// Audience-specific contact (legacy)
+		path = "audiences/" + options.AudienceId + "/contacts/" + options.Id
+	} else {
+		// Global contact
+		path = "contacts/" + options.Id
+	}
 
 	// Prepare request
 	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
@@ -179,23 +253,31 @@ func (s *ContactsSvcImpl) RemoveWithContext(ctx context.Context, audienceId, id 
 	return *resp, nil
 }
 
-// Remove removes a given contact entry by id or email
-//
-// @param [id] - can be either a contact id or email
-//
-// https://resend.com/docs/api-reference/contacts/delete-contact
-func (s *ContactsSvcImpl) Remove(audienceId, id string) (RemoveContactResponse, error) {
-	return s.RemoveWithContext(context.Background(), audienceId, id)
+// Get retrieves a single contact.
+// This method can be used to retrieve a contact by either its ID or email address.
+// If options.AudienceId is empty, retrieves a global contact. Otherwise retrieves an audience-specific contact.
+// https://resend.com/docs/api-reference/contacts/get-contact
+func (s *ContactsSvcImpl) Get(options *GetContactOptions) (Contact, error) {
+	return s.GetWithContext(context.Background(), options)
 }
 
-// GetWithContext Retrieve a single contact.
+// GetWithContext retrieves a single contact with context.
 // This method can be used to retrieve a contact by either its ID or email address.
-//
-// @param [id] - can be either a contact id or email
-//
+// If options.AudienceId is empty, retrieves a global contact. Otherwise retrieves an audience-specific contact.
 // https://resend.com/docs/api-reference/contacts/get-contact
-func (s *ContactsSvcImpl) GetWithContext(ctx context.Context, audienceId, id string) (Contact, error) {
-	path := "audiences/" + audienceId + "/contacts/" + id
+func (s *ContactsSvcImpl) GetWithContext(ctx context.Context, options *GetContactOptions) (Contact, error) {
+	if options == nil || options.Id == "" {
+		return Contact{}, errors.New("[ERROR]: Id is required")
+	}
+
+	var path string
+	if options.AudienceId != "" {
+		// Audience-specific contact (legacy)
+		path = "audiences/" + options.AudienceId + "/contacts/" + options.Id
+	} else {
+		// Global contact
+		path = "contacts/" + options.Id
+	}
 
 	// Prepare request
 	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
@@ -215,22 +297,17 @@ func (s *ContactsSvcImpl) GetWithContext(ctx context.Context, audienceId, id str
 	return *contact, nil
 }
 
-// Get Retrieve a single contact.
-// This method can be used to retrieve a contact by either its ID or email address.
-//
-// @param [id] - can be either a contact id or email
-// https://resend.com/docs/api-reference/contacts/get-contact
-func (s *ContactsSvcImpl) Get(audienceId, id string) (Contact, error) {
-	return s.GetWithContext(context.Background(), audienceId, id)
+// Update updates an existing Contact based on the given params
+// Supports both global contacts (without audience_id) and audience-specific contacts.
+// https://resend.com/docs/api-reference/contacts/update-contact
+func (s *ContactsSvcImpl) Update(params *UpdateContactRequest) (UpdateContactResponse, error) {
+	return s.UpdateWithContext(context.Background(), params)
 }
 
-// UpdateWithContext updates an existing Contact based on the given params
+// UpdateWithContext updates an existing Contact based on the given params with context
+// Supports both global contacts (without audience_id) and audience-specific contacts.
 // https://resend.com/docs/api-reference/contacts/update-contact
 func (s *ContactsSvcImpl) UpdateWithContext(ctx context.Context, params *UpdateContactRequest) (UpdateContactResponse, error) {
-	if params.AudienceId == "" {
-		return UpdateContactResponse{}, errors.New("[ERROR]: AudienceId is missing")
-	}
-
 	if params.Id == "" && params.Email == "" {
 		return UpdateContactResponse{}, &MissingRequiredFieldsError{message: "[ERROR]: Missing `id` or `email` field."}
 	}
@@ -242,7 +319,14 @@ func (s *ContactsSvcImpl) UpdateWithContext(ctx context.Context, params *UpdateC
 		val = params.Email
 	}
 
-	path := "audiences/" + params.AudienceId + "/contacts/" + val
+	var path string
+	if params.AudienceId != "" {
+		// Audience-specific contact (legacy path)
+		path = "audiences/" + params.AudienceId + "/contacts/" + val
+	} else {
+		// Global contact
+		path = "contacts/" + val
+	}
 
 	// Prepare request
 	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, params)
@@ -275,7 +359,10 @@ func (r UpdateContactRequest) MarshalJSON() ([]byte, error) {
 	if r.Email != "" {
 		aux["email"] = r.Email
 	}
-	aux["audience_id"] = r.AudienceId
+	// Only include audience_id if provided (supports global contacts)
+	if r.AudienceId != "" {
+		aux["audience_id"] = r.AudienceId
+	}
 	if r.FirstName != "" {
 		aux["first_name"] = r.FirstName
 	}
@@ -285,12 +372,11 @@ func (r UpdateContactRequest) MarshalJSON() ([]byte, error) {
 	if r.unsubscribedSet {
 		aux["unsubscribed"] = r.Unsubscribed
 	}
+	// Include properties if provided (for global contacts)
+	if r.Properties != nil && len(r.Properties) > 0 {
+		aux["properties"] = r.Properties
+	}
 
 	return json.Marshal(aux)
 }
 
-// Update updates an existing Contact based on the given params
-// https://resend.com/docs/api-reference/contacts/update-contact
-func (s *ContactsSvcImpl) Update(params *UpdateContactRequest) (UpdateContactResponse, error) {
-	return s.UpdateWithContext(context.Background(), params)
-}

--- a/contacts_test.go
+++ b/contacts_test.go
@@ -70,7 +70,9 @@ func TestListContacts(t *testing.T) {
 		fmt.Fprint(w, ret)
 	})
 
-	contacts, err := client.Contacts.List(audienceId)
+	contacts, err := client.Contacts.List(&ListContactsOptions{
+		AudienceId: audienceId,
+	})
 	if err != nil {
 		t.Errorf("Contacts.List returned error: %v", err)
 	}
@@ -105,7 +107,7 @@ func TestRemoveContact(t *testing.T) {
 		fmt.Fprint(w, ret)
 	})
 
-	deleted, err := client.Contacts.Remove(audienceId, contactId)
+	deleted, err := client.Contacts.Remove(&RemoveContactOptions{AudienceId: audienceId, Id: contactId})
 	if err != nil {
 		t.Errorf("Domains.Remove returned error: %v", err)
 	}
@@ -138,7 +140,7 @@ func TestGetContact(t *testing.T) {
 		fmt.Fprint(w, ret)
 	})
 
-	contact, err := client.Contacts.Get(audienceId, contactId)
+	contact, err := client.Contacts.Get(&GetContactOptions{AudienceId: audienceId, Id: contactId})
 	if err != nil {
 		t.Errorf("Contacts.Get returned error: %v", err)
 	}
@@ -177,7 +179,7 @@ func TestGetContactByEmail(t *testing.T) {
 		fmt.Fprint(w, ret)
 	})
 
-	contact, err := client.Contacts.Get(audienceId, contactEmail)
+	contact, err := client.Contacts.Get(&GetContactOptions{AudienceId: audienceId, Id: contactEmail})
 	if err != nil {
 		t.Errorf("Contacts.Get returned error: %v", err)
 	}
@@ -391,17 +393,236 @@ func TestUpdateContactAudienceIdMissing(t *testing.T) {
 	setup()
 	defer teardown()
 
-	audienceId := ""
+	// With the new global contacts feature, AudienceId is now optional
+	// This test verifies that updating a contact without AudienceId works (global contact)
 	id := "123123123"
 
+	mux.HandleFunc("/contacts/"+id, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `{
+			"data": {
+				"object": "contact",
+				"id": "123123123",
+				"email": "test@example.com",
+				"first_name": "Updated First Name",
+				"last_name": "Test",
+				"created_at": "2023-04-26T20:21:26.347412+00:00",
+				"unsubscribed": false
+			},
+			"error": {}
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
 	params := &UpdateContactRequest{
-		AudienceId: audienceId,
-		Id:         id,
-		FirstName:  "Updated First Name",
+		// AudienceId is omitted - this is now a global contact
+		Id:        id,
+		FirstName: "Updated First Name",
 	}
 	resp, err := client.Contacts.Update(params)
 
-	assert.NotNil(t, err)
-	assert.Equal(t, resp, UpdateContactResponse{})
-	assert.Containsf(t, err.Error(), "[ERROR]: AudienceId is missing", "expected error containing %q, got %s", "[ERROR]: AudienceId is missing", err)
+	assert.Nil(t, err)
+	assert.Equal(t, "123123123", resp.Data.Id)
+	assert.Equal(t, "Updated First Name", resp.Data.FirstName)
+}
+// Global Contacts Tests
+
+func TestCreateGlobalContact(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/contacts", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprint(w, `{
+			"object": "contact",
+			"id": "479e3145-dd38-476b-932c-529ceb705947"
+		}`)
+	})
+
+	req := &CreateContactRequest{
+		Email:     "global@example.com",
+		FirstName: "Global",
+		LastName:  "Contact",
+		Properties: map[string]interface{}{
+			"tier":          "premium",
+			"role":          "admin",
+			"signup_source": "website",
+		},
+	}
+	resp, err := client.Contacts.Create(req)
+	if err != nil {
+		t.Errorf("Contacts.Create returned error: %v", err)
+	}
+	assert.Equal(t, "contact", resp.Object)
+	assert.Equal(t, "479e3145-dd38-476b-932c-529ceb705947", resp.Id)
+}
+
+func TestListGlobalContacts(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/contacts", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.WriteHeader(http.StatusOK)
+
+		ret := `{
+			"object": "list",
+			"data": [
+				{
+					"id": "479e3145-dd38-476b-932c-529ceb705947",
+					"email": "global@example.com",
+					"first_name": "Global",
+					"last_name": "Contact",
+					"created_at": "2023-10-06T22:59:55.977Z",
+					"unsubscribed": false,
+					"properties": {
+						"tier": "premium",
+						"role": "admin"
+					}
+				}
+			],
+			"has_more": false
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	contacts, err := client.Contacts.List(&ListContactsOptions{})
+	if err != nil {
+		t.Errorf("Contacts.List returned error: %v", err)
+	}
+
+	assert.Equal(t, 1, len(contacts.Data))
+	assert.Equal(t, "list", contacts.Object)
+	assert.Equal(t, "479e3145-dd38-476b-932c-529ceb705947", contacts.Data[0].Id)
+	assert.Equal(t, "global@example.com", contacts.Data[0].Email)
+	assert.NotNil(t, contacts.Data[0].Properties)
+	assert.Equal(t, "premium", contacts.Data[0].Properties["tier"])
+}
+
+func TestGetGlobalContact(t *testing.T) {
+	setup()
+	defer teardown()
+
+	contactId := "479e3145-dd38-476b-932c-529ceb705947"
+
+	mux.HandleFunc("/contacts/"+contactId, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `{
+			"object": "contact",
+			"id": "479e3145-dd38-476b-932c-529ceb705947",
+			"email": "global@example.com",
+			"first_name": "Global",
+			"last_name": "Contact",
+			"created_at": "2023-10-06T22:59:55.977Z",
+			"unsubscribed": false,
+			"properties": {
+				"tier": "premium"
+			}
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	contact, err := client.Contacts.Get(&GetContactOptions{Id: contactId})
+	if err != nil {
+		t.Errorf("Contact.Get returned error: %v", err)
+	}
+
+	assert.Equal(t, "contact", contact.Object)
+	assert.Equal(t, contactId, contact.Id)
+	assert.Equal(t, "global@example.com", contact.Email)
+	assert.NotNil(t, contact.Properties)
+	assert.Equal(t, "premium", contact.Properties["tier"])
+}
+
+func TestUpdateGlobalContact(t *testing.T) {
+	setup()
+	defer teardown()
+
+	contactId := "479e3145-dd38-476b-932c-529ceb705947"
+
+	mux.HandleFunc("/contacts/"+contactId, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `{
+			"data": {
+				"object": "contact",
+				"id": "479e3145-dd38-476b-932c-529ceb705947",
+				"email": "updated@example.com",
+				"first_name": "Updated",
+				"last_name": "Name",
+				"created_at": "2023-04-26T20:21:26.347412+00:00",
+				"unsubscribed": false,
+				"properties": {
+					"tier": "enterprise"
+				}
+			},
+			"error": {}
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	params := &UpdateContactRequest{
+		Id:        contactId,
+		Email:     "updated@example.com",
+		FirstName: "Updated",
+		LastName:  "Name",
+		Properties: map[string]interface{}{
+			"tier": "enterprise",
+		},
+	}
+	resp, err := client.Contacts.Update(params)
+
+	if err != nil {
+		t.Errorf("Contacts.Update returned error: %v", err)
+	}
+
+	assert.Equal(t, "contact", resp.Data.Object)
+	assert.Equal(t, contactId, resp.Data.Id)
+	assert.Equal(t, "updated@example.com", resp.Data.Email)
+	assert.NotNil(t, resp.Data.Properties)
+	assert.Equal(t, "enterprise", resp.Data.Properties["tier"])
+}
+
+func TestRemoveGlobalContact(t *testing.T) {
+	setup()
+	defer teardown()
+
+	contactId := "479e3145-dd38-476b-932c-529ceb705947"
+
+	mux.HandleFunc("/contacts/"+contactId, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		w.WriteHeader(http.StatusOK)
+
+		var ret interface{}
+		ret = `{
+			"object": "contact",
+			"id": "479e3145-dd38-476b-932c-529ceb705947",
+			"deleted": true
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	deleted, err := client.Contacts.Remove(&RemoveContactOptions{Id: contactId})
+	if err != nil {
+		t.Errorf("Contacts.Remove returned error: %v", err)
+	}
+	assert.True(t, deleted.Deleted)
+	assert.Equal(t, contactId, deleted.Id)
+	assert.Equal(t, "contact", deleted.Object)
 }

--- a/examples/api_keys.go
+++ b/examples/api_keys.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v3"
 )
 
 func apiKeysExample() {

--- a/examples/audiences.go
+++ b/examples/audiences.go
@@ -8,6 +8,8 @@ import (
 	"github.com/resend/resend-go/v2"
 )
 
+// audiencesExample demonstrates the deprecated Audiences API
+// Note: This is maintained for backward compatibility. New code should use Segments instead.
 func audiencesExample() {
 	ctx := context.TODO()
 	apiKey := os.Getenv("RESEND_API_KEY")
@@ -15,6 +17,7 @@ func audiencesExample() {
 	client := resend.NewClient(apiKey)
 
 	// Create Audience params
+	// Note: Audiences API internally calls the Segments API
 	params := &resend.CreateAudienceRequest{
 		Name: "New Audience",
 	}

--- a/examples/audiences.go
+++ b/examples/audiences.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v3"
 )
 
 // audiencesExample demonstrates the deprecated Audiences API

--- a/examples/broadcasts.go
+++ b/examples/broadcasts.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v3"
 )
 
 func broadcastExamples() {

--- a/examples/broadcasts.go
+++ b/examples/broadcasts.go
@@ -16,11 +16,11 @@ func broadcastExamples() {
 
 	// Create Broadcast
 	params := &resend.CreateBroadcastRequest{
-		AudienceId: "ca4e37c5-a82a-4199-a3b8-bf912a6472aa",
-		From:       "onboarding@resend.dev",
-		Html:       "<html><body><h1>Hello, world!</h1></body></html>",
-		Name:       "Test Broadcast",
-		Subject:    "Hello, world!",
+		SegmentId: "ca4e37c5-a82a-4199-a3b8-bf912a6472aa",
+		From:      "onboarding@resend.dev",
+		Html:      "<html><body><h1>Hello, world!</h1></body></html>",
+		Name:      "Test Broadcast",
+		Subject:   "Hello, world!",
 	}
 
 	broadcast, err := client.Broadcasts.CreateWithContext(ctx, params)
@@ -37,7 +37,7 @@ func broadcastExamples() {
 
 	fmt.Println("ID: " + retrievedBroadcast.Id)
 	fmt.Println("Name: " + retrievedBroadcast.Name)
-	fmt.Println("Audience ID: " + retrievedBroadcast.AudienceId)
+	fmt.Println("Segment ID: " + retrievedBroadcast.SegmentId)
 	fmt.Println("From: " + retrievedBroadcast.From)
 	fmt.Println("Subject: " + retrievedBroadcast.Subject)
 	fmt.Println("Preview Text: " + retrievedBroadcast.PreviewText)
@@ -79,7 +79,7 @@ func broadcastExamples() {
 	for _, b := range listResponse.Data {
 		fmt.Println("ID: " + b.Id)
 		fmt.Println("Name: " + b.Name)
-		fmt.Println("Audience ID: " + b.AudienceId)
+		fmt.Println("Segment ID: " + b.SegmentId)
 		fmt.Println("From: " + b.From)
 		fmt.Println("Subject: " + b.Subject)
 		fmt.Println("Preview Text: " + b.PreviewText)

--- a/examples/contact_properties.go
+++ b/examples/contact_properties.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v3"
 )
 
 func contactPropertiesExample() {

--- a/examples/contact_segments.go
+++ b/examples/contact_segments.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v3"
 )
 
 func contactSegmentsExample() {

--- a/examples/contact_segments.go
+++ b/examples/contact_segments.go
@@ -1,0 +1,96 @@
+package examples
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/resend/resend-go/v2"
+)
+
+func contactSegmentsExample() {
+	apiKey := os.Getenv("RESEND_API_KEY")
+
+	client := resend.NewClient(apiKey)
+
+	// Example 1: Add a contact to a segment by contact ID
+	addParams := &resend.AddContactSegmentRequest{
+		SegmentId: "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+		ContactId: "479e3145-dd38-476b-932c-529ceb705947",
+	}
+
+	addResp, err := client.Contacts.Segments.Add(addParams)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Contact added to segment: %s\n", addResp.Id)
+
+	// Example 2: Add a contact to a segment by email
+	addByEmailParams := &resend.AddContactSegmentRequest{
+		SegmentId: "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+		Email:     "user@example.com",
+	}
+
+	addByEmailResp, err := client.Contacts.Segments.Add(addByEmailParams)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Contact added to segment by email: %s\n", addByEmailResp.Id)
+
+	// Example 3: List all segments for a contact by contact ID
+	listParams := &resend.ListContactSegmentsRequest{
+		ContactId: "479e3145-dd38-476b-932c-529ceb705947",
+	}
+
+	listResp, err := client.Contacts.Segments.List(listParams)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Found %d segments for contact\n", len(listResp.Data))
+	for _, segment := range listResp.Data {
+		fmt.Printf("  - %s (ID: %s)\n", segment.Name, segment.Id)
+	}
+
+	// Example 4: List all segments for a contact by email with pagination
+	limit := 10
+	listWithPaginationParams := &resend.ListContactSegmentsRequest{
+		Email: "user@example.com",
+	}
+	options := &resend.ListOptions{
+		Limit: &limit,
+	}
+
+	paginatedResp, err := client.Contacts.Segments.ListWithOptions(
+		context.Background(),
+		listWithPaginationParams,
+		options,
+	)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Found %d segments (has more: %v)\n", len(paginatedResp.Data), paginatedResp.HasMore)
+
+	// Example 5: Remove a contact from a segment by contact ID
+	removeParams := &resend.RemoveContactSegmentRequest{
+		SegmentId: "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+		ContactId: "479e3145-dd38-476b-932c-529ceb705947",
+	}
+
+	removeResp, err := client.Contacts.Segments.Remove(removeParams)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Contact removed from segment: %v\n", removeResp.Deleted)
+
+	// Example 6: Remove a contact from a segment by email
+	removeByEmailParams := &resend.RemoveContactSegmentRequest{
+		SegmentId: "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+		Email:     "user@example.com",
+	}
+
+	removeByEmailResp, err := client.Contacts.Segments.Remove(removeByEmailParams)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Contact removed from segment by email: %v\n", removeByEmailResp.Deleted)
+}

--- a/examples/contacts.go
+++ b/examples/contacts.go
@@ -63,21 +63,29 @@ func contactsExample() {
 	}
 
 	// Get by ID
-	retrievedContact, err := client.Contacts.GetWithContext(ctx, audienceId, contact.Id)
+	retrievedContact, err := client.Contacts.GetWithContext(ctx, &resend.GetContactOptions{
+		AudienceId: audienceId,
+		Id:         contact.Id,
+	})
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("\nRetrieved contact by ID: %v\n", retrievedContact)
 
 	// Get by email
-	retrievedByEmail, err := client.Contacts.GetWithContext(ctx, audienceId, contactEmail)
+	retrievedByEmail, err := client.Contacts.GetWithContext(ctx, &resend.GetContactOptions{
+		AudienceId: audienceId,
+		Id:         contactEmail,
+	})
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("\nRetrieved contact by email: %v\n", retrievedByEmail)
 
 	// List
-	contacts, err := client.Contacts.ListWithContext(ctx, audienceId)
+	contacts, err := client.Contacts.ListWithContext(ctx, &resend.ListContactsOptions{
+		AudienceId: audienceId,
+	})
 	if err != nil {
 		panic(err)
 	}
@@ -152,10 +160,16 @@ func contactsExample() {
 	// ====================================
 
 	// Remove by id
-	removed, err := client.Contacts.RemoveWithContext(ctx, audienceId, contact.Id)
+	removed, err := client.Contacts.RemoveWithContext(ctx, &resend.RemoveContactOptions{
+		AudienceId: audienceId,
+		Id:         contact.Id,
+	})
 
 	// Remove by email
-	// removed, err := client.Contacts.RemoveWithContext(ctx, audienceId, "hi@example.com")
+	// removed, err := client.Contacts.RemoveWithContext(ctx, &resend.RemoveContactOptions{
+	//   AudienceId: audienceId,
+	//   Id:         "hi@example.com",
+	// })
 	if err != nil {
 		panic(err)
 	}

--- a/examples/contacts.go
+++ b/examples/contacts.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v3"
 )
 
 func contactsExample() {

--- a/examples/domains.go
+++ b/examples/domains.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v3"
 )
 
 func domainsExample() {

--- a/examples/global_contacts.go
+++ b/examples/global_contacts.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v3"
 )
 
 func globalContactsExample() {

--- a/examples/global_contacts.go
+++ b/examples/global_contacts.go
@@ -1,0 +1,175 @@
+package examples
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/resend/resend-go/v2"
+)
+
+func globalContactsExample() {
+	apiKey := os.Getenv("RESEND_API_KEY")
+
+	client := resend.NewClient(apiKey)
+
+	// First, define custom properties (required before using them on contacts)
+	propertiesToCreate := []struct {
+		key string
+		typ string
+	}{
+		{"tier", "string"},
+		{"role", "string"},
+		{"signup_source", "string"},
+		{"active", "string"},
+		{"age", "string"},
+		{"source", "string"},
+	}
+
+	for _, prop := range propertiesToCreate {
+		_, err := client.Contacts.Properties.Create(&resend.CreateContactPropertyRequest{
+			Key:  prop.key,
+			Type: prop.typ,
+		})
+		if err != nil {
+			// Property might already exist, that's okay
+			fmt.Printf("Note: Could not create property '%s': %v\n", prop.key, err)
+		} else {
+			fmt.Printf("Created property: %s\n", prop.key)
+		}
+	}
+
+	// Example 1: Create a global contact with custom properties
+	// Global contacts don't require an audience_id and support custom properties
+	createParams := &resend.CreateContactRequest{
+		Email:     "user@example.com",
+		FirstName: "John",
+		LastName:  "Doe",
+		Properties: map[string]interface{}{
+			"tier":          "premium",
+			"role":          "admin",
+			"signup_source": "website",
+			"active":        "true",
+			"age":           "30",
+		},
+	}
+
+	created, err := client.Contacts.Create(createParams)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created global contact: %s\n", created.Id)
+
+	// Example 2: List all global contacts
+	// Omit AudienceId to list global contacts
+	contacts, err := client.Contacts.List(&resend.ListContactsOptions{})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Found %d global contacts\n", len(contacts.Data))
+	for _, contact := range contacts.Data {
+		fmt.Printf("  - %s %s (%s)\n", contact.FirstName, contact.LastName, contact.Email)
+		if contact.Properties != nil {
+			fmt.Printf("    Properties: %+v\n", contact.Properties)
+		}
+	}
+
+	// Example 3: Get a specific global contact
+	// Omit AudienceId to get a global contact
+	contact, err := client.Contacts.Get(&resend.GetContactOptions{
+		Id: created.Id,
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Retrieved contact: %s (%s)\n", contact.Email, contact.Id)
+	if contact.Properties != nil {
+		fmt.Printf("Properties: %+v\n", contact.Properties)
+	}
+
+	// Example 4: Update a global contact with new properties
+	updateParams := &resend.UpdateContactRequest{
+		Id:        created.Id,
+		FirstName: "Jane",
+		Properties: map[string]interface{}{
+			"tier":   "enterprise",
+			"role":   "owner",
+			"active": "true", // Use string, not boolean
+		},
+	}
+
+	updated, err := client.Contacts.Update(updateParams)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Updated contact: %s\n", updated.Data.Email)
+	fmt.Printf("New properties: %+v\n", updated.Data.Properties)
+
+	// Example 5: Remove a global contact
+	// Omit AudienceId to remove a global contact
+	removed, err := client.Contacts.Remove(&resend.RemoveContactOptions{
+		Id: created.Id,
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Removed contact: %s (deleted: %v)\n", removed.Id, removed.Deleted)
+
+	// Example 6: Create a global contact and add to segments
+	// First create a segment
+	segment, err := client.Segments.Create(&resend.CreateSegmentRequest{
+		Name: "Example Segment",
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created segment: %s (ID: %s)\n", segment.Name, segment.Id)
+
+	// Create a global contact
+	globalContact := &resend.CreateContactRequest{
+		Email:     "segmented@example.com",
+		FirstName: "Segmented",
+		LastName:  "User",
+		Properties: map[string]interface{}{
+			"source": "landing_page",
+		},
+	}
+
+	contactResp, err := client.Contacts.Create(globalContact)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created global contact: %s\n", contactResp.Id)
+
+	// Add the contact to the segment using the Contacts.Segments API
+	addToSegment := &resend.AddContactSegmentRequest{
+		ContactId: contactResp.Id,
+		SegmentId: segment.Id,
+	}
+
+	_, err = client.Contacts.Segments.Add(addToSegment)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Added contact to segment")
+
+	// List all segments for this global contact
+	listSegments := &resend.ListContactSegmentsRequest{
+		ContactId: contactResp.Id,
+	}
+
+	segmentsList, err := client.Contacts.Segments.List(listSegments)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Contact is in %d segment(s):\n", len(segmentsList.Data))
+	for _, seg := range segmentsList.Data {
+		fmt.Printf("  - %s (ID: %s)\n", seg.Name, seg.Id)
+	}
+
+	// Clean up: Remove the segment
+	removedSegment, err := client.Segments.Remove(segment.Id)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Segment deleted: %v\n", removedSegment.Deleted)
+}

--- a/examples/handle_rate_limit.go
+++ b/examples/handle_rate_limit.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v3"
 )
 
 func handleRateLimitExample() {

--- a/examples/receiving.go
+++ b/examples/receiving.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v3"
 )
 
 func receivingExample() {

--- a/examples/schedule_email.go
+++ b/examples/schedule_email.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v3"
 )
 
 func scheduleEmail() {

--- a/examples/segments.go
+++ b/examples/segments.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v3"
 )
 
 func segmentsExample() {

--- a/examples/segments.go
+++ b/examples/segments.go
@@ -1,0 +1,104 @@
+package examples
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/resend/resend-go/v2"
+)
+
+func segmentsExample() {
+	ctx := context.TODO()
+	apiKey := os.Getenv("RESEND_API_KEY")
+
+	client := resend.NewClient(apiKey)
+
+	// Create a segment
+	params := &resend.CreateSegmentRequest{
+		Name: "Premium Users",
+	}
+
+	segment, err := client.Segments.CreateWithContext(ctx, params)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created segment: %s (ID: %s)\n", segment.Name, segment.Id)
+
+	// Create a global contact
+	contactParams := &resend.CreateContactRequest{
+		Email:     "premium.user@example.com",
+		FirstName: "Premium",
+		LastName:  "User",
+	}
+
+	contact, err := client.Contacts.CreateWithContext(ctx, contactParams)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created contact: %s\n", contact.Id)
+
+	// Add the contact to the segment
+	addToSegment := &resend.AddContactSegmentRequest{
+		ContactId: contact.Id,
+		SegmentId: segment.Id,
+	}
+
+	_, err = client.Contacts.Segments.AddWithContext(ctx, addToSegment)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Added contact to segment\n")
+
+	// List all segments for this contact
+	contactSegments, err := client.Contacts.Segments.ListWithContext(ctx, &resend.ListContactSegmentsRequest{
+		ContactId: contact.Id,
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Contact is in %d segment(s):\n", len(contactSegments.Data))
+	for _, seg := range contactSegments.Data {
+		fmt.Printf("  - %s (ID: %s)\n", seg.Name, seg.Id)
+	}
+
+	// Get segment details
+	retrievedSegment, err := client.Segments.GetWithContext(ctx, segment.Id)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("\nRetrieved segment: %s\n", retrievedSegment.Name)
+
+	// List all segments
+	segments, err := client.Segments.ListWithContext(ctx)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("You have %d segments in your project\n", len(segments.Data))
+
+	// Clean up: Remove the contact from the segment
+	removeFromSegment, err := client.Contacts.Segments.RemoveWithContext(ctx, &resend.RemoveContactSegmentRequest{
+		ContactId: contact.Id,
+		SegmentId: segment.Id,
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("\nRemoved contact from segment: %v\n", removeFromSegment.Deleted)
+
+	// Clean up: Remove the contact
+	removedContact, err := client.Contacts.RemoveWithContext(ctx, &resend.RemoveContactOptions{
+		Id: contact.Id,
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Deleted contact: %v\n", removedContact.Deleted)
+
+	// Clean up: Remove the segment
+	removedSegment, err := client.Segments.RemoveWithContext(ctx, segment.Id)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Deleted segment: %v\n", removedSegment.Deleted)
+}

--- a/examples/send_batch_email.go
+++ b/examples/send_batch_email.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v3"
 )
 
 func sendBatchEmails() {

--- a/examples/send_email.go
+++ b/examples/send_email.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v3"
 )
 
 func sendEmailExample() {

--- a/examples/send_email_custom_client.go
+++ b/examples/send_email_custom_client.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v3"
 )
 
 func sendEmailCustomClientExample() {

--- a/examples/send_email_with_template.go
+++ b/examples/send_email_with_template.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v3"
 )
 
 func sendEmailWithTemplateExample() {

--- a/examples/templates.go
+++ b/examples/templates.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v3"
 )
 
 func templatesExample() {

--- a/examples/topics.go
+++ b/examples/topics.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v3"
 )
 
 func topicsExample() {

--- a/examples/webhook_receiver.go
+++ b/examples/webhook_receiver.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v3"
 )
 
 // Demonstrates how to receive and verify webhooks

--- a/examples/webhooks.go
+++ b/examples/webhooks.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v3"
 )
 
 func webhooksExample() {

--- a/examples/with_attachments.go
+++ b/examples/with_attachments.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v3"
 )
 
 func withAttachments() {

--- a/examples/with_inline_attachments.go
+++ b/examples/with_inline_attachments.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v3"
 )
 
 func inlineAttachmentExample() {

--- a/examples/with_pagination.go
+++ b/examples/with_pagination.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/resend/resend-go/v2"
+	"github.com/resend/resend-go/v3"
 )
 
 func withPaginationExample() {

--- a/examples/with_pagination.go
+++ b/examples/with_pagination.go
@@ -50,21 +50,21 @@ func withPaginationExample() {
 		}
 	}
 
-	// List audiences using before cursor
-	fmt.Println("\n=== List audiences with before cursor ===")
+	// List segments using before cursor
+	fmt.Println("\n=== List segments with before cursor ===")
 
 	before := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
 	limit3 := 3
-	audiencesResp, err := client.Audiences.ListWithOptions(ctx, &resend.ListOptions{
+	segmentsResp, err := client.Segments.ListWithOptions(ctx, &resend.ListOptions{
 		Limit:  &limit3,
 		Before: &before,
 	})
 	if err != nil {
-		log.Printf("Error listing audiences: %v", err)
+		log.Printf("Error listing segments: %v", err)
 	} else {
-		fmt.Printf("Found %d audiences before cursor (HasMore: %t)\n", len(audiencesResp.Data), audiencesResp.HasMore)
-		for _, audience := range audiencesResp.Data {
-			fmt.Printf("  - %s (ID: %s)\n", audience.Name, audience.Id)
+		fmt.Printf("Found %d segments before cursor (HasMore: %t)\n", len(segmentsResp.Data), segmentsResp.HasMore)
+		for _, segment := range segmentsResp.Data {
+			fmt.Printf("  - %s (ID: %s)\n", segment.Name, segment.Id)
 		}
 	}
 
@@ -73,8 +73,9 @@ func withPaginationExample() {
 
 	audienceId := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
 	limit20 := 20
-	contactsResp, err := client.Contacts.ListWithOptions(ctx, audienceId, &resend.ListOptions{
-		Limit: &limit20,
+	contactsResp, err := client.Contacts.ListWithContext(ctx, &resend.ListContactsOptions{
+		AudienceId: audienceId,
+		Limit:      &limit20,
 	})
 	if err != nil {
 		log.Printf("Error listing contacts: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/resend/resend-go/v2
+module github.com/resend/resend-go/v3
 
 go 1.23
 

--- a/resend.go
+++ b/resend.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version     = "2.28.0"
+	version     = "3.0.0"
 	userAgent   = "resend-go/" + version
 	contentType = "application/json"
 )
@@ -54,6 +54,8 @@ type Client struct {
 	Batch             BatchSvc
 	ApiKeys           ApiKeysSvc
 	Domains           DomainsSvc
+	Segments          SegmentsSvc
+	// Deprecated: Use Segments instead. Audiences have been renamed to Segments.
 	Audiences         AudiencesSvc
 	Contacts          *ContactsSvcImpl
 	ContactProperties ContactPropertiesSvc
@@ -85,12 +87,17 @@ func NewCustomClient(httpClient *http.Client, apiKey string) *Client {
 
 	contactsSvc := &ContactsSvcImpl{client: c}
 	contactsSvc.Topics = &ContactTopicsSvcImpl{client: c}
+	contactsSvc.Segments = &ContactSegmentsSvcImpl{client: c}
+	contactsSvc.Properties = &ContactPropertiesSvcImpl{client: c}
 	c.Contacts = contactsSvc
 
 	c.Batch = &BatchSvcImpl{client: c}
 	c.ApiKeys = &ApiKeysSvcImpl{client: c}
 	c.Domains = &DomainsSvcImpl{client: c}
-	c.Audiences = &AudiencesSvcImpl{client: c}
+	segmentsSvc := &SegmentsSvcImpl{client: c}
+	c.Segments = segmentsSvc
+	// Audiences is a deprecated alias for Segments for backward compatibility
+	c.Audiences = &AudiencesSvcImpl{segments: segmentsSvc}
 	c.ContactProperties = &ContactPropertiesSvcImpl{client: c}
 	c.Broadcasts = &BroadcastsSvcImpl{client: c}
 	c.Templates = &TemplatesSvcImpl{client: c}

--- a/segments.go
+++ b/segments.go
@@ -1,0 +1,175 @@
+package resend
+
+import (
+	"context"
+	"errors"
+	"net/http"
+)
+
+type SegmentsSvc interface {
+	CreateWithContext(ctx context.Context, params *CreateSegmentRequest) (CreateSegmentResponse, error)
+	Create(params *CreateSegmentRequest) (CreateSegmentResponse, error)
+	ListWithOptions(ctx context.Context, options *ListOptions) (ListSegmentsResponse, error)
+	ListWithContext(ctx context.Context) (ListSegmentsResponse, error)
+	List() (ListSegmentsResponse, error)
+	GetWithContext(ctx context.Context, segmentId string) (Segment, error)
+	Get(segmentId string) (Segment, error)
+	RemoveWithContext(ctx context.Context, segmentId string) (RemoveSegmentResponse, error)
+	Remove(segmentId string) (RemoveSegmentResponse, error)
+}
+
+type SegmentsSvcImpl struct {
+	client *Client
+}
+
+type CreateSegmentRequest struct {
+	Name string `json:"name"`
+}
+
+type CreateSegmentResponse struct {
+	Id     string `json:"id"`
+	Name   string `json:"name"`
+	Object string `json:"object"`
+}
+
+type RemoveSegmentResponse struct {
+	Id      string `json:"id"`
+	Object  string `json:"object"`
+	Deleted bool   `json:"deleted"`
+}
+
+type ListSegmentsResponse struct {
+	Object  string    `json:"object"`
+	Data    []Segment `json:"data"`
+	HasMore bool      `json:"has_more"`
+}
+
+type Segment struct {
+	Id        string `json:"id"`
+	Name      string `json:"name"`
+	Object    string `json:"object"`
+	CreatedAt string `json:"created_at"`
+}
+
+// CreateWithContext creates a new Segment entry based on the given params
+// https://resend.com/docs/api-reference/segments/create-segment
+func (s *SegmentsSvcImpl) CreateWithContext(ctx context.Context, params *CreateSegmentRequest) (CreateSegmentResponse, error) {
+	path := "segments"
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, params)
+	if err != nil {
+		return CreateSegmentResponse{}, errors.New("[ERROR]: Failed to create Segments.Create request")
+	}
+
+	// Build response recipient obj
+	segmentsResp := new(CreateSegmentResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, segmentsResp)
+
+	if err != nil {
+		return CreateSegmentResponse{}, err
+	}
+
+	return *segmentsResp, nil
+}
+
+// Create creates a new Segment entry based on the given params
+// https://resend.com/docs/api-reference/segments/create-segment
+func (s *SegmentsSvcImpl) Create(params *CreateSegmentRequest) (CreateSegmentResponse, error) {
+	return s.CreateWithContext(context.Background(), params)
+}
+
+// ListWithOptions returns the list of all segments with pagination options
+// https://resend.com/docs/api-reference/segments/list-segments
+func (s *SegmentsSvcImpl) ListWithOptions(ctx context.Context, options *ListOptions) (ListSegmentsResponse, error) {
+	path := "segments" + buildPaginationQuery(options)
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return ListSegmentsResponse{}, errors.New("[ERROR]: Failed to create Segments.List request")
+	}
+
+	segments := new(ListSegmentsResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, segments)
+
+	if err != nil {
+		return ListSegmentsResponse{}, err
+	}
+
+	return *segments, nil
+}
+
+// ListWithContext returns the list of all segments
+// https://resend.com/docs/api-reference/segments/list-segments
+func (s *SegmentsSvcImpl) ListWithContext(ctx context.Context) (ListSegmentsResponse, error) {
+	return s.ListWithOptions(ctx, nil)
+}
+
+// List returns the list of all segments
+// https://resend.com/docs/api-reference/segments/list-segments
+func (s *SegmentsSvcImpl) List() (ListSegmentsResponse, error) {
+	return s.ListWithContext(context.Background())
+}
+
+// RemoveWithContext removes a given segment by id
+// https://resend.com/docs/api-reference/segments/delete-segment
+func (s *SegmentsSvcImpl) RemoveWithContext(ctx context.Context, segmentId string) (RemoveSegmentResponse, error) {
+	path := "segments/" + segmentId
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return RemoveSegmentResponse{}, errors.New("[ERROR]: Failed to create Segment.Remove request")
+	}
+
+	resp := new(RemoveSegmentResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, resp)
+
+	if err != nil {
+		return RemoveSegmentResponse{}, err
+	}
+
+	return *resp, nil
+}
+
+// Remove removes a given segment entry by id
+// https://resend.com/docs/api-reference/segments/delete-segment
+func (s *SegmentsSvcImpl) Remove(segmentId string) (RemoveSegmentResponse, error) {
+	return s.RemoveWithContext(context.Background(), segmentId)
+}
+
+// GetWithContext Retrieve a single segment.
+// https://resend.com/docs/api-reference/segments/get-segment
+func (s *SegmentsSvcImpl) GetWithContext(ctx context.Context, segmentId string) (Segment, error) {
+	path := "segments/" + segmentId
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return Segment{}, errors.New("[ERROR]: Failed to create Segment.Get request")
+	}
+
+	segment := new(Segment)
+
+	// Send Request
+	_, err = s.client.Perform(req, segment)
+
+	if err != nil {
+		return Segment{}, err
+	}
+
+	return *segment, nil
+}
+
+// Get Retrieve a single segment.
+// https://resend.com/docs/api-reference/segments/get-segment
+func (s *SegmentsSvcImpl) Get(segmentId string) (Segment, error) {
+	return s.GetWithContext(context.Background(), segmentId)
+}

--- a/segments_test.go
+++ b/segments_test.go
@@ -8,13 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestCreateAudience tests the deprecated Audiences API
-// which internally calls the Segments API
-func TestCreateAudience(t *testing.T) {
+func TestCreateSegment(t *testing.T) {
 	setup()
 	defer teardown()
 
-	// Note: This still hits /segments endpoint because Audiences wraps Segments
 	mux.HandleFunc("/segments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, http.MethodPost)
 		w.Header().Set("Content-Type", "application/json")
@@ -31,19 +28,19 @@ func TestCreateAudience(t *testing.T) {
 		fmt.Fprint(w, ret)
 	})
 
-	req := &CreateAudienceRequest{
-		Name: "New Audience",
+	req := &CreateSegmentRequest{
+		Name: "New Segment",
 	}
-	resp, err := client.Audiences.Create(req)
+	resp, err := client.Segments.Create(req)
 	if err != nil {
-		t.Errorf("Audiences.Create returned error: %v", err)
+		t.Errorf("Segments.Create returned error: %v", err)
 	}
 	assert.Equal(t, resp.Id, "78261eea-8f8b-4381-83c6-79fa7120f1c")
 	assert.Equal(t, resp.Object, "segment")
 	assert.Equal(t, resp.Name, "Registered Users")
 }
 
-func TestListAudiences(t *testing.T) {
+func TestListSegments(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -66,19 +63,19 @@ func TestListAudiences(t *testing.T) {
 		fmt.Fprint(w, ret)
 	})
 
-	audiences, err := client.Audiences.List()
+	segments, err := client.Segments.List()
 	if err != nil {
-		t.Errorf("Audiences.List returned error: %v", err)
+		t.Errorf("Segments.List returned error: %v", err)
 	}
 
-	assert.Equal(t, len(audiences.Data), 1)
-	assert.Equal(t, audiences.Object, "list")
-	assert.Equal(t, audiences.Data[0].Id, "d91cd9bd-1176-453e-8fc1-35364d380206")
-	assert.Equal(t, audiences.Data[0].Name, "Registered Users")
-	assert.Equal(t, audiences.Data[0].CreatedAt, "2023-04-26T20:21:26.347412+00:00")
+	assert.Equal(t, len(segments.Data), 1)
+	assert.Equal(t, segments.Object, "list")
+	assert.Equal(t, segments.Data[0].Id, "d91cd9bd-1176-453e-8fc1-35364d380206")
+	assert.Equal(t, segments.Data[0].Name, "Registered Users")
+	assert.Equal(t, segments.Data[0].CreatedAt, "2023-04-26T20:21:26.347412+00:00")
 }
 
-func TestRemoveAudience(t *testing.T) {
+func TestRemoveSegment(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -97,16 +94,16 @@ func TestRemoveAudience(t *testing.T) {
 		fmt.Fprint(w, ret)
 	})
 
-	deleted, err := client.Audiences.Remove("b6d24b8e-af0b-4c3c-be0c-359bbd97381e")
+	deleted, err := client.Segments.Remove("b6d24b8e-af0b-4c3c-be0c-359bbd97381e")
 	if err != nil {
-		t.Errorf("Audiences.Remove returned error: %v", err)
+		t.Errorf("Segments.Remove returned error: %v", err)
 	}
 	assert.True(t, deleted.Deleted)
 	assert.Equal(t, deleted.Id, "b6d24b8e-af0b-4c3c-be0c-359bbd97381e")
 	assert.Equal(t, deleted.Object, "segment")
 }
 
-func TestGetAudience(t *testing.T) {
+func TestGetSegment(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -126,13 +123,13 @@ func TestGetAudience(t *testing.T) {
 		fmt.Fprint(w, ret)
 	})
 
-	audience, err := client.Audiences.Get("d91cd9bd-1176-453e-8fc1-35364d380206")
+	segment, err := client.Segments.Get("d91cd9bd-1176-453e-8fc1-35364d380206")
 	if err != nil {
-		t.Errorf("Audience.Get returned error: %v", err)
+		t.Errorf("Segment.Get returned error: %v", err)
 	}
 
-	assert.Equal(t, audience.Id, "d91cd9bd-1176-453e-8fc1-35364d380206")
-	assert.Equal(t, audience.Object, "segment")
-	assert.Equal(t, audience.Name, "Registered Users")
-	assert.Equal(t, audience.CreatedAt, "2023-10-06T22:59:55.977Z")
+	assert.Equal(t, segment.Id, "d91cd9bd-1176-453e-8fc1-35364d380206")
+	assert.Equal(t, segment.Object, "segment")
+	assert.Equal(t, segment.Name, "Registered Users")
+	assert.Equal(t, segment.CreatedAt, "2023-10-06T22:59:55.977Z")
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Releases v3.0.0 with a redesigned Contacts API and a new Segments service. Adds global contacts and properties, updates broadcasts to target segments, and keeps Audiences as a backward-compatible wrapper. Email sending APIs remain unchanged.

- **New Features**
  - Added Segments service (replaces Audiences; Audiences now wraps Segments).
  - Added Contacts.Segments for managing a contact’s segment membership.
  - Added global contacts (AudienceId optional) and contact Properties support.
  - Broadcasts now support SegmentId (AudienceId deprecated).
  - Updated module path to github.com/resend/resend-go/v3 and version to 3.0.0.

- **Migration**
  - Update imports to v3: github.com/resend/resend-go/v3.
  - Contacts methods now use option structs:
    - Get: Contacts.Get(&GetContactOptions{...})
    - List: Contacts.List(&ListContactsOptions{...})
    - Remove: Contacts.Remove(&RemoveContactOptions{...})
  - Prefer Segments over Audiences; Audiences continues to work but is deprecated.

<sup>Written for commit 124f5b1ce5fee280ed32cd579629b6bb2ee51932. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

