### PR TITLE
feat: add broadcasts send and scheduledAt options

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
 

--- a/broadcasts.go
+++ b/broadcasts.go
@@ -22,7 +22,15 @@ type CreateBroadcastRequest struct {
 	ReplyTo    []string `json:"reply_to,omitempty"`
 	Html       string   `json:"html,omitempty"`
 	Text       string   `json:"text,omitempty"`
-	Name       string   `json:"name,omitempty""`
+	Name       string   `json:"name,omitempty"`
+
+	// Send the broadcast immediately upon creation instead of creating a draft.
+	Send bool `json:"send,omitempty"`
+
+	// Schedule email to be sent later. The date should be in natural language (e.g.: in 1 min)
+	// or ISO 8601 format (e.g: 2024-08-05T11:52:01.858Z).
+	// Only valid when Send is true.
+	ScheduledAt string `json:"scheduled_at,omitempty"`
 }
 
 type UpdateBroadcastRequest struct {

--- a/broadcasts_test.go
+++ b/broadcasts_test.go
@@ -39,6 +39,71 @@ func TestCreateBroadcast(t *testing.T) {
 	assert.Equal(t, resp.Id, "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794")
 }
 
+func TestCreateAndSendBroadcast(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/broadcasts", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		var ret interface{}
+		ret = `
+		{
+			"id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	req := &CreateBroadcastRequest{
+		Name:       "New Broadcast",
+		AudienceId: "709d076c-2bb1-4be6-94ed-3f8f32622db6",
+		From:       "hi@example.com",
+		Subject:    "Hello, world!",
+		Send:       true,
+	}
+	resp, err := client.Broadcasts.Create(req)
+	if err != nil {
+		t.Errorf("Broadcasts.Create returned error: %v", err)
+	}
+	assert.Equal(t, resp.Id, "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794")
+}
+
+func TestCreateAndScheduleBroadcast(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/broadcasts", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		var ret interface{}
+		ret = `
+		{
+			"id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	req := &CreateBroadcastRequest{
+		Name:        "New Broadcast",
+		AudienceId:  "709d076c-2bb1-4be6-94ed-3f8f32622db6",
+		From:        "hi@example.com",
+		Subject:     "Hello, world!",
+		Send:        true,
+		ScheduledAt: "2024-12-01T19:32:22.980Z",
+	}
+	resp, err := client.Broadcasts.Create(req)
+	if err != nil {
+		t.Errorf("Broadcasts.Create returned error: %v", err)
+	}
+	assert.Equal(t, resp.Id, "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794")
+}
+
 func TestUpdateBroadcast(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add send and schedule options to broadcast creation so you can send immediately or set a delivery time. Includes tests for send-now and scheduled sends.

- **New Features**
  - CreateBroadcastRequest supports Send to send immediately.
  - ScheduledAt sets delivery time (ISO 8601 or natural language). Only valid when Send is true.

- **Bug Fixes**
  - Fixed JSON tag for Name (removed extra quote).

<sup>Written for commit 46a701fad706a0708e387ea2beac1210b898bc5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

