### PR TITLE
feat(domains): add DomainStatus and DomainRecordStatus typed constants

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -23,6 +23,26 @@ const (
 	RecordTypeTrackingCAA RecordType = "TrackingCAA"
 )
 
+type DomainStatus = string
+
+const (
+	DomainStatusPending           DomainStatus = "pending"
+	DomainStatusVerified          DomainStatus = "verified"
+	DomainStatusFailed            DomainStatus = "failed"
+	DomainStatusNotStarted        DomainStatus = "not_started"
+	DomainStatusPartiallyVerified DomainStatus = "partially_verified"
+	DomainStatusPartiallyFailed   DomainStatus = "partially_failed"
+)
+
+type DomainRecordStatus = string
+
+const (
+	DomainRecordStatusPending    DomainRecordStatus = "pending"
+	DomainRecordStatusVerified   DomainRecordStatus = "verified"
+	DomainRecordStatusFailed     DomainRecordStatus = "failed"
+	DomainRecordStatusNotStarted DomainRecordStatus = "not_started"
+)
+
 type DomainsSvc interface {
 	CreateWithContext(ctx context.Context, params *CreateDomainRequest) (CreateDomainResponse, error)
 	Create(params *CreateDomainRequest) (CreateDomainResponse, error)

--- a/domains.go
+++ b/domains.go
@@ -37,10 +37,11 @@ const (
 type DomainRecordStatus = string
 
 const (
-	DomainRecordStatusPending    DomainRecordStatus = "pending"
-	DomainRecordStatusVerified   DomainRecordStatus = "verified"
-	DomainRecordStatusFailed     DomainRecordStatus = "failed"
-	DomainRecordStatusNotStarted DomainRecordStatus = "not_started"
+	DomainRecordStatusPending         DomainRecordStatus = "pending"
+	DomainRecordStatusVerified        DomainRecordStatus = "verified"
+	DomainRecordStatusFailed          DomainRecordStatus = "failed"
+	DomainRecordStatusTemporaryFailed DomainRecordStatus = "temporary_failure"
+	DomainRecordStatusNotStarted      DomainRecordStatus = "not_started"
 )
 
 type DomainsSvc interface {

--- a/domains_test.go
+++ b/domains_test.go
@@ -226,6 +226,99 @@ func TestGetDomain(t *testing.T) {
 	assert.Equal(t, domain.Records[0].Name, "bounces")
 }
 
+func TestGetDomainPartiallyVerified(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/domains/fd61172c-cafc-40f5-b049-b45947779a29", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"object": "domain",
+			"id": "fd61172c-cafc-40f5-b049-b45947779a29",
+			"name": "resend.com",
+			"status": "partially_verified",
+			"created_at": "2023-06-21T06:10:36.144Z",
+			"region": "us-east-1",
+			"records": [
+				{
+					"record": "DKIM",
+					"name": "resend._domainkey",
+					"value": "p=MIG...",
+					"type": "TXT",
+					"status": "verified",
+					"ttl": "Auto"
+				},
+				{
+					"record": "Tracking",
+					"name": "track.resend.com",
+					"value": "tracking.resend.com",
+					"type": "CNAME",
+					"ttl": "Auto",
+					"status": "pending"
+				}
+			]
+		}`)
+	})
+
+	domain, err := client.Domains.Get("fd61172c-cafc-40f5-b049-b45947779a29")
+	if err != nil {
+		t.Errorf("Domains.Get returned error: %v", err)
+	}
+
+	assert.Equal(t, domain.Status, DomainStatusPartiallyVerified)
+	assert.Equal(t, domain.Records[0].Status, DomainRecordStatusVerified)
+	assert.Equal(t, domain.Records[1].Status, DomainRecordStatusPending)
+}
+
+func TestGetDomainPartiallyFailed(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/domains/fd61172c-cafc-40f5-b049-b45947779a30", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"object": "domain",
+			"id": "fd61172c-cafc-40f5-b049-b45947779a30",
+			"name": "resend.com",
+			"status": "partially_failed",
+			"created_at": "2023-06-21T06:10:36.144Z",
+			"region": "us-east-1",
+			"records": [
+				{
+					"record": "DKIM",
+					"name": "resend._domainkey",
+					"value": "p=MIG...",
+					"type": "TXT",
+					"status": "verified",
+					"ttl": "Auto"
+				},
+				{
+					"record": "Receiving",
+					"name": "resend.com",
+					"value": "inbound-mx.resend.com",
+					"type": "MX",
+					"ttl": "Auto",
+					"status": "failed",
+					"priority": 10
+				}
+			]
+		}`)
+	})
+
+	domain, err := client.Domains.Get("fd61172c-cafc-40f5-b049-b45947779a30")
+	if err != nil {
+		t.Errorf("Domains.Get returned error: %v", err)
+	}
+
+	assert.Equal(t, domain.Status, DomainStatusPartiallyFailed)
+	assert.Equal(t, domain.Records[0].Status, DomainRecordStatusVerified)
+	assert.Equal(t, domain.Records[1].Status, DomainRecordStatusFailed)
+}
+
 func TestCreateDomainWithTrackingSubdomain(t *testing.T) {
 	setup()
 	defer teardown()

--- a/resend.go
+++ b/resend.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version     = "3.5.0"
+	version     = "3.6.0"
 	userAgent   = "resend-go/" + version
 	contentType = "application/json"
 )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `DomainStatus` and `DomainRecordStatus` typed constants to standardize domain and record verification states, including partial and temporary failure statuses. Bumps version to 3.6.0.

- **New Features**
  - Adds `DomainStatus`: `pending`, `verified`, `failed`, `not_started`, `partially_verified`, `partially_failed`.
  - Adds `DomainRecordStatus`: `pending`, `verified`, `failed`, `temporary_failure`, `not_started`.
  - Extends tests for partial domain statuses and record-level statuses.

<sup>Written for commit ee1f269e4a5b2c29564bc36692efa2a4452ca2d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

