### PR TITLE
chore: bump to v3.1.0

### DIFF
--- a/resend.go
+++ b/resend.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version     = "3.0.0"
+	version     = "3.1.0"
 	userAgent   = "resend-go/" + version
 	contentType = "application/json"
 )
@@ -50,11 +50,11 @@ type Client struct {
 	headers map[string]string
 
 	// Services
-	Emails            *EmailsSvcImpl
-	Batch             BatchSvc
-	ApiKeys           ApiKeysSvc
-	Domains           DomainsSvc
-	Segments          SegmentsSvc
+	Emails   *EmailsSvcImpl
+	Batch    BatchSvc
+	ApiKeys  ApiKeysSvc
+	Domains  DomainsSvc
+	Segments SegmentsSvc
 	// Deprecated: Use Segments instead. Audiences have been renamed to Segments.
 	Audiences         AudiencesSvc
 	Contacts          *ContactsSvcImpl


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumps the library version to 3.1.0 and updates the user agent to resend-go/3.1.0. No functional or API changes.

<sup>Written for commit dc644b2f911cbd7cd9015dd3cd89aa4874a08f81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

