### PR TITLE
feat(domains): add TrackingCAA record support

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -14,6 +14,15 @@ const (
 	Opportunistic TlsOption = "opportunistic"
 )
 
+type RecordType = string
+
+const (
+	RecordTypeSPF         RecordType = "SPF"
+	RecordTypeDKIM        RecordType = "DKIM"
+	RecordTypeTracking    RecordType = "Tracking"
+	RecordTypeTrackingCAA RecordType = "TrackingCAA"
+)
+
 type DomainsSvc interface {
 	CreateWithContext(ctx context.Context, params *CreateDomainRequest) (CreateDomainResponse, error)
 	Create(params *CreateDomainRequest) (CreateDomainResponse, error)
@@ -81,7 +90,7 @@ type Domain struct {
 }
 
 type Record struct {
-	Record   string      `json:"record"`
+	Record   RecordType  `json:"record"`
 	Name     string      `json:"name"`
 	Type     string      `json:"type"`
 	Ttl      string      `json:"ttl"`

--- a/domains_test.go
+++ b/domains_test.go
@@ -262,6 +262,14 @@ func TestCreateDomainWithTrackingSubdomain(t *testing.T) {
 					"type": "CNAME",
 					"ttl": "Auto",
 					"status": "not_started"
+				},
+				{
+					"record": "TrackingCAA",
+					"name": "",
+					"value": "0 issue \"amazon.com\"",
+					"type": "CAA",
+					"ttl": "Auto",
+					"status": "not_started"
 				}
 			]
 		}`)
@@ -280,12 +288,17 @@ func TestCreateDomainWithTrackingSubdomain(t *testing.T) {
 	assert.True(t, resp.OpenTracking)
 	assert.True(t, resp.ClickTracking)
 	assert.Equal(t, resp.TrackingSubdomain, "links")
-	assert.Equal(t, len(resp.Records), 2)
+	assert.Equal(t, len(resp.Records), 3)
 	assert.Equal(t, resp.Records[1].Record, "Tracking")
 	assert.Equal(t, resp.Records[1].Name, "links.example.com")
 	assert.Equal(t, resp.Records[1].Value, "links1.resend-dns.com")
 	assert.Equal(t, resp.Records[1].Type, "CNAME")
 	assert.Equal(t, resp.Records[1].Priority, json.Number(""))
+	assert.Equal(t, resp.Records[2].Record, "TrackingCAA")
+	assert.Equal(t, resp.Records[2].Name, "")
+	assert.Equal(t, resp.Records[2].Value, "0 issue \"amazon.com\"")
+	assert.Equal(t, resp.Records[2].Type, "CAA")
+	assert.Equal(t, resp.Records[2].Ttl, "Auto")
 }
 
 func TestGetDomainWithTrackingFields(t *testing.T) {
@@ -319,6 +332,14 @@ func TestGetDomainWithTrackingFields(t *testing.T) {
 					"type": "CNAME",
 					"ttl": "Auto",
 					"status": "not_started"
+				},
+				{
+					"record": "TrackingCAA",
+					"name": "",
+					"value": "0 issue \"amazon.com\"",
+					"type": "CAA",
+					"ttl": "Auto",
+					"status": "verified"
 				}
 			]
 		}`)
@@ -332,6 +353,10 @@ func TestGetDomainWithTrackingFields(t *testing.T) {
 	assert.True(t, domain.OpenTracking)
 	assert.True(t, domain.ClickTracking)
 	assert.Equal(t, domain.TrackingSubdomain, "links")
+	assert.Equal(t, len(domain.Records), 3)
+	assert.Equal(t, domain.Records[2].Record, "TrackingCAA")
+	assert.Equal(t, domain.Records[2].Type, "CAA")
+	assert.Equal(t, domain.Records[2].Value, "0 issue \"amazon.com\"")
 }
 
 func TestUpdateDomainWithTrackingSubdomain(t *testing.T) {

--- a/domains_test.go
+++ b/domains_test.go
@@ -92,7 +92,7 @@ func TestCreateDomain(t *testing.T) {
 	assert.NotNil(t, resp.Records)
 	assert.Equal(t, len(resp.Records), 5)
 
-	assert.Equal(t, resp.Records[0].Record, "SPF")
+	assert.Equal(t, resp.Records[0].Record, RecordTypeSPF)
 	assert.Equal(t, resp.Records[0].Name, "bounces")
 	assert.Equal(t, resp.Records[0].Type, "MX")
 	assert.Equal(t, resp.Records[0].Ttl, "Auto")
@@ -162,7 +162,7 @@ func TestListDomains(t *testing.T) {
 	assert.Equal(t, domains.Data[0].Status, "not_started")
 	assert.Equal(t, domains.Data[0].CreatedAt, "2023-04-26T20:21:26.347412+00:00")
 	assert.Equal(t, domains.Data[0].Region, "us-east-1")
-	assert.Equal(t, domains.Data[0].Records[0].Record, "SPF")
+	assert.Equal(t, domains.Data[0].Records[0].Record, RecordTypeSPF)
 }
 
 func TestRemoveDomain(t *testing.T) {
@@ -222,7 +222,7 @@ func TestGetDomain(t *testing.T) {
 	assert.Equal(t, domain.Status, "not_started")
 	assert.Equal(t, domain.CreatedAt, "2023-04-26T20:21:26.347412+00:00")
 	assert.Equal(t, domain.Region, "us-east-1")
-	assert.Equal(t, domain.Records[0].Record, "SPF")
+	assert.Equal(t, domain.Records[0].Record, RecordTypeSPF)
 	assert.Equal(t, domain.Records[0].Name, "bounces")
 }
 
@@ -289,11 +289,12 @@ func TestCreateDomainWithTrackingSubdomain(t *testing.T) {
 	assert.True(t, resp.ClickTracking)
 	assert.Equal(t, resp.TrackingSubdomain, "links")
 	assert.Equal(t, len(resp.Records), 3)
-	assert.Equal(t, resp.Records[1].Record, "Tracking")
+	assert.Equal(t, resp.Records[1].Record, RecordTypeTracking)
 	assert.Equal(t, resp.Records[1].Name, "links.example.com")
 	assert.Equal(t, resp.Records[1].Value, "links1.resend-dns.com")
 	assert.Equal(t, resp.Records[1].Type, "CNAME")
 	assert.Equal(t, resp.Records[1].Priority, json.Number(""))
+	assert.Equal(t, resp.Records[2].Record, RecordTypeTrackingCAA)
 	assert.Equal(t, resp.Records[2].Record, "TrackingCAA")
 	assert.Equal(t, resp.Records[2].Name, "")
 	assert.Equal(t, resp.Records[2].Value, "0 issue \"amazon.com\"")
@@ -354,7 +355,7 @@ func TestGetDomainWithTrackingFields(t *testing.T) {
 	assert.True(t, domain.ClickTracking)
 	assert.Equal(t, domain.TrackingSubdomain, "links")
 	assert.Equal(t, len(domain.Records), 3)
-	assert.Equal(t, domain.Records[2].Record, "TrackingCAA")
+	assert.Equal(t, domain.Records[2].Record, RecordTypeTrackingCAA)
 	assert.Equal(t, domain.Records[2].Type, "CAA")
 	assert.Equal(t, domain.Records[2].Value, "0 issue \"amazon.com\"")
 }

--- a/resend.go
+++ b/resend.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version     = "3.4.0"
+	version     = "3.4.1"
 	userAgent   = "resend-go/" + version
 	contentType = "application/json"
 )


### PR DESCRIPTION
## Summary

The Domains API now returns an additional DNS record on `POST /domains` and `GET /domains/:id` responses when:

1. A `tracking_subdomain` is configured on the domain, AND
2. The customer's root domain has CAA records that would otherwise prevent AWS from issuing a TLS certificate.

The new record looks like:

```json
{
  "record": "TrackingCAA",
  "name": "",
  "type": "CAA",
  "ttl": "Auto",
  "value": "0 issue \"amazon.com\"",
  "status": "verified"
}
```

The Go SDK's `Record` struct already accepts arbitrary string `record` values, so no source change is required. This PR only extends the test fixtures (and assertions) for the create-with-tracking-subdomain and get-with-tracking-fields cases so the SDK exercises the new record shape end-to-end.

## Test plan

- [x] `go test ./...` passes locally
- [x] New fixture round-trips through `Record` cleanly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add coverage for the `TrackingCAA` DNS record when a tracking subdomain is set on domains with restrictive CAA, and introduce type-safe record identifiers via `RecordType`. Bumps the SDK to 3.4.1.

- **New Features**
  - Added `TrackingCAA` to create/get fixtures; assert type `CAA`, value `0 issue "amazon.com"`, ttl `Auto`, and updated record counts.

- **Refactors**
  - Introduced `RecordType` with constants (`RecordTypeSPF`, `RecordTypeDKIM`, `RecordTypeTracking`, `RecordTypeTrackingCAA`) and updated `Record.Record` to use it.
  - Replaced string literals in tests with constants; bumped version to 3.4.1.

<sup>Written for commit bf9e31e73aa724b053ece5bde7ea6c72f809997d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

