### PR TITLE
feat(webhooks): add missing webhook email event types

### DIFF
--- a/webhooks.go
+++ b/webhooks.go
@@ -25,6 +25,7 @@ const (
 	EventEmailClicked         = "email.clicked"
 	EventEmailReceived        = "email.received"
 	EventEmailFailed          = "email.failed"
+	EventEmailScheduled       = "email.scheduled"
 	EventEmailSuppressed      = "email.suppressed"
 
 	// Contact events

--- a/webhooks.go
+++ b/webhooks.go
@@ -25,6 +25,7 @@ const (
 	EventEmailClicked         = "email.clicked"
 	EventEmailReceived        = "email.received"
 	EventEmailFailed          = "email.failed"
+	EventEmailSuppressed      = "email.suppressed"
 
 	// Contact events
 	EventContactCreated = "contact.created"


### PR DESCRIPTION
## Summary
  - Add email.suppressed (https://resend.com/docs/webhooks/emails/suppressed)
  - Add email.scheduled  (https://resend.com/docs/webhooks/emails/scheduled)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing Resend webhook email events email.scheduled and email.suppressed so apps can handle scheduled and suppressed notifications. Aligns our event constants with the latest Resend webhook docs.

<sup>Written for commit 26c83684cd52c5c615b1aa3d6fd8d6e44c77dfe6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

