### PR TITLE
chore: gh actions hardening

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,10 +9,14 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         go:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,10 +25,10 @@ jobs:
           - "1.21"
     name: "Test: go v${{ matrix.go }}"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ matrix.go }}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened the `resend-go` CI by adding top‑level `permissions: contents: read`, setting a 10‑minute timeout for the build job, and pinning GitHub Actions to commit SHAs to reduce supply‑chain risk. Addresses DEV-656 (MED: top‑level permissions; LOW: missing `timeout-minutes`).

- **Dependencies**
  - Pinned `actions/checkout` (v3) to a specific commit SHA.
  - Pinned `actions/setup-go` (v5) to a specific commit SHA.

<sup>Written for commit 9192f40910d599a8c81d5988dd744fcdcdf33659. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

