### PR TITLE
feat(domains): add OpenTracking and ClickTracking to CreateDomainRequest

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -48,6 +48,8 @@ type CreateDomainRequest struct {
 	Region            string `json:"region,omitempty"`
 	CustomReturnPath  string `json:"custom_return_path,omitempty"`
 	TrackingSubdomain string `json:"tracking_subdomain,omitempty"`
+	OpenTracking      bool   `json:"open_tracking,omitempty"`
+	ClickTracking     bool   `json:"click_tracking,omitempty"`
 }
 
 type CreateDomainResponse struct {

--- a/domains.go
+++ b/domains.go
@@ -48,8 +48,8 @@ type CreateDomainRequest struct {
 	Region            string `json:"region,omitempty"`
 	CustomReturnPath  string `json:"custom_return_path,omitempty"`
 	TrackingSubdomain string `json:"tracking_subdomain,omitempty"`
-	OpenTracking      bool   `json:"open_tracking,omitempty"`
-	ClickTracking     bool   `json:"click_tracking,omitempty"`
+	OpenTracking      *bool  `json:"open_tracking,omitempty"`
+	ClickTracking     *bool  `json:"click_tracking,omitempty"`
 }
 
 type CreateDomainResponse struct {
@@ -76,6 +76,39 @@ type UpdateDomainRequest struct {
 	ClickTracking     bool      `json:"click_tracking,omitempty"`
 	Tls               TlsOption `json:"tls,omitempty"`
 	TrackingSubdomain string    `json:"tracking_subdomain,omitempty"`
+	openTrackingSet   bool      `json:"-"`
+	clickTrackingSet  bool      `json:"-"`
+}
+
+// SetOpenTracking explicitly sets the open_tracking field, allowing false to be sent.
+// Setting OpenTracking directly on the struct does not send false due to omitempty.
+func (r *UpdateDomainRequest) SetOpenTracking(val bool) {
+	r.OpenTracking = val
+	r.openTrackingSet = true
+}
+
+// SetClickTracking explicitly sets the click_tracking field, allowing false to be sent.
+// Setting ClickTracking directly on the struct does not send false due to omitempty.
+func (r *UpdateDomainRequest) SetClickTracking(val bool) {
+	r.ClickTracking = val
+	r.clickTrackingSet = true
+}
+
+func (r UpdateDomainRequest) MarshalJSON() ([]byte, error) {
+	aux := make(map[string]any)
+	if r.openTrackingSet || r.OpenTracking {
+		aux["open_tracking"] = r.OpenTracking
+	}
+	if r.clickTrackingSet || r.ClickTracking {
+		aux["click_tracking"] = r.ClickTracking
+	}
+	if r.Tls != "" {
+		aux["tls"] = r.Tls
+	}
+	if r.TrackingSubdomain != "" {
+		aux["tracking_subdomain"] = r.TrackingSubdomain
+	}
+	return json.Marshal(aux)
 }
 
 type Domain struct {

--- a/domains_test.go
+++ b/domains_test.go
@@ -279,8 +279,8 @@ func TestCreateDomainWithTrackingSubdomain(t *testing.T) {
 		Name:              "example.com",
 		Region:            "us-east-1",
 		TrackingSubdomain: "links",
-		OpenTracking:      true,
-		ClickTracking:     true,
+		OpenTracking:      Bool(true),
+		ClickTracking:     Bool(true),
 	}
 	resp, err := client.Domains.Create(req)
 	if err != nil {
@@ -379,6 +379,42 @@ func TestUpdateDomainWithTrackingSubdomain(t *testing.T) {
 	params := &UpdateDomainRequest{
 		TrackingSubdomain: "links",
 	}
+	updated, err := client.Domains.Update("d91cd9bd-1176-453e-8fc1-35364d380206", params)
+	if err != nil {
+		t.Errorf("Domains.Update returned error: %v", err)
+	}
+	assert.Equal(t, updated.Id, "d91cd9bd-1176-453e-8fc1-35364d380206")
+}
+
+func TestUpdateDomainSetTrackingToFalse(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/domains/d91cd9bd-1176-453e-8fc1-35364d380206", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		// Both fields must be present and false in the payload
+		openTracking, ok := body["open_tracking"]
+		assert.True(t, ok, "open_tracking should be present in payload")
+		assert.Equal(t, false, openTracking)
+
+		clickTracking, ok := body["click_tracking"]
+		assert.True(t, ok, "click_tracking should be present in payload")
+		assert.Equal(t, false, clickTracking)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id": "d91cd9bd-1176-453e-8fc1-35364d380206", "object": "domain"}`)
+	})
+
+	params := &UpdateDomainRequest{}
+	params.SetOpenTracking(false)
+	params.SetClickTracking(false)
+
 	updated, err := client.Domains.Update("d91cd9bd-1176-453e-8fc1-35364d380206", params)
 	if err != nil {
 		t.Errorf("Domains.Update returned error: %v", err)

--- a/domains_test.go
+++ b/domains_test.go
@@ -279,6 +279,8 @@ func TestCreateDomainWithTrackingSubdomain(t *testing.T) {
 		Name:              "example.com",
 		Region:            "us-east-1",
 		TrackingSubdomain: "links",
+		OpenTracking:      true,
+		ClickTracking:     true,
 	}
 	resp, err := client.Domains.Create(req)
 	if err != nil {

--- a/domains_test.go
+++ b/domains_test.go
@@ -295,7 +295,6 @@ func TestCreateDomainWithTrackingSubdomain(t *testing.T) {
 	assert.Equal(t, resp.Records[1].Type, "CNAME")
 	assert.Equal(t, resp.Records[1].Priority, json.Number(""))
 	assert.Equal(t, resp.Records[2].Record, RecordTypeTrackingCAA)
-	assert.Equal(t, resp.Records[2].Record, "TrackingCAA")
 	assert.Equal(t, resp.Records[2].Name, "")
 	assert.Equal(t, resp.Records[2].Value, "0 issue \"amazon.com\"")
 	assert.Equal(t, resp.Records[2].Type, "CAA")

--- a/resend.go
+++ b/resend.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version     = "3.4.1"
+	version     = "3.5.0"
 	userAgent   = "resend-go/" + version
 	contentType = "application/json"
 )

--- a/utils.go
+++ b/utils.go
@@ -14,6 +14,12 @@ func BytesToIntArray(a []byte) []int {
 	return res
 }
 
+// Bool returns a pointer to the given bool value.
+// Use this to set *bool fields on request structs.
+func Bool(v bool) *bool {
+	return &v
+}
+
 func getEnv(key, df string) string {
 	if value, ok := os.LookupEnv(key); ok {
 		return value


### PR DESCRIPTION
## Summary
- Add `OpenTracking` and `ClickTracking` fields to `CreateDomainRequest`, allowing these to be set at domain creation time instead of requiring a separate update call
- Update test to exercise the new create params

> **Note:** This branch also includes the TrackingCAA record commit from `feat/tracking-caa-record`.

## Test plan
- [x] `go test -run TestCreateDomain -v` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add open and click tracking options to domain creation via `*bool` and a `Bool` helper, and fix updates so false values are sent. Tests cover these fields, false-update payloads, and the new `TrackingCAA` DNS record when a tracking subdomain is set and root CAA would block AWS; version bumped to 3.5.0.

- **Bug Fixes**
  - `UpdateDomainRequest` adds `SetOpenTracking`/`SetClickTracking` and custom JSON marshalling to include false values in PATCH payloads.

<sup>Written for commit 094cf86539ad9f8999442c5c096f61be2e82c232. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

