### PR TITLE
chore: quick fix on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ First, you need to get an API key, which is available in the [Resend Dashboard](
 ## Example
 
 ```go
+package main
+
 import (
     "fmt"
     "github.com/resend/resend-go/v3"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added the missing package declaration to the Go example in the README so the snippet compiles and runs when copy-pasted.

<sup>Written for commit a73d53bdf80811da48ec62b00109e5b3bc628183. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

