### PR TITLE
feat(emails): add Headers to Email response from Get

### DIFF
--- a/emails.go
+++ b/emails.go
@@ -66,18 +66,19 @@ type UpdateEmailResponse struct {
 
 // Email provides the structure for the response from the Get call.
 type Email struct {
-	Id        string   `json:"id"`
-	Object    string   `json:"object"`
-	To        []string `json:"to"`
-	From      string   `json:"from"`
-	CreatedAt string   `json:"created_at"`
-	Subject   string   `json:"subject"`
-	Html      string   `json:"html"`
-	Text      string   `json:"text"`
-	Bcc       []string `json:"bcc"`
-	Cc        []string `json:"cc"`
-	ReplyTo   []string `json:"reply_to"`
-	LastEvent string   `json:"last_event"`
+	Id        string            `json:"id"`
+	Object    string            `json:"object"`
+	To        []string          `json:"to"`
+	From      string            `json:"from"`
+	CreatedAt string            `json:"created_at"`
+	Subject   string            `json:"subject"`
+	Html      string            `json:"html"`
+	Text      string            `json:"text"`
+	Bcc       []string          `json:"bcc"`
+	Cc        []string          `json:"cc"`
+	ReplyTo   []string          `json:"reply_to"`
+	Headers   map[string]string `json:"headers"`
+	LastEvent string            `json:"last_event"`
 }
 
 // ListEmailsResponse is the response from the List call.

--- a/emails_test.go
+++ b/emails_test.go
@@ -280,7 +280,11 @@ func TestGetEmail(t *testing.T) {
 			"to":["james@bond.com"],
 			"created_at":"2023-04-03T22:13:42.674981+00:00",
 			"subject": "Hello World",
-			"html":"html"
+			"html":"html",
+			"headers": {
+				"Message-ID": "<test-message-id@example.com>",
+				"X-Custom-Header": "value"
+			}
 		}`
 		fmt.Fprintf(w, ret)
 	})
@@ -294,6 +298,9 @@ func TestGetEmail(t *testing.T) {
 	assert.Equal(t, resp.Html, "html")
 	assert.Equal(t, resp.To[0], "james@bond.com")
 	assert.Equal(t, resp.Subject, "Hello World")
+	assert.Equal(t, 2, len(resp.Headers))
+	assert.Equal(t, "<test-message-id@example.com>", resp.Headers["Message-ID"])
+	assert.Equal(t, "value", resp.Headers["X-Custom-Header"])
 }
 
 func TestCancelScheduledEmail(t *testing.T) {


### PR DESCRIPTION
## Summary

Surface email headers from `GET /emails/:id` on the `Email` response struct. The API already returns `headers` in the response body, but the SDK omits the field, so callers can't read threading headers (`Message-ID`, `In-Reply-To`, `References`) for sent emails.

## Why

For applications that thread inbound replies back to the sent email that started the conversation, the SES-rewritten `Message-ID` (e.g. `<…@email.amazonses.com>`) is the only header the recipient's MUA quotes in `In-Reply-To`. Without `Headers` on `Email`, there's no way to capture that Message-ID via the SDK after a send — forcing consumers to make raw HTTP calls.

This change mirrors the existing `ReceivedEmail.Headers` field in [`receiving.go`](https://github.com/resend/resend-go/blob/main/receiving.go), so the pattern is already accepted on the inbound side. The PR just brings the outbound `Email` struct in line.

## Changes

- Add `Headers map[string]string` to `Email` in `emails.go`
- Extend `TestGetEmail` in `emails_test.go` to assert the new field, mirroring the assertions in `TestGetReceivedEmail`

## Note for Resend maintainers

The `headers` field is returned by `GET /emails/:id` in production today (verified against live API responses), but it's **not listed in the public [retrieve-email docs](https://resend.com/docs/api-reference/emails/retrieve-email)**. It would be great to formally document this field alongside this SDK change — both to give other API consumers a paved path and to commit to the field's stability. Happy to also open a docs PR if helpful.

## Test plan

- [x] `go test ./...` passes
- [x] No breaking changes — new field is additive