### PR TITLE
feat(domains): add Capabilities to CreateDomainRequest

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -64,13 +64,19 @@ type DomainsSvcImpl struct {
 	client *Client
 }
 
+type DomainCapabilities struct {
+	Sending   string `json:"sending,omitempty"`
+	Receiving string `json:"receiving,omitempty"`
+}
+
 type CreateDomainRequest struct {
-	Name              string `json:"name"`
-	Region            string `json:"region,omitempty"`
-	CustomReturnPath  string `json:"custom_return_path,omitempty"`
-	TrackingSubdomain string `json:"tracking_subdomain,omitempty"`
-	OpenTracking      *bool  `json:"open_tracking,omitempty"`
-	ClickTracking     *bool  `json:"click_tracking,omitempty"`
+	Name              string              `json:"name"`
+	Region            string              `json:"region,omitempty"`
+	CustomReturnPath  string              `json:"custom_return_path,omitempty"`
+	TrackingSubdomain string              `json:"tracking_subdomain,omitempty"`
+	OpenTracking      *bool               `json:"open_tracking,omitempty"`
+	ClickTracking     *bool               `json:"click_tracking,omitempty"`
+	Capabilities      *DomainCapabilities `json:"capabilities,omitempty"`
 }
 
 type CreateDomainResponse struct {

--- a/domains.go
+++ b/domains.go
@@ -64,9 +64,16 @@ type DomainsSvcImpl struct {
 	client *Client
 }
 
+type DomainCapabilityStatus = string
+
+const (
+	DomainCapabilityStatusEnabled  DomainCapabilityStatus = "enabled"
+	DomainCapabilityStatusDisabled DomainCapabilityStatus = "disabled"
+)
+
 type DomainCapabilities struct {
-	Sending   string `json:"sending,omitempty"`
-	Receiving string `json:"receiving,omitempty"`
+	Sending   DomainCapabilityStatus `json:"sending,omitempty"`
+	Receiving DomainCapabilityStatus `json:"receiving,omitempty"`
 }
 
 type CreateDomainRequest struct {

--- a/domains_test.go
+++ b/domains_test.go
@@ -136,8 +136,8 @@ func TestCreateDomainWithCapabilities(t *testing.T) {
 		Name:   "example.com",
 		Region: "us-east-1",
 		Capabilities: &DomainCapabilities{
-			Sending:   "enabled",
-			Receiving: "enabled",
+			Sending:   DomainCapabilityStatusEnabled,
+			Receiving: DomainCapabilityStatusEnabled,
 		},
 	}
 	resp, err := client.Domains.Create(req)

--- a/domains_test.go
+++ b/domains_test.go
@@ -103,6 +103,87 @@ func TestCreateDomain(t *testing.T) {
 	assert.Equal(t, resp.Records[1].Priority, json.Number(""))
 }
 
+func TestCreateDomainWithCapabilities(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/domains", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		capabilities, ok := body["capabilities"].(map[string]any)
+		assert.True(t, ok, "capabilities should be present in payload as an object")
+		assert.Equal(t, "enabled", capabilities["sending"])
+		assert.Equal(t, "enabled", capabilities["receiving"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprint(w, `{
+			"id": "4dd369bc-aa82-4ff3-97de-514ae3000ee0",
+			"name": "example.com",
+			"createdAt": "2023-03-28T17:12:02.059593+00:00",
+			"status": "not_started",
+			"region": "us-east-1",
+			"dnsProvider": "Unidentified"
+		}`)
+	})
+
+	req := &CreateDomainRequest{
+		Name:   "example.com",
+		Region: "us-east-1",
+		Capabilities: &DomainCapabilities{
+			Sending:   "enabled",
+			Receiving: "enabled",
+		},
+	}
+	resp, err := client.Domains.Create(req)
+	if err != nil {
+		t.Errorf("Domains.Create returned error: %v", err)
+	}
+	assert.Equal(t, resp.Id, "4dd369bc-aa82-4ff3-97de-514ae3000ee0")
+}
+
+func TestCreateDomainWithoutCapabilitiesOmitsKey(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/domains", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		_, present := body["capabilities"]
+		assert.False(t, present, "capabilities should be omitted when not set")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprint(w, `{
+			"id": "4dd369bc-aa82-4ff3-97de-514ae3000ee0",
+			"name": "example.com",
+			"createdAt": "2023-03-28T17:12:02.059593+00:00",
+			"status": "not_started",
+			"region": "us-east-1",
+			"dnsProvider": "Unidentified"
+		}`)
+	})
+
+	req := &CreateDomainRequest{
+		Name:   "example.com",
+		Region: "us-east-1",
+	}
+	_, err := client.Domains.Create(req)
+	if err != nil {
+		t.Errorf("Domains.Create returned error: %v", err)
+	}
+}
+
 func TestVerifyDomain(t *testing.T) {
 	setup()
 	defer teardown()

--- a/resend.go
+++ b/resend.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version     = "3.6.0"
+	version     = "3.7.0"
 	userAgent   = "resend-go/" + version
 	contentType = "application/json"
 )


### PR DESCRIPTION
## Summary
- Add a typed `DomainCapabilities` struct and `Capabilities *DomainCapabilities` field on `CreateDomainRequest`, allowing callers to enable `sending` and `receiving` at domain creation time instead of falling back to raw HTTP.
- Backwards compatible: `omitempty` + pointer ensures requests that don't set `Capabilities` serialize exactly as before.
- Mirrors the existing pattern used by `OpenTracking` / `ClickTracking` (PR #111) — request-only field, no change to the response/`Domain` types (consistent with how nested objects like `Template` on `SendEmailRequest` are handled today; happy to extend to the response if preferred).

## Example
```go
resend.CreateDomainRequest{
    Name: "inbox.example.com",
    Capabilities: &resend.DomainCapabilities{
        Sending:   "enabled",
        Receiving: "enabled",
    },
}
```

API reference: https://resend.com/docs/api-reference/domains/create-domain

## Test plan
- [x] `go test ./...` — all tests pass, including two new ones:
  - `TestCreateDomainWithCapabilities` — asserts the request body includes `capabilities.sending` and `capabilities.receiving`.
  - `TestCreateDomainWithoutCapabilitiesOmitsKey` — asserts the `capabilities` key is absent when not set.
- [x] `gofmt -l .` clean on changed files.
- [x] `go vet ./...` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `DomainCapabilities` to `CreateDomainRequest` to enable `sending` and `receiving` at creation; backward compatible via an `omitempty` pointer. Introduce typed `DomainCapabilityStatus` (`DomainCapabilityStatusEnabled`/`Disabled`) and bump client version to `3.7.0`.

<sup>Written for commit d500ba5b5a869336fad9c252122b7e16b771ab86. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/resend-go/pull/115?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

