### PR TITLE
feat: integrate HTTPClient interface

### DIFF
--- a/resend.go
+++ b/resend.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 	"time"
 )
@@ -30,6 +31,17 @@ var defaultHTTPClient = &http.Client{
 // circuit breakers, or any other HTTP-level middleware.
 type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
+}
+
+// isNilHTTPClient checks if an HTTPClient is nil, including typed-nil values.
+// In Go, an interface containing a nil pointer is not equal to nil,
+// so we need reflection to detect this case.
+func isNilHTTPClient(c HTTPClient) bool {
+	if c == nil {
+		return true
+	}
+	v := reflect.ValueOf(c)
+	return v.Kind() == reflect.Ptr && v.IsNil()
 }
 
 // Options interface is used to define additional options that can be passed
@@ -80,7 +92,7 @@ func NewClient(apiKey string) *Client {
 
 // NewCustomClient builds a new Resend API client, using a provided Http client.
 func NewCustomClient(httpClient HTTPClient, apiKey string) *Client {
-	if httpClient == nil {
+	if isNilHTTPClient(httpClient) {
 		httpClient = defaultHTTPClient
 	}
 

--- a/resend.go
+++ b/resend.go
@@ -25,6 +25,13 @@ var defaultHTTPClient = &http.Client{
 	Timeout: time.Minute,
 }
 
+// HTTPClient is an interface that allows custom HTTP client implementations.
+// This enables users to implement custom rate limiting, retry logic,
+// circuit breakers, or any other HTTP-level middleware.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // Options interface is used to define additional options that can be passed
 // to the API methods.
 type Options interface {
@@ -35,7 +42,7 @@ type Options interface {
 // Client handles communication with Resend API.
 type Client struct {
 	// HTTP client
-	client *http.Client
+	client HTTPClient
 
 	// Api Key
 	ApiKey string
@@ -72,7 +79,7 @@ func NewClient(apiKey string) *Client {
 }
 
 // NewCustomClient builds a new Resend API client, using a provided Http client.
-func NewCustomClient(httpClient *http.Client, apiKey string) *Client {
+func NewCustomClient(httpClient HTTPClient, apiKey string) *Client {
 	if httpClient == nil {
 		httpClient = defaultHTTPClient
 	}
@@ -112,7 +119,7 @@ func NewCustomClient(httpClient *http.Client, apiKey string) *Client {
 // NewRequestWithOptions builds and returns a new HTTP request object
 // based on the given arguments and options
 // It is used to set additional options like idempotency key
-func (c *Client) NewRequestWithOptions(ctx context.Context, method, path string, params interface{}, options Options) (*http.Request, error) {
+func (c *Client) NewRequestWithOptions(ctx context.Context, method, path string, params any, options Options) (*http.Request, error) {
 	req, err := c.NewRequest(ctx, method, path, params)
 
 	if err != nil {
@@ -138,7 +145,7 @@ func (c *Client) NewRequestWithOptions(ctx context.Context, method, path string,
 
 // NewRequest builds and returns a new HTTP request object
 // based on the given arguments
-func (c *Client) NewRequest(ctx context.Context, method, path string, params interface{}) (*http.Request, error) {
+func (c *Client) NewRequest(ctx context.Context, method, path string, params any) (*http.Request, error) {
 	u, err := c.BaseURL.Parse(path)
 	if err != nil {
 		return nil, err
@@ -173,7 +180,7 @@ func (c *Client) NewRequest(ctx context.Context, method, path string, params int
 }
 
 // Perform sends the request to the Resend API
-func (c *Client) Perform(req *http.Request, ret interface{}) (*http.Response, error) {
+func (c *Client) Perform(req *http.Request, ret any) (*http.Response, error) {
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
[More information in this issue](https://github.com/resend/resend-go/issues/100)

But basically this PR changes the implementation of a client and uses an interface for htt cliant and not a concrete implementation of `*http.Client` so it makes rate limit and implement http middlewares easier

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the client to use an HTTPClient interface instead of *http.Client. This enables custom HTTP middleware like rate limiting, retries, and circuit breakers while keeping the default behavior.

- **Refactors**
  - Added HTTPClient interface with Do(req) support.
  - Updated Client and NewCustomClient to use HTTPClient.
  - Added isNilHTTPClient to correctly detect typed-nil clients and use the default client.
  - Switched method params from interface{} to any in NewRequest, NewRequestWithOptions, and Perform.
  - Default http.Client remains the fallback.

<sup>Written for commit c0c9b1f827ce82d645311b9a129ab542c3311b1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

