### PR TITLE
Update parsed fields on email receiving API

### DIFF
--- a/receiving.go
+++ b/receiving.go
@@ -8,7 +8,7 @@ import (
 // ReceivedEmail provides the structure for the response from the Receiving.Get call.
 type ReceivedEmail struct {
 	Id          string               `json:"id"`
-	Object      string               `json:"object"` // Always "inbound" for received emails
+	Object      string               `json:"object"` // Always "email" for received emails
 	To          []string             `json:"to"`
 	From        string               `json:"from"`
 	CreatedAt   string               `json:"created_at"`
@@ -19,7 +19,9 @@ type ReceivedEmail struct {
 	Cc          []string             `json:"cc"`
 	ReplyTo     []string             `json:"reply_to"`
 	Headers     map[string]string    `json:"headers"`
+	MessageId   string               `json:"message_id"`
 	Attachments []ReceivedAttachment `json:"attachments"`
+	Raw         RawEmail             `json:"raw"`
 }
 
 // ListReceivedEmail provides the structure for items in the Receiving.List call.
@@ -33,6 +35,7 @@ type ListReceivedEmail struct {
 	Bcc         []string             `json:"bcc"`
 	Cc          []string             `json:"cc"`
 	ReplyTo     []string             `json:"reply_to"`
+	MessageId   string               `json:"message_id"`
 	Attachments []ReceivedAttachment `json:"attachments"`
 }
 
@@ -50,6 +53,11 @@ type ReceivedAttachment struct {
 	ContentType        string `json:"content_type"`
 	ContentDisposition string `json:"content_disposition"`
 	ContentId          string `json:"content_id"`
+}
+
+type RawEmail struct {
+	DownloadUrl string `json:"download_url"`
+	ExpiresAt   string `json:"expires_at"`
 }
 
 // ReceivingSvc handles operations for received/inbound emails

--- a/receiving_test.go
+++ b/receiving_test.go
@@ -21,12 +21,13 @@ func TestGetReceivedEmail(t *testing.T) {
 
 		ret := `
 		{
-			"object": "inbound",
+			"object": "email",
 			"id": "8136d3fb-0439-4b09-b939-b8436a3524b6",
 			"to": ["delivered@resend.dev"],
 			"from": "Acme <onboarding@resend.dev>",
 			"created_at": "2023-04-03T22:13:42.674981+00:00",
 			"subject": "Hello World",
+			"message_id": "<test-message-id@example.com>",
 			"html": "Congrats on sending your <strong>first email</strong>!",
 			"text": "Congrats on sending your first email!",
 			"bcc": [],
@@ -34,6 +35,10 @@ func TestGetReceivedEmail(t *testing.T) {
 			"reply_to": ["reply@example.com"],
 			"headers": {
 				"X-Custom-Header": "value"
+			},
+			"raw": {
+				"download_url": "https://cdn.example.com/just-a-test-url",
+				"expires_at": "2023-04-20T16:23:29.315Z"
 			},
 			"attachments": [
 				{
@@ -53,7 +58,7 @@ func TestGetReceivedEmail(t *testing.T) {
 		t.Errorf("Emails.Receiving.Get returned error: %v", err)
 	}
 	assert.Equal(t, "8136d3fb-0439-4b09-b939-b8436a3524b6", resp.Id)
-	assert.Equal(t, "inbound", resp.Object)
+	assert.Equal(t, "email", resp.Object)
 	assert.Equal(t, "Acme <onboarding@resend.dev>", resp.From)
 	assert.Equal(t, "Hello World", resp.Subject)
 	assert.Equal(t, "Congrats on sending your <strong>first email</strong>!", resp.Html)
@@ -66,12 +71,15 @@ func TestGetReceivedEmail(t *testing.T) {
 	assert.Equal(t, "reply@example.com", resp.ReplyTo[0])
 	assert.Equal(t, 1, len(resp.Headers))
 	assert.Equal(t, "value", resp.Headers["X-Custom-Header"])
+	assert.Equal(t, "<test-message-id@example.com>", resp.MessageId)
 	assert.Equal(t, 1, len(resp.Attachments))
 	assert.Equal(t, "2a0c9ce0-3112-4728-976e-47ddcd16a318", resp.Attachments[0].Id)
 	assert.Equal(t, "avatar.png", resp.Attachments[0].Filename)
 	assert.Equal(t, "image/png", resp.Attachments[0].ContentType)
 	assert.Equal(t, "inline", resp.Attachments[0].ContentDisposition)
 	assert.Equal(t, "img001", resp.Attachments[0].ContentId)
+	assert.Equal(t, "https://cdn.example.com/just-a-test-url", resp.Raw.DownloadUrl)
+	assert.Equal(t, "2023-04-20T16:23:29.315Z", resp.Raw.ExpiresAt)
 }
 
 func TestGetReceivedEmailWithNullFields(t *testing.T) {
@@ -85,7 +93,7 @@ func TestGetReceivedEmailWithNullFields(t *testing.T) {
 
 		ret := `
 		{
-			"object": "inbound",
+			"object": "email",
 			"id": "null-fields-id",
 			"to": ["delivered@resend.dev"],
 			"from": "sender@example.com",


### PR DESCRIPTION
* Add message ID - Matches Node SDK PR https://github.com/resend/resend-node/pull/702
* `object` is "email", not "inbound - matches Node SDK PR https://github.com/resend/resend-node/pull/721
* Add `raw` download URL and expiration time to ReceivedEmail struct, documented here: https://resend.com/docs/api-reference/emails/retrieve-received-email

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the receiving API models to add message_id and raw download info, and changed the object value to "email" to match the Node SDK and docs. Tests updated to cover the new fields.

- **New Features**
  - ReceivedEmail: added message_id and raw (download_url, expires_at).
  - ListReceivedEmail: added message_id.
  - Object for received emails is now "email" (was "inbound").

- **Migration**
  - Update any logic that checks object == "inbound" to object == "email".

<sup>Written for commit 93c6e0164648e81899e0b21fdca1c79a73b72985. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

