### PR TITLE
modernize: replace interface{} -> any

### DIFF
--- a/audiences_test.go
+++ b/audiences_test.go
@@ -20,7 +20,7 @@ func TestCreateAudience(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		var ret interface{}
+		var ret any
 		ret = `
 		{
 			"object": "segment",
@@ -86,7 +86,7 @@ func TestRemoveAudience(t *testing.T) {
 		testMethod(t, r, http.MethodDelete)
 		w.WriteHeader(http.StatusOK)
 
-		var ret interface{}
+		var ret any
 		ret = `
 		{
 			"object": "segment",

--- a/broadcasts_test.go
+++ b/broadcasts_test.go
@@ -17,7 +17,7 @@ func TestCreateBroadcast(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		var ret interface{}
+		var ret any
 		ret = `
 		{
 			"id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
@@ -48,7 +48,7 @@ func TestCreateAndSendBroadcast(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		var ret interface{}
+		var ret any
 		ret = `
 		{
 			"id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
@@ -80,7 +80,7 @@ func TestCreateAndScheduleBroadcast(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		var ret interface{}
+		var ret any
 		ret = `
 		{
 			"id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
@@ -279,7 +279,7 @@ func TestRemoveBroadcast(t *testing.T) {
 		testMethod(t, r, http.MethodDelete)
 		w.WriteHeader(http.StatusOK)
 
-		var ret interface{}
+		var ret any
 		ret = `
 		{
 			"object": "broadcast",

--- a/contact_properties.go
+++ b/contact_properties.go
@@ -25,18 +25,18 @@ type ContactPropertiesSvcImpl struct {
 }
 
 type ContactProperty struct {
-	Id            string      `json:"id"`
-	Key           string      `json:"key"`
-	Object        string      `json:"object"`
-	CreatedAt     string      `json:"created_at"`
-	Type          string      `json:"type"`
-	FallbackValue any `json:"fallback_value"`
+	Id            string `json:"id"`
+	Key           string `json:"key"`
+	Object        string `json:"object"`
+	CreatedAt     string `json:"created_at"`
+	Type          string `json:"type"`
+	FallbackValue any    `json:"fallback_value"`
 }
 
 type CreateContactPropertyRequest struct {
-	Key           string      `json:"key"`
-	Type          string      `json:"type"`
-	FallbackValue any `json:"fallback_value"`
+	Key           string `json:"key"`
+	Type          string `json:"type"`
+	FallbackValue any    `json:"fallback_value"`
 }
 
 type CreateContactPropertyResponse struct {
@@ -45,8 +45,8 @@ type CreateContactPropertyResponse struct {
 }
 
 type UpdateContactPropertyRequest struct {
-	Id            string      `json:"-"`
-	FallbackValue any `json:"fallback_value"`
+	Id            string `json:"-"`
+	FallbackValue any    `json:"fallback_value"`
 }
 
 type UpdateContactPropertyResponse struct {

--- a/contact_properties.go
+++ b/contact_properties.go
@@ -30,13 +30,13 @@ type ContactProperty struct {
 	Object        string      `json:"object"`
 	CreatedAt     string      `json:"created_at"`
 	Type          string      `json:"type"`
-	FallbackValue interface{} `json:"fallback_value"`
+	FallbackValue any `json:"fallback_value"`
 }
 
 type CreateContactPropertyRequest struct {
 	Key           string      `json:"key"`
 	Type          string      `json:"type"`
-	FallbackValue interface{} `json:"fallback_value"`
+	FallbackValue any `json:"fallback_value"`
 }
 
 type CreateContactPropertyResponse struct {
@@ -46,7 +46,7 @@ type CreateContactPropertyResponse struct {
 
 type UpdateContactPropertyRequest struct {
 	Id            string      `json:"-"`
-	FallbackValue interface{} `json:"fallback_value"`
+	FallbackValue any `json:"fallback_value"`
 }
 
 type UpdateContactPropertyResponse struct {

--- a/contacts.go
+++ b/contacts.go
@@ -56,8 +56,8 @@ type CreateContactRequest struct {
 	// Properties are custom key-value pairs for global contacts (when audience_id is omitted).
 	// NOTE: Currently, the Resend API only accepts string values for properties.
 	// Non-string values (numbers, booleans, etc.) will be rejected by the API with a validation error.
-	// Example: Properties: map[string]interface{}{"tier": "premium", "age": "30", "active": "true"}
-	Properties map[string]interface{} `json:"properties,omitempty"`
+	// Example: Properties: map[string]any{"tier": "premium", "age": "30", "active": "true"}
+	Properties map[string]any `json:"properties,omitempty"`
 }
 
 type UpdateContactRequest struct {
@@ -70,8 +70,8 @@ type UpdateContactRequest struct {
 	// Properties are custom key-value pairs for global contacts (when audience_id is omitted).
 	// NOTE: Currently, the Resend API only accepts string values for properties.
 	// Non-string values (numbers, booleans, etc.) will be rejected by the API with a validation error.
-	// Example: Properties: map[string]interface{}{"tier": "premium", "age": "30", "active": "true"}
-	Properties      map[string]interface{} `json:"properties,omitempty"`
+	// Example: Properties: map[string]any{"tier": "premium", "age": "30", "active": "true"}
+	Properties      map[string]any `json:"properties,omitempty"`
 	unsubscribedSet bool                   `json:"-"`
 }
 
@@ -115,7 +115,7 @@ type Contact struct {
 	LastName     string                 `json:"last_name"`
 	CreatedAt    string                 `json:"created_at"`
 	Unsubscribed bool                   `json:"unsubscribed"`
-	Properties   map[string]interface{} `json:"properties,omitempty"` // Custom properties for global contacts (currently API only returns string values)
+	Properties   map[string]any `json:"properties,omitempty"` // Custom properties for global contacts (currently API only returns string values)
 }
 
 // Create creates a new Contact based on the given params
@@ -353,7 +353,7 @@ func (s *ContactsSvcImpl) UpdateWithContext(ctx context.Context, params *UpdateC
 // require a breaking change
 func (r UpdateContactRequest) MarshalJSON() ([]byte, error) {
 	type Alias UpdateContactRequest
-	aux := make(map[string]interface{})
+	aux := make(map[string]any)
 
 	aux["id"] = r.Id
 	if r.Email != "" {
@@ -373,10 +373,9 @@ func (r UpdateContactRequest) MarshalJSON() ([]byte, error) {
 		aux["unsubscribed"] = r.Unsubscribed
 	}
 	// Include properties if provided (for global contacts)
-	if r.Properties != nil && len(r.Properties) > 0 {
+	if len(r.Properties) > 0 {
 		aux["properties"] = r.Properties
 	}
 
 	return json.Marshal(aux)
 }
-

--- a/contacts.go
+++ b/contacts.go
@@ -48,9 +48,9 @@ type RemoveContactOptions struct {
 }
 
 type CreateContactRequest struct {
-	Email      string `json:"email"`
-	AudienceId string `json:"audience_id,omitempty"` // Deprecated: Optional, use Segments API for contact organization
-	Unsubscribed bool `json:"unsubscribed,omitempty"`
+	Email        string `json:"email"`
+	AudienceId   string `json:"audience_id,omitempty"` // Deprecated: Optional, use Segments API for contact organization
+	Unsubscribed bool   `json:"unsubscribed,omitempty"`
 	FirstName    string `json:"first_name,omitempty"`
 	LastName     string `json:"last_name,omitempty"`
 	// Properties are custom key-value pairs for global contacts (when audience_id is omitted).
@@ -72,7 +72,7 @@ type UpdateContactRequest struct {
 	// Non-string values (numbers, booleans, etc.) will be rejected by the API with a validation error.
 	// Example: Properties: map[string]any{"tier": "premium", "age": "30", "active": "true"}
 	Properties      map[string]any `json:"properties,omitempty"`
-	unsubscribedSet bool                   `json:"-"`
+	unsubscribedSet bool           `json:"-"`
 }
 
 // Temporary setter for the `unsubscribed` field. This is here
@@ -108,13 +108,13 @@ type ListContactsResponse struct {
 }
 
 type Contact struct {
-	Id           string                 `json:"id"`
-	Email        string                 `json:"email"`
-	Object       string                 `json:"object"`
-	FirstName    string                 `json:"first_name"`
-	LastName     string                 `json:"last_name"`
-	CreatedAt    string                 `json:"created_at"`
-	Unsubscribed bool                   `json:"unsubscribed"`
+	Id           string         `json:"id"`
+	Email        string         `json:"email"`
+	Object       string         `json:"object"`
+	FirstName    string         `json:"first_name"`
+	LastName     string         `json:"last_name"`
+	CreatedAt    string         `json:"created_at"`
+	Unsubscribed bool           `json:"unsubscribed"`
 	Properties   map[string]any `json:"properties,omitempty"` // Custom properties for global contacts (currently API only returns string values)
 }
 

--- a/contacts_test.go
+++ b/contacts_test.go
@@ -429,6 +429,7 @@ func TestUpdateContactAudienceIdMissing(t *testing.T) {
 	assert.Equal(t, "123123123", resp.Data.Id)
 	assert.Equal(t, "Updated First Name", resp.Data.FirstName)
 }
+
 // Global Contacts Tests
 
 func TestCreateGlobalContact(t *testing.T) {

--- a/contacts_test.go
+++ b/contacts_test.go
@@ -20,7 +20,7 @@ func TestCreateContact(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		var ret interface{}
+		var ret any
 		ret = `
 		{
 			"object": "contact",
@@ -96,7 +96,7 @@ func TestRemoveContact(t *testing.T) {
 		testMethod(t, r, http.MethodDelete)
 		w.WriteHeader(http.StatusOK)
 
-		var ret interface{}
+		var ret any
 		ret = `
 		{
 			"object": "contact",
@@ -205,7 +205,7 @@ func TestUpdateContactById(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		var ret interface{}
+		var ret any
 		ret = `
 		{
 			"data": {
@@ -243,7 +243,7 @@ func TestUpdateContactUnsubscribedFalse(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		var ret interface{}
+		var ret any
 		ret = `
 		{
 			"data": {
@@ -283,7 +283,7 @@ func TestUpdateContactUnsubscribedNil(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		var ret interface{}
+		var ret any
 		ret = `
 		{
 			"data": {
@@ -322,7 +322,7 @@ func TestUpdateContactByEmail(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		var ret interface{}
+		var ret any
 		ret = `
 		{
 			"data": {
@@ -450,7 +450,7 @@ func TestCreateGlobalContact(t *testing.T) {
 		Email:     "global@example.com",
 		FirstName: "Global",
 		LastName:  "Contact",
-		Properties: map[string]interface{}{
+		Properties: map[string]any{
 			"tier":          "premium",
 			"role":          "admin",
 			"signup_source": "website",
@@ -581,7 +581,7 @@ func TestUpdateGlobalContact(t *testing.T) {
 		Email:     "updated@example.com",
 		FirstName: "Updated",
 		LastName:  "Name",
-		Properties: map[string]interface{}{
+		Properties: map[string]any{
 			"tier": "enterprise",
 		},
 	}
@@ -608,7 +608,7 @@ func TestRemoveGlobalContact(t *testing.T) {
 		testMethod(t, r, http.MethodDelete)
 		w.WriteHeader(http.StatusOK)
 
-		var ret interface{}
+		var ret any
 		ret = `{
 			"object": "contact",
 			"id": "479e3145-dd38-476b-932c-529ceb705947",

--- a/domains_test.go
+++ b/domains_test.go
@@ -18,7 +18,7 @@ func TestCreateDomain(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		var ret interface{}
+		var ret any
 		ret = `
 		{
 			"id": "4dd369bc-aa82-4ff3-97de-514ae3000ee0",

--- a/emails.go
+++ b/emails.go
@@ -19,7 +19,7 @@ type EmailTemplate struct {
 	// Id is the template ID or alias to use for this email
 	Id string `json:"id"`
 	// Variables are the key-value pairs to populate the template placeholders
-	Variables map[string]interface{} `json:"variables,omitempty"`
+	Variables map[string]any `json:"variables,omitempty"`
 }
 
 // SendEmailRequest is the request object for the Send call.

--- a/emails_test.go
+++ b/emails_test.go
@@ -527,8 +527,8 @@ func TestSendEmailWithTemplate(t *testing.T) {
 	})
 
 	req := &SendEmailRequest{
-		From: "sender@example.com",
-		To:   []string{"recipient@example.com"},
+		From:    "sender@example.com",
+		To:      []string{"recipient@example.com"},
 		Subject: "Welcome!",
 		Template: &EmailTemplate{
 			Id: "welcome-template",
@@ -574,8 +574,8 @@ func TestSendEmailWithTemplateAndVariables(t *testing.T) {
 	})
 
 	req := &SendEmailRequest{
-		From: "noreply@example.com",
-		To:   []string{"john@example.com"},
+		From:    "noreply@example.com",
+		To:      []string{"john@example.com"},
 		Subject: "Welcome to our service",
 		Template: &EmailTemplate{
 			Id: "user-welcome",
@@ -622,8 +622,8 @@ func TestSendEmailWithTemplateByAlias(t *testing.T) {
 	})
 
 	req := &SendEmailRequest{
-		From: "team@example.com",
-		To:   []string{"user@example.com"},
+		From:    "team@example.com",
+		To:      []string{"user@example.com"},
 		Subject: "Hello!",
 		Template: &EmailTemplate{
 			Id: "welcome-v2",
@@ -728,8 +728,8 @@ func TestSendEmailWithTemplateAndContext(t *testing.T) {
 
 	ctx := context.Background()
 	req := &SendEmailRequest{
-		From: "sender@example.com",
-		To:   []string{"recipient@example.com"},
+		From:    "sender@example.com",
+		To:      []string{"recipient@example.com"},
 		Subject: "Context Test",
 		Template: &EmailTemplate{
 			Id: "context-template",
@@ -776,8 +776,8 @@ func TestSendEmailWithTemplateComplexVariables(t *testing.T) {
 	})
 
 	req := &SendEmailRequest{
-		From: "sender@example.com",
-		To:   []string{"recipient@example.com"},
+		From:    "sender@example.com",
+		To:      []string{"recipient@example.com"},
 		Subject: "Complex Variables Test",
 		Template: &EmailTemplate{
 			Id: "complex-template",

--- a/emails_test.go
+++ b/emails_test.go
@@ -579,7 +579,7 @@ func TestSendEmailWithTemplateAndVariables(t *testing.T) {
 		Subject: "Welcome to our service",
 		Template: &EmailTemplate{
 			Id: "user-welcome",
-			Variables: map[string]interface{}{
+			Variables: map[string]any{
 				"name": "John Doe",
 				"age":  25,
 			},
@@ -686,7 +686,7 @@ func TestSendEmailWithTemplateAndOverrides(t *testing.T) {
 		},
 		Template: &EmailTemplate{
 			Id: "newsletter-template",
-			Variables: map[string]interface{}{
+			Variables: map[string]any{
 				"title": "Custom Newsletter",
 			},
 		},
@@ -733,7 +733,7 @@ func TestSendEmailWithTemplateAndContext(t *testing.T) {
 		Subject: "Context Test",
 		Template: &EmailTemplate{
 			Id: "context-template",
-			Variables: map[string]interface{}{
+			Variables: map[string]any{
 				"contextVar": "test",
 			},
 		},
@@ -781,7 +781,7 @@ func TestSendEmailWithTemplateComplexVariables(t *testing.T) {
 		Subject: "Complex Variables Test",
 		Template: &EmailTemplate{
 			Id: "complex-template",
-			Variables: map[string]interface{}{
+			Variables: map[string]any{
 				"count": 42,
 			},
 		},

--- a/examples/global_contacts.go
+++ b/examples/global_contacts.go
@@ -44,7 +44,7 @@ func globalContactsExample() {
 		Email:     "user@example.com",
 		FirstName: "John",
 		LastName:  "Doe",
-		Properties: map[string]interface{}{
+		Properties: map[string]any{
 			"tier":          "premium",
 			"role":          "admin",
 			"signup_source": "website",
@@ -90,7 +90,7 @@ func globalContactsExample() {
 	updateParams := &resend.UpdateContactRequest{
 		Id:        created.Id,
 		FirstName: "Jane",
-		Properties: map[string]interface{}{
+		Properties: map[string]any{
 			"tier":   "enterprise",
 			"role":   "owner",
 			"active": "true", // Use string, not boolean
@@ -129,7 +129,7 @@ func globalContactsExample() {
 		Email:     "segmented@example.com",
 		FirstName: "Segmented",
 		LastName:  "User",
-		Properties: map[string]interface{}{
+		Properties: map[string]any{
 			"source": "landing_page",
 		},
 	}

--- a/examples/send_batch_email.go
+++ b/examples/send_batch_email.go
@@ -85,8 +85,8 @@ func sendBatchEmails() {
 	for _, email := range sent.Data {
 		fmt.Printf("  - Email ID: %s\n", email.Id)
 	}
-	
-	if sent.Errors != nil && len(sent.Errors) > 0 {
+
+	if len(sent.Errors) > 0 {
 		fmt.Printf("Failed to send %d emails:\n", len(sent.Errors))
 		for _, err := range sent.Errors {
 			fmt.Printf("  - Index %d: %s\n", err.Index, err.Message)

--- a/examples/send_email_with_template.go
+++ b/examples/send_email_with_template.go
@@ -67,7 +67,7 @@ func sendEmailWithTemplateExample() {
 		To: []string{"delivered@resend.dev"},
 		Template: &resend.EmailTemplate{
 			Id: template.Id,
-			Variables: map[string]interface{}{
+			Variables: map[string]any{
 				"userName":     "Alice Johnson",
 				"companyName":  "Acme Corporation",
 				"messageCount": 12,
@@ -86,7 +86,7 @@ func sendEmailWithTemplateExample() {
 		To: []string{"delivered@resend.dev"},
 		Template: &resend.EmailTemplate{
 			Id: "welcome", // Using alias instead of ID
-			Variables: map[string]interface{}{
+			Variables: map[string]any{
 				"userName":     "Bob Smith",
 				"companyName":  "Tech Startup Inc",
 				"messageCount": 3,
@@ -109,7 +109,7 @@ func sendEmailWithTemplateExample() {
 		ReplyTo: "noreply@resend.dev",
 		Template: &resend.EmailTemplate{
 			Id: template.Id,
-			Variables: map[string]interface{}{
+			Variables: map[string]any{
 				"userName":     "Charlie Brown",
 				"companyName":  "Example LLC",
 				"messageCount": 7,

--- a/examples/templates.go
+++ b/examples/templates.go
@@ -82,7 +82,6 @@ func templatesExample() {
 	}
 	fmt.Printf("Created full template: %s (object: %s)\n", fullTemplate.Id, fullTemplate.Object)
 
-
 	// Get a template by ID
 	retrievedTemplate, err := client.Templates.GetWithContext(ctx, template.Id)
 	if err != nil {

--- a/examples/webhook_receiver.go
+++ b/examples/webhook_receiver.go
@@ -55,7 +55,7 @@ func webhookReceiverExample() {
 		}
 
 		// Parse the verified payload
-		var payload map[string]interface{}
+		var payload map[string]any
 		if err := json.Unmarshal(body, &payload); err != nil {
 			log.Printf("Error parsing JSON: %v", err)
 			http.Error(w, "Invalid JSON payload", http.StatusBadRequest)

--- a/resend.go
+++ b/resend.go
@@ -112,7 +112,7 @@ func NewCustomClient(httpClient *http.Client, apiKey string) *Client {
 // NewRequestWithOptions builds and returns a new HTTP request object
 // based on the given arguments and options
 // It is used to set additional options like idempotency key
-func (c *Client) NewRequestWithOptions(ctx context.Context, method, path string, params interface{}, options Options) (*http.Request, error) {
+func (c *Client) NewRequestWithOptions(ctx context.Context, method, path string, params any, options Options) (*http.Request, error) {
 	req, err := c.NewRequest(ctx, method, path, params)
 
 	if err != nil {
@@ -138,7 +138,7 @@ func (c *Client) NewRequestWithOptions(ctx context.Context, method, path string,
 
 // NewRequest builds and returns a new HTTP request object
 // based on the given arguments
-func (c *Client) NewRequest(ctx context.Context, method, path string, params interface{}) (*http.Request, error) {
+func (c *Client) NewRequest(ctx context.Context, method, path string, params any) (*http.Request, error) {
 	u, err := c.BaseURL.Parse(path)
 	if err != nil {
 		return nil, err
@@ -173,7 +173,7 @@ func (c *Client) NewRequest(ctx context.Context, method, path string, params int
 }
 
 // Perform sends the request to the Resend API
-func (c *Client) Perform(req *http.Request, ret interface{}) (*http.Response, error) {
+func (c *Client) Perform(req *http.Request, ret any) (*http.Response, error) {
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err

--- a/segments_test.go
+++ b/segments_test.go
@@ -17,7 +17,7 @@ func TestCreateSegment(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 
-		var ret interface{}
+		var ret any
 		ret = `
 		{
 			"object": "segment",
@@ -83,7 +83,7 @@ func TestRemoveSegment(t *testing.T) {
 		testMethod(t, r, http.MethodDelete)
 		w.WriteHeader(http.StatusOK)
 
-		var ret interface{}
+		var ret any
 		ret = `
 		{
 			"object": "segment",

--- a/templates.go
+++ b/templates.go
@@ -19,7 +19,7 @@ const (
 type TemplateVariable struct {
 	Key           string       `json:"key"`
 	Type          VariableType `json:"type"`
-	FallbackValue interface{}  `json:"fallback_value,omitempty"`
+	FallbackValue any  `json:"fallback_value,omitempty"`
 }
 
 // CreateTemplateRequest is the request payload for creating a template
@@ -30,7 +30,7 @@ type CreateTemplateRequest struct {
 	Alias     string              `json:"alias,omitempty"`
 	From      string              `json:"from,omitempty"`
 	Subject   string              `json:"subject,omitempty"`
-	ReplyTo   interface{}         `json:"reply_to,omitempty"` // string or []string
+	ReplyTo   any         `json:"reply_to,omitempty"` // string or []string
 	Html      string              `json:"html"`
 	Text      string              `json:"text,omitempty"`
 	Variables []*TemplateVariable `json:"variables,omitempty"`
@@ -50,7 +50,7 @@ type UpdateTemplateRequest struct {
 	Alias     string              `json:"alias,omitempty"`
 	From      string              `json:"from,omitempty"`
 	Subject   string              `json:"subject,omitempty"`
-	ReplyTo   interface{}         `json:"reply_to,omitempty"` // string or []string
+	ReplyTo   any         `json:"reply_to,omitempty"` // string or []string
 	Html      string              `json:"html"`
 	Text      string              `json:"text,omitempty"`
 	Variables []*TemplateVariable `json:"variables,omitempty"`
@@ -104,7 +104,7 @@ type TemplateVariableResponse struct {
 	Id            string       `json:"id"`
 	Key           string       `json:"key"`
 	Type          VariableType `json:"type"`
-	FallbackValue interface{}  `json:"fallback_value"`
+	FallbackValue any  `json:"fallback_value"`
 	CreatedAt     string       `json:"created_at"`
 	UpdatedAt     string       `json:"updated_at"`
 }
@@ -121,7 +121,7 @@ type Template struct {
 	PublishedAt string                      `json:"published_at"`
 	From        string                      `json:"from"`
 	Subject     string                      `json:"subject"`
-	ReplyTo     interface{}                 `json:"reply_to"` // string, []string, or null
+	ReplyTo     any                 `json:"reply_to"` // string, []string, or null
 	Html        string                      `json:"html"`
 	Text        string                      `json:"text"`
 	Variables   []*TemplateVariableResponse `json:"variables"`

--- a/templates.go
+++ b/templates.go
@@ -19,7 +19,7 @@ const (
 type TemplateVariable struct {
 	Key           string       `json:"key"`
 	Type          VariableType `json:"type"`
-	FallbackValue any  `json:"fallback_value,omitempty"`
+	FallbackValue any          `json:"fallback_value,omitempty"`
 }
 
 // CreateTemplateRequest is the request payload for creating a template
@@ -30,7 +30,7 @@ type CreateTemplateRequest struct {
 	Alias     string              `json:"alias,omitempty"`
 	From      string              `json:"from,omitempty"`
 	Subject   string              `json:"subject,omitempty"`
-	ReplyTo   any         `json:"reply_to,omitempty"` // string or []string
+	ReplyTo   any                 `json:"reply_to,omitempty"` // string or []string
 	Html      string              `json:"html"`
 	Text      string              `json:"text,omitempty"`
 	Variables []*TemplateVariable `json:"variables,omitempty"`
@@ -50,7 +50,7 @@ type UpdateTemplateRequest struct {
 	Alias     string              `json:"alias,omitempty"`
 	From      string              `json:"from,omitempty"`
 	Subject   string              `json:"subject,omitempty"`
-	ReplyTo   any         `json:"reply_to,omitempty"` // string or []string
+	ReplyTo   any                 `json:"reply_to,omitempty"` // string or []string
 	Html      string              `json:"html"`
 	Text      string              `json:"text,omitempty"`
 	Variables []*TemplateVariable `json:"variables,omitempty"`
@@ -104,7 +104,7 @@ type TemplateVariableResponse struct {
 	Id            string       `json:"id"`
 	Key           string       `json:"key"`
 	Type          VariableType `json:"type"`
-	FallbackValue any  `json:"fallback_value"`
+	FallbackValue any          `json:"fallback_value"`
 	CreatedAt     string       `json:"created_at"`
 	UpdatedAt     string       `json:"updated_at"`
 }
@@ -121,7 +121,7 @@ type Template struct {
 	PublishedAt string                      `json:"published_at"`
 	From        string                      `json:"from"`
 	Subject     string                      `json:"subject"`
-	ReplyTo     any                 `json:"reply_to"` // string, []string, or null
+	ReplyTo     any                         `json:"reply_to"` // string, []string, or null
 	Html        string                      `json:"html"`
 	Text        string                      `json:"text"`
 	Variables   []*TemplateVariableResponse `json:"variables"`

--- a/templates_test.go
+++ b/templates_test.go
@@ -136,7 +136,7 @@ func TestCreateTemplateWithAllFields(t *testing.T) {
 		assert.Equal(t, "Hello", req.Text)
 
 		// ReplyTo can be string or []string
-		replyTo, ok := req.ReplyTo.([]interface{})
+		replyTo, ok := req.ReplyTo.([]any)
 		assert.True(t, ok)
 		assert.Equal(t, 2, len(replyTo))
 		assert.Equal(t, "support@example.com", replyTo[0].(string))
@@ -736,8 +736,8 @@ func TestGetTemplateWithMultipleReplyTo(t *testing.T) {
 	assert.Equal(t, "multi-reply-to-id", resp.Id)
 	assert.NotNil(t, resp.ReplyTo)
 
-	// ReplyTo is []interface{} when decoded from JSON
-	replyTo, ok := resp.ReplyTo.([]interface{})
+	// ReplyTo is []any when decoded from JSON
+	replyTo, ok := resp.ReplyTo.([]any)
 	assert.True(t, ok)
 	assert.Equal(t, 2, len(replyTo))
 	assert.Equal(t, "support@example.com", replyTo[0].(string))
@@ -928,7 +928,7 @@ func TestUpdateTemplateWithAllFields(t *testing.T) {
 		assert.Equal(t, "Updated Text", req.Text)
 
 		// ReplyTo can be string or []string
-		replyTo, ok := req.ReplyTo.([]interface{})
+		replyTo, ok := req.ReplyTo.([]any)
 		assert.True(t, ok)
 		assert.Equal(t, 1, len(replyTo))
 		assert.Equal(t, "updated@example.com", replyTo[0].(string))


### PR DESCRIPTION
Replaces `interface{}` with the `any` keyword, introduced in go1.18 (15 March 2022).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced interface{} with the any alias across the SDK to modernize the API and improve readability. No behavior changes.

- **Refactors**
  - Swapped interface{} for any in public structs, method signatures, tests, and examples.
  - Updated map/slice types and comments (map[string]any, []any).
  - Removed redundant nil checks (maps/slices) and applied go fmt formatting.

- **Migration**
  - Requires Go 1.18+ (any is available since 1.18).
  - Public API stays source compatible; no changes needed for consumers on Go 1.18+.

<sup>Written for commit 3c13ab4d7ca1fd09610f63461fe5277de7f1a983. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

