### PR TITLE
feat: add logs API support

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -97,3 +97,9 @@ var (
 	ErrFailedToCreateTopicUpdateRequest = errors.New("[ERROR]: Failed to create Topics.Update request")
 	ErrFailedToCreateTopicRemoveRequest = errors.New("[ERROR]: Failed to create Topics.Remove request")
 )
+
+// LogsSvc errors
+var (
+	ErrFailedToCreateLogsGetRequest  = errors.New("[ERROR]: Failed to create Logs.Get request")
+	ErrFailedToCreateLogsListRequest = errors.New("[ERROR]: Failed to create Logs.List request")
+)

--- a/examples/logs.go
+++ b/examples/logs.go
@@ -1,0 +1,56 @@
+package examples
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/resend/resend-go/v3"
+)
+
+func logsExample() {
+	ctx := context.TODO()
+	apiKey := os.Getenv("RESEND_API_KEY")
+
+	client := resend.NewClient(apiKey)
+
+	// Retrieve a single log
+	log, err := client.Logs.GetWithContext(ctx, "log_123abc")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Log ID: %s\n", log.Id)
+	fmt.Printf("Endpoint: %s %s\n", log.Method, log.Endpoint)
+	fmt.Printf("Response status: %d\n", log.ResponseStatus)
+	fmt.Printf("Created at: %s\n", log.CreatedAt)
+
+	// List logs
+	logs, err := client.Logs.ListWithContext(ctx)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Total logs: %d\n", len(logs.Data))
+	fmt.Printf("Has more: %v\n", logs.HasMore)
+
+	// List logs with pagination
+	limit := 10
+	logsPage, err := client.Logs.ListWithOptions(ctx, &resend.ListOptions{
+		Limit: &limit,
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Page logs: %d\n", len(logsPage.Data))
+
+	if logsPage.HasMore {
+		lastId := logsPage.Data[len(logsPage.Data)-1].Id
+		nextPage, err := client.Logs.ListWithOptions(ctx, &resend.ListOptions{
+			Limit: &limit,
+			After: &lastId,
+		})
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("Next page logs: %d\n", len(nextPage.Data))
+	}
+}

--- a/examples/main/main.go
+++ b/examples/main/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/resend/resend-go/v3"
+)
+
+func main() {
+	ctx := context.TODO()
+	apiKey := os.Getenv("RESEND_API_KEY")
+
+	client := resend.NewClient(apiKey)
+
+	// Create API Key
+	params := &resend.CreateApiKeyRequest{
+		Name: "nice api key",
+	}
+
+	resp, err := client.ApiKeys.CreateWithContext(ctx, params)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Created API Key id: " + resp.Id)
+	fmt.Println("Token: " + resp.Token)
+
+	// List
+	apiKeys, err := client.ApiKeys.ListWithContext(ctx)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("You have %d api keys in your project\n", len(apiKeys.Data))
+	if len(apiKeys.Data) > 0 {
+		fmt.Println("Created API Key id: " + apiKeys.Data[0].Id)
+		if apiKeys.Data[0].LastUsedAt != nil {
+			fmt.Println("Last used at: " + *apiKeys.Data[0].LastUsedAt)
+		}
+	}
+
+	// Delete
+	_, err = client.ApiKeys.RemoveWithContext(ctx, resp.Id)
+	if err != nil {
+		panic(err)
+	}
+	println("deleted api key id: " + resp.Id)
+}

--- a/logs.go
+++ b/logs.go
@@ -1,0 +1,92 @@
+package resend
+
+import (
+	"context"
+	"net/http"
+)
+
+type Log struct {
+	Object         string  `json:"object,omitempty"`
+	Id             string  `json:"id"`
+	CreatedAt      string  `json:"created_at"`
+	Endpoint       string  `json:"endpoint"`
+	Method         string  `json:"method"`
+	ResponseStatus int     `json:"response_status"`
+	UserAgent      *string `json:"user_agent"`
+	RequestBody    any     `json:"request_body,omitempty"`
+	ResponseBody   any     `json:"response_body,omitempty"`
+}
+
+type ListLogsResponse struct {
+	Object  string `json:"object"`
+	Data    []Log  `json:"data"`
+	HasMore bool   `json:"has_more"`
+}
+
+type LogsSvc interface {
+	GetWithContext(ctx context.Context, logId string) (Log, error)
+	Get(logId string) (Log, error)
+	ListWithOptions(ctx context.Context, options *ListOptions) (ListLogsResponse, error)
+	ListWithContext(ctx context.Context) (ListLogsResponse, error)
+	List() (ListLogsResponse, error)
+}
+
+type LogsSvcImpl struct {
+	client *Client
+}
+
+// GetWithContext retrieves a single log entry by ID
+// https://resend.com/docs/api-reference/logs/retrieve-log
+func (s *LogsSvcImpl) GetWithContext(ctx context.Context, logId string) (Log, error) {
+	path := "logs/" + logId
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return Log{}, ErrFailedToCreateLogsGetRequest
+	}
+
+	logResp := new(Log)
+
+	_, err = s.client.Perform(req, logResp)
+	if err != nil {
+		return Log{}, err
+	}
+
+	return *logResp, nil
+}
+
+// Get retrieves a single log entry by ID
+func (s *LogsSvcImpl) Get(logId string) (Log, error) {
+	return s.GetWithContext(context.Background(), logId)
+}
+
+// ListWithOptions lists all logs with pagination options
+// https://resend.com/docs/api-reference/logs/list-logs
+func (s *LogsSvcImpl) ListWithOptions(ctx context.Context, options *ListOptions) (ListLogsResponse, error) {
+	path := "logs" + buildPaginationQuery(options)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return ListLogsResponse{}, ErrFailedToCreateLogsListRequest
+	}
+
+	logsResp := new(ListLogsResponse)
+
+	_, err = s.client.Perform(req, logsResp)
+	if err != nil {
+		return ListLogsResponse{}, err
+	}
+
+	return *logsResp, nil
+}
+
+// ListWithContext lists all logs
+// https://resend.com/docs/api-reference/logs/list-logs
+func (s *LogsSvcImpl) ListWithContext(ctx context.Context) (ListLogsResponse, error) {
+	return s.ListWithOptions(ctx, nil)
+}
+
+// List lists all logs
+func (s *LogsSvcImpl) List() (ListLogsResponse, error) {
+	return s.ListWithContext(context.Background())
+}

--- a/logs_test.go
+++ b/logs_test.go
@@ -1,0 +1,174 @@
+package resend
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLog(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/logs/log_123", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `{
+			"object": "log",
+			"id": "log_123",
+			"created_at": "2026-03-30 13:43:54.622865+00",
+			"endpoint": "/emails",
+			"method": "POST",
+			"response_status": 200,
+			"user_agent": "resend-go/3.2.0",
+			"request_body": {"from": "hello@example.com"},
+			"response_body": {"id": "email_abc"}
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	resp, err := client.Logs.Get("log_123")
+	if err != nil {
+		t.Errorf("Logs.Get returned error: %v", err)
+	}
+	assert.Equal(t, "log", resp.Object)
+	assert.Equal(t, "log_123", resp.Id)
+	assert.Equal(t, "2026-03-30 13:43:54.622865+00", resp.CreatedAt)
+	assert.Equal(t, "/emails", resp.Endpoint)
+	assert.Equal(t, "POST", resp.Method)
+	assert.Equal(t, 200, resp.ResponseStatus)
+	assert.NotNil(t, resp.UserAgent)
+	assert.Equal(t, "resend-go/3.2.0", *resp.UserAgent)
+	assert.NotNil(t, resp.RequestBody)
+	assert.NotNil(t, resp.ResponseBody)
+}
+
+func TestGetLogNullUserAgent(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/logs/log_456", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `{
+			"object": "log",
+			"id": "log_456",
+			"created_at": "2026-03-30 14:00:00.000000+00",
+			"endpoint": "/api-keys",
+			"method": "GET",
+			"response_status": 200,
+			"user_agent": null
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	resp, err := client.Logs.Get("log_456")
+	if err != nil {
+		t.Errorf("Logs.Get returned error: %v", err)
+	}
+	assert.Equal(t, "log_456", resp.Id)
+	assert.Nil(t, resp.UserAgent)
+}
+
+func TestListLogs(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/logs", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `{
+			"object": "list",
+			"has_more": false,
+			"data": [
+				{
+					"id": "log_111",
+					"created_at": "2026-03-30 13:43:54.622865+00",
+					"endpoint": "/emails",
+					"method": "POST",
+					"response_status": 200,
+					"user_agent": "resend-go/3.2.0"
+				},
+				{
+					"id": "log_222",
+					"created_at": "2026-03-29 10:00:00.000000+00",
+					"endpoint": "/domains",
+					"method": "GET",
+					"response_status": 200,
+					"user_agent": null
+				}
+			]
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	resp, err := client.Logs.List()
+	if err != nil {
+		t.Errorf("Logs.List returned error: %v", err)
+	}
+	assert.Equal(t, "list", resp.Object)
+	assert.Equal(t, false, resp.HasMore)
+	assert.Equal(t, 2, len(resp.Data))
+	assert.Equal(t, "log_111", resp.Data[0].Id)
+	assert.Equal(t, "/emails", resp.Data[0].Endpoint)
+	assert.Equal(t, "POST", resp.Data[0].Method)
+	assert.Equal(t, 200, resp.Data[0].ResponseStatus)
+	assert.NotNil(t, resp.Data[0].UserAgent)
+	assert.Equal(t, "resend-go/3.2.0", *resp.Data[0].UserAgent)
+	assert.Equal(t, "log_222", resp.Data[1].Id)
+	assert.Nil(t, resp.Data[1].UserAgent)
+}
+
+func TestListLogsWithOptions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/logs", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+
+		assert.Equal(t, "5", r.URL.Query().Get("limit"))
+		assert.Equal(t, "log_000", r.URL.Query().Get("after"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `{
+			"object": "list",
+			"has_more": true,
+			"data": [
+				{
+					"id": "log_333",
+					"created_at": "2026-03-28 09:00:00.000000+00",
+					"endpoint": "/emails",
+					"method": "POST",
+					"response_status": 422,
+					"user_agent": "resend-node/6.0.3"
+				}
+			]
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	limit := 5
+	after := "log_000"
+	resp, err := client.Logs.ListWithOptions(context.Background(), &ListOptions{
+		Limit: &limit,
+		After: &after,
+	})
+	if err != nil {
+		t.Errorf("Logs.ListWithOptions returned error: %v", err)
+	}
+	assert.Equal(t, true, resp.HasMore)
+	assert.Equal(t, 1, len(resp.Data))
+	assert.Equal(t, "log_333", resp.Data[0].Id)
+	assert.Equal(t, 422, resp.Data[0].ResponseStatus)
+}

--- a/resend.go
+++ b/resend.go
@@ -63,6 +63,7 @@ type Client struct {
 	Templates         TemplatesSvc
 	Topics            TopicsSvc
 	Webhooks          WebhooksSvc
+	Logs              LogsSvc
 }
 
 // NewClient is the default client constructor
@@ -103,6 +104,7 @@ func NewCustomClient(httpClient *http.Client, apiKey string) *Client {
 	c.Templates = &TemplatesSvcImpl{client: c}
 	c.Topics = &TopicsSvcImpl{client: c}
 	c.Webhooks = &WebhooksSvcImpl{client: c}
+	c.Logs = &LogsSvcImpl{client: c}
 
 	c.ApiKey = apiKey
 	c.headers = make(map[string]string)


### PR DESCRIPTION
  Implements GET /logs and GET /logs/{log_id} endpoints.                                         
                                                                                                                                                                                
  - New Logs service on the client (client.Logs.Get, client.Logs.List, client.Logs.ListWithOptions)                                                                          
  - Bumps version to v3.3.0   