### PR TITLE
Upgrade to go 1.25 and minor updates

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,18 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go:
-          - "1.23"
-          - "1.22"
-          - "1.21"
-    name: "Test: go v${{ matrix.go }}"
+        go-version: ['1.24','1.25']
+    name: "Test: go v${{ matrix.go-version }}"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Setup go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go }}
+          go-version: ${{ matrix.go-version }}
 
       - name: Build
         run: go build -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23
+FROM golang:1.25
 
 WORKDIR /app
 

--- a/api_keys_test.go
+++ b/api_keys_test.go
@@ -22,7 +22,7 @@ func TestCreateApiKey(t *testing.T) {
 			"id": "dacf4072-4119-4d88-932f-6202748ac7c8",
 			"token": "re_c1tpEyD8_NKFusih9vKVQknRAQfmFcWCv"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	req := &CreateApiKeyRequest{
@@ -55,7 +55,7 @@ func TestListApiKeys(t *testing.T) {
 				}
 			]
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.ApiKeys.List()

--- a/broadcasts.go
+++ b/broadcasts.go
@@ -22,7 +22,7 @@ type CreateBroadcastRequest struct {
 	ReplyTo    []string `json:"reply_to,omitempty"`
 	Html       string   `json:"html,omitempty"`
 	Text       string   `json:"text,omitempty"`
-	Name       string   `json:"name,omitempty""`
+	Name       string   `json:"name,omitempty"`
 }
 
 type UpdateBroadcastRequest struct {

--- a/contacts.go
+++ b/contacts.go
@@ -48,9 +48,9 @@ type RemoveContactOptions struct {
 }
 
 type CreateContactRequest struct {
-	Email      string `json:"email"`
-	AudienceId string `json:"audience_id,omitempty"` // Deprecated: Optional, use Segments API for contact organization
-	Unsubscribed bool `json:"unsubscribed,omitempty"`
+	Email        string `json:"email"`
+	AudienceId   string `json:"audience_id,omitempty"` // Deprecated: Optional, use Segments API for contact organization
+	Unsubscribed bool   `json:"unsubscribed,omitempty"`
 	FirstName    string `json:"first_name,omitempty"`
 	LastName     string `json:"last_name,omitempty"`
 	// Properties are custom key-value pairs for global contacts (when audience_id is omitted).
@@ -373,10 +373,10 @@ func (r UpdateContactRequest) MarshalJSON() ([]byte, error) {
 		aux["unsubscribed"] = r.Unsubscribed
 	}
 	// Include properties if provided (for global contacts)
-	if r.Properties != nil && len(r.Properties) > 0 {
+	// len() for nil maps is defined as zero
+	if len(r.Properties) > 0 {
 		aux["properties"] = r.Properties
 	}
 
 	return json.Marshal(aux)
 }
-

--- a/emails_test.go
+++ b/emails_test.go
@@ -282,7 +282,7 @@ func TestGetEmail(t *testing.T) {
 			"subject": "Hello World",
 			"html":"html"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Emails.Get("49a3999c-0ce1-4ea6-ab68-afcd6dc2e794")
@@ -310,7 +310,7 @@ func TestCancelScheduledEmail(t *testing.T) {
 			"id": "dacf4072-4119-4d88-932f-6202748ac7c8",
 			"object": "email"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Emails.Cancel("dacf4072-4119-4d88-932f-6202748ac7c8")
@@ -527,8 +527,8 @@ func TestSendEmailWithTemplate(t *testing.T) {
 	})
 
 	req := &SendEmailRequest{
-		From: "sender@example.com",
-		To:   []string{"recipient@example.com"},
+		From:    "sender@example.com",
+		To:      []string{"recipient@example.com"},
 		Subject: "Welcome!",
 		Template: &EmailTemplate{
 			Id: "welcome-template",
@@ -574,8 +574,8 @@ func TestSendEmailWithTemplateAndVariables(t *testing.T) {
 	})
 
 	req := &SendEmailRequest{
-		From: "noreply@example.com",
-		To:   []string{"john@example.com"},
+		From:    "noreply@example.com",
+		To:      []string{"john@example.com"},
 		Subject: "Welcome to our service",
 		Template: &EmailTemplate{
 			Id: "user-welcome",
@@ -622,8 +622,8 @@ func TestSendEmailWithTemplateByAlias(t *testing.T) {
 	})
 
 	req := &SendEmailRequest{
-		From: "team@example.com",
-		To:   []string{"user@example.com"},
+		From:    "team@example.com",
+		To:      []string{"user@example.com"},
 		Subject: "Hello!",
 		Template: &EmailTemplate{
 			Id: "welcome-v2",
@@ -728,8 +728,8 @@ func TestSendEmailWithTemplateAndContext(t *testing.T) {
 
 	ctx := context.Background()
 	req := &SendEmailRequest{
-		From: "sender@example.com",
-		To:   []string{"recipient@example.com"},
+		From:    "sender@example.com",
+		To:      []string{"recipient@example.com"},
 		Subject: "Context Test",
 		Template: &EmailTemplate{
 			Id: "context-template",
@@ -776,8 +776,8 @@ func TestSendEmailWithTemplateComplexVariables(t *testing.T) {
 	})
 
 	req := &SendEmailRequest{
-		From: "sender@example.com",
-		To:   []string{"recipient@example.com"},
+		From:    "sender@example.com",
+		To:      []string{"recipient@example.com"},
 		Subject: "Complex Variables Test",
 		Template: &EmailTemplate{
 			Id: "complex-template",

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/resend/resend-go/v3
 
-go 1.23
+go 1.25.5
 
-require github.com/stretchr/testify v1.8.2
+require github.com/stretchr/testify v1.11.1
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/receiving_test.go
+++ b/receiving_test.go
@@ -45,7 +45,7 @@ func TestGetReceivedEmail(t *testing.T) {
 				}
 			]
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Emails.Receiving.Get("8136d3fb-0439-4b09-b939-b8436a3524b6")
@@ -99,7 +99,7 @@ func TestGetReceivedEmailWithNullFields(t *testing.T) {
 			"headers": {},
 			"attachments": []
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Emails.Receiving.Get("null-fields-id")
@@ -292,7 +292,7 @@ func TestGetReceivedEmailAttachment(t *testing.T) {
 			"download_url": "https://inbound-cdn.resend.com/4ef9a417-02e9-4d39-ad75-9611e0fcc33c/attachments/2a0c9ce0-3112-4728-976e-47ddcd16a318?some-params=example&signature=sig-123",
 			"expires_at": "2025-10-17T14:29:41.521Z"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Emails.Receiving.GetAttachment(emailId, attachmentId)
@@ -331,7 +331,7 @@ func TestGetReceivedEmailAttachmentWithContext(t *testing.T) {
 			"download_url": "https://inbound-cdn.resend.com/test-email-id/attachments/test-attachment-id",
 			"expires_at": "2025-10-18T12:00:00.000Z"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	ctx := context.Background()

--- a/templates_test.go
+++ b/templates_test.go
@@ -34,7 +34,7 @@ func TestCreateTemplate(t *testing.T) {
 			"id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794",
 			"object": "template"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Templates.Create(&CreateTemplateRequest{
@@ -82,7 +82,7 @@ func TestCreateTemplateWithVariables(t *testing.T) {
 			"id": "template-with-vars-id",
 			"object": "template"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Templates.Create(&CreateTemplateRequest{
@@ -147,7 +147,7 @@ func TestCreateTemplateWithAllFields(t *testing.T) {
 			"id": "full-template-id",
 			"object": "template"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Templates.Create(&CreateTemplateRequest{
@@ -180,7 +180,7 @@ func TestCreateTemplateWithContext(t *testing.T) {
 			"id": "context-template-id",
 			"object": "template"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	ctx := context.Background()
@@ -228,7 +228,7 @@ func TestCreateTemplateWithAllVariableTypes(t *testing.T) {
 			"id": "all-types-template-id",
 			"object": "template"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Templates.Create(&CreateTemplateRequest{
@@ -279,7 +279,7 @@ func TestCreateTemplateWithSingleReplyTo(t *testing.T) {
 			"id": "single-reply-to-id",
 			"object": "template"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Templates.Create(&CreateTemplateRequest{
@@ -330,7 +330,7 @@ func TestGetTemplate(t *testing.T) {
 				}
 			]
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Templates.Get(templateId)
@@ -387,7 +387,7 @@ func TestGetTemplateByAlias(t *testing.T) {
 			"text": "Welcome!",
 			"variables": []
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Templates.Get(templateAlias)
@@ -434,7 +434,7 @@ func TestGetTemplateWithContext(t *testing.T) {
 			"text": "Test",
 			"variables": []
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	ctx := context.Background()
@@ -486,7 +486,7 @@ func TestListTemplates(t *testing.T) {
 			],
 			"has_more": false
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	limit := 2
@@ -541,7 +541,7 @@ func TestListTemplatesWithAfter(t *testing.T) {
 			],
 			"has_more": true
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	limit := 2
@@ -589,7 +589,7 @@ func TestListTemplatesWithBefore(t *testing.T) {
 			],
 			"has_more": false
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	limit := 2
@@ -632,7 +632,7 @@ func TestListTemplatesWithContext(t *testing.T) {
 			],
 			"has_more": false
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	ctx := context.Background()
@@ -686,7 +686,7 @@ func TestListTemplatesWithoutOptions(t *testing.T) {
 			],
 			"has_more": false
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Templates.List(nil)
@@ -726,7 +726,7 @@ func TestGetTemplateWithMultipleReplyTo(t *testing.T) {
 			"text": "Test",
 			"variables": []
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Templates.Get(templateId)
@@ -770,7 +770,7 @@ func TestUpdateTemplate(t *testing.T) {
 			"id": "34a080c9-b17d-4187-ad80-5af20266e535",
 			"object": "template"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Templates.Update(templateId, &UpdateTemplateRequest{
@@ -815,7 +815,7 @@ func TestUpdateTemplateWithVariables(t *testing.T) {
 			"id": "template-with-vars",
 			"object": "template"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Templates.Update(templateId, &UpdateTemplateRequest{
@@ -857,7 +857,7 @@ func TestUpdateTemplateByAlias(t *testing.T) {
 			"id": "updated-by-alias-id",
 			"object": "template"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Templates.Update(templateAlias, &UpdateTemplateRequest{
@@ -887,7 +887,7 @@ func TestUpdateTemplateWithContext(t *testing.T) {
 			"id": "context-update-id",
 			"object": "template"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	ctx := context.Background()
@@ -938,7 +938,7 @@ func TestUpdateTemplateWithAllFields(t *testing.T) {
 			"id": "full-update-id",
 			"object": "template"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Templates.Update(templateId, &UpdateTemplateRequest{
@@ -973,7 +973,7 @@ func TestPublishTemplate(t *testing.T) {
 			"id": "34a080c9-b17d-4187-ad80-5af20266e535",
 			"object": "template"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Templates.Publish(templateId)
@@ -1000,7 +1000,7 @@ func TestPublishTemplateByAlias(t *testing.T) {
 			"id": "published-by-alias-id",
 			"object": "template"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Templates.Publish(templateAlias)
@@ -1027,7 +1027,7 @@ func TestPublishTemplateWithContext(t *testing.T) {
 			"id": "context-publish-id",
 			"object": "template"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	ctx := context.Background()
@@ -1055,7 +1055,7 @@ func TestDuplicateTemplate(t *testing.T) {
 			"id": "duplicated-template-id-789",
 			"object": "template"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Templates.Duplicate(templateId)
@@ -1082,7 +1082,7 @@ func TestDuplicateTemplateByAlias(t *testing.T) {
 			"id": "duplicated-by-alias-id",
 			"object": "template"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Templates.Duplicate(templateAlias)
@@ -1109,7 +1109,7 @@ func TestDuplicateTemplateWithContext(t *testing.T) {
 			"id": "context-duplicate-id-result",
 			"object": "template"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	ctx := context.Background()
@@ -1138,7 +1138,7 @@ func TestRemoveTemplate(t *testing.T) {
 			"id": "34a080c9-b17d-4187-ad80-5af20266e535",
 			"deleted": true
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Templates.Remove(templateId)
@@ -1167,7 +1167,7 @@ func TestRemoveTemplateByAlias(t *testing.T) {
 			"id": "removed-by-alias-id",
 			"deleted": true
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Templates.Remove(templateAlias)
@@ -1196,7 +1196,7 @@ func TestRemoveTemplateWithContext(t *testing.T) {
 			"id": "context-remove-id",
 			"deleted": true
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	ctx := context.Background()

--- a/topics_test.go
+++ b/topics_test.go
@@ -33,7 +33,7 @@ func TestCreateTopic(t *testing.T) {
 		{
 			"id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Topics.Create(&CreateTopicRequest{
@@ -69,7 +69,7 @@ func TestCreateTopicWithOptOut(t *testing.T) {
 		{
 			"id": "opt-out-topic-id"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Topics.Create(&CreateTopicRequest{
@@ -106,7 +106,7 @@ func TestCreateTopicWithDescription(t *testing.T) {
 		{
 			"id": "topic-with-description-id"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Topics.Create(&CreateTopicRequest{
@@ -133,7 +133,7 @@ func TestCreateTopicWithContext(t *testing.T) {
 		{
 			"id": "context-topic-id"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	ctx := context.Background()
@@ -166,7 +166,7 @@ func TestGetTopic(t *testing.T) {
 			"default_subscription": "opt_in",
 			"created_at": "2023-04-08T00:11:13.110779+00:00"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Topics.Get(topicId)
@@ -199,7 +199,7 @@ func TestGetTopicWithOptOut(t *testing.T) {
 			"default_subscription": "opt_out",
 			"created_at": "2023-04-08T00:11:13.110779+00:00"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Topics.Get(topicId)
@@ -232,7 +232,7 @@ func TestGetTopicWithContext(t *testing.T) {
 			"default_subscription": "opt_in",
 			"created_at": "2023-04-08T00:11:13.110779+00:00"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	ctx := context.Background()
@@ -281,7 +281,7 @@ func TestListTopics(t *testing.T) {
 				}
 			]
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	limit := 2
@@ -331,7 +331,7 @@ func TestListTopicsWithAfter(t *testing.T) {
 				}
 			]
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	limit := 2
@@ -377,7 +377,7 @@ func TestListTopicsWithBefore(t *testing.T) {
 				}
 			]
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	limit := 2
@@ -418,7 +418,7 @@ func TestListTopicsWithContext(t *testing.T) {
 				}
 			]
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	ctx := context.Background()
@@ -468,7 +468,7 @@ func TestListTopicsWithoutOptions(t *testing.T) {
 				}
 			]
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Topics.List(nil)
@@ -505,7 +505,7 @@ func TestUpdateTopic(t *testing.T) {
 		{
 			"id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Topics.Update(topicId, &UpdateTopicRequest{
@@ -543,7 +543,7 @@ func TestUpdateTopicNameOnly(t *testing.T) {
 		{
 			"id": "topic-name-only-id"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Topics.Update(topicId, &UpdateTopicRequest{
@@ -580,7 +580,7 @@ func TestUpdateTopicDescriptionOnly(t *testing.T) {
 		{
 			"id": "topic-description-only-id"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Topics.Update(topicId, &UpdateTopicRequest{
@@ -607,7 +607,7 @@ func TestUpdateTopicWithContext(t *testing.T) {
 		{
 			"id": "context-update-id"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	ctx := context.Background()
@@ -638,7 +638,7 @@ func TestRemoveTopic(t *testing.T) {
 			"id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
 			"deleted": true
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Topics.Remove(topicId)
@@ -667,7 +667,7 @@ func TestRemoveTopicWithContext(t *testing.T) {
 			"id": "context-remove-id",
 			"deleted": true
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	ctx := context.Background()

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -24,7 +24,7 @@ func TestCreateWebhook(t *testing.T) {
 			"id": "4dd369bc-aa82-4ff3-97de-514ae3000ee0",
 			"signing_secret": "whsec_xxxxxxxxxx"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	req := &CreateWebhookRequest{
@@ -55,7 +55,7 @@ func TestCreateWebhookWithContext(t *testing.T) {
 			"id": "test-webhook-id",
 			"signing_secret": "whsec_test_secret"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	ctx := context.Background()
@@ -93,7 +93,7 @@ func TestGetWebhook(t *testing.T) {
 			"events": ["email.sent", "email.received"],
 			"signing_secret": "whsec_xxxxxxxxxx"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Webhooks.Get(webhookId)
@@ -132,7 +132,7 @@ func TestGetWebhookWithContext(t *testing.T) {
 			"events": ["email.delivered"],
 			"signing_secret": "whsec_test_secret"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	ctx := context.Background()
@@ -166,7 +166,7 @@ func TestUpdateWebhook(t *testing.T) {
 			"object": "webhook",
 			"id": "430eed87-632a-4ea6-90db-0aace67ec228"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	endpoint := "https://new-webhook.example.com/handler"
@@ -200,7 +200,7 @@ func TestUpdateWebhookWithContext(t *testing.T) {
 			"object": "webhook",
 			"id": "test-update-id"
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	ctx := context.Background()
@@ -246,7 +246,7 @@ func TestListWebhooks(t *testing.T) {
 				}
 			]
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Webhooks.List()
@@ -293,7 +293,7 @@ func TestListWebhooksWithOptions(t *testing.T) {
 				}
 			]
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	limit := 10
@@ -329,7 +329,7 @@ func TestRemoveWebhook(t *testing.T) {
 			"id": "4dd369bc-aa82-4ff3-97de-514ae3000ee0",
 			"deleted": true
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	resp, err := client.Webhooks.Remove(webhookId)
@@ -358,7 +358,7 @@ func TestRemoveWebhookWithContext(t *testing.T) {
 			"id": "test-delete-id",
 			"deleted": true
 		}`
-		fmt.Fprintf(w, ret)
+		fmt.Fprint(w, ret)
 	})
 
 	ctx := context.Background()


### PR DESCRIPTION
I'm not 100% sure if you can have a matrix-based pipeline testing a downgraded version (vs. having a go.mod with 1.24 and testing up to 1.25) but giving it a try!

The other changes in this PR:
- Tests were throwing warnings due to `non-constant format string in call to fmt.Fprintf`, so the statements were changed to simply `fmt.Fprint`
- In contacts.go, I updated the nil check to just do `len() > 0` because `len()` for nil maps is defined as zero (so the check was redundant)
- broadcasts.go had a malformed struct tag with an extra quote, so removed it (this would have been a bug / actual problem for anyone trying to use this)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade project to Go 1.25.5, update CI to test Go 1.24 and 1.25, and align Docker and dependencies. Also fix test warnings and a malformed struct tag.

- **Dependencies**
  - Set go directive to 1.25.5 and update Docker base to golang:1.25.
  - Update GitHub Actions to checkout/setup-go v6 and test Go 1.24/1.25.
  - Bump testify to v1.11.1.

- **Bug Fixes**
  - Replace fmt.Fprintf with fmt.Fprint in tests to remove non-constant format warnings.
  - Fix malformed JSON struct tag on CreateBroadcastRequest.Name.
  - Simplify UpdateContactRequest properties check to use len(r.Properties) > 0.

<sup>Written for commit 22707e574295fe44278323a2d5aa48f9a96f2f4a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

