### PR TITLE
chore: bump version to 3.4.0

### DIFF
--- a/resend.go
+++ b/resend.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version     = "3.3.0"
+	version     = "3.4.0"
 	userAgent   = "resend-go/" + version
 	contentType = "application/json"
 )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump SDK version to 3.4.0 to prepare the release and update the `resend-go` User-Agent header.

<sup>Written for commit 9c06c2dd729c71baf3270ffd508473a62487e34d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

