### PR TITLE
feat(domains): add capabilities to Domain and CreateDomainResponse structs

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -94,9 +94,10 @@ type CreateDomainResponse struct {
 	Records           []Record `json:"records"`
 	Region            string   `json:"region"`
 	DnsProvider       string   `json:"dnsProvider"`
-	OpenTracking      bool     `json:"open_tracking,omitempty"`
-	ClickTracking     bool     `json:"click_tracking,omitempty"`
-	TrackingSubdomain string   `json:"tracking_subdomain,omitempty"`
+	OpenTracking      bool                `json:"open_tracking,omitempty"`
+	ClickTracking     bool                `json:"click_tracking,omitempty"`
+	TrackingSubdomain string              `json:"tracking_subdomain,omitempty"`
+	Capabilities      *DomainCapabilities `json:"capabilities,omitempty"`
 }
 
 type ListDomainsResponse struct {
@@ -153,9 +154,10 @@ type Domain struct {
 	Status            string   `json:"status,omitempty"`
 	Region            string   `json:"region,omitempty"`
 	Records           []Record `json:"records,omitempty"`
-	OpenTracking      bool     `json:"open_tracking,omitempty"`
-	ClickTracking     bool     `json:"click_tracking,omitempty"`
-	TrackingSubdomain string   `json:"tracking_subdomain,omitempty"`
+	OpenTracking      bool                `json:"open_tracking,omitempty"`
+	ClickTracking     bool                `json:"click_tracking,omitempty"`
+	TrackingSubdomain string              `json:"tracking_subdomain,omitempty"`
+	Capabilities      *DomainCapabilities `json:"capabilities,omitempty"`
 }
 
 type Record struct {

--- a/domains_test.go
+++ b/domains_test.go
@@ -184,6 +184,38 @@ func TestCreateDomainWithoutCapabilitiesOmitsKey(t *testing.T) {
 	}
 }
 
+func TestCreateDomainResponseDeserializesCapabilities(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/domains", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{
+			"id": "4dd369bc-aa82-4ff3-97de-514ae3000ee0",
+			"name": "example.com",
+			"createdAt": "2023-03-28T17:12:02.059593+00:00",
+			"status": "not_started",
+			"region": "us-east-1",
+			"dnsProvider": "Unidentified",
+			"capabilities": {
+				"sending": "enabled",
+				"receiving": "disabled"
+			}
+		}`)
+	})
+
+	req := &CreateDomainRequest{Name: "example.com"}
+	resp, err := client.Domains.Create(req)
+	if err != nil {
+		t.Errorf("Domains.Create returned error: %v", err)
+	}
+	assert.NotNil(t, resp.Capabilities)
+	assert.Equal(t, DomainCapabilityStatusEnabled, resp.Capabilities.Sending)
+	assert.Equal(t, DomainCapabilityStatusDisabled, resp.Capabilities.Receiving)
+}
+
 func TestVerifyDomain(t *testing.T) {
 	setup()
 	defer teardown()
@@ -305,6 +337,37 @@ func TestGetDomain(t *testing.T) {
 	assert.Equal(t, domain.Region, "us-east-1")
 	assert.Equal(t, domain.Records[0].Record, RecordTypeSPF)
 	assert.Equal(t, domain.Records[0].Name, "bounces")
+}
+
+func TestGetDomainDeserializesCapabilities(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/domains/d91cd9bd-1176-453e-8fc1-35364d380206", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"object": "domain",
+			"id": "d91cd9bd-1176-453e-8fc1-35364d380206",
+			"name": "example.com",
+			"status": "not_started",
+			"created_at": "2023-04-26T20:21:26.347412+00:00",
+			"region": "us-east-1",
+			"capabilities": {
+				"sending": "enabled",
+				"receiving": "enabled"
+			}
+		}`)
+	})
+
+	domain, err := client.Domains.Get("d91cd9bd-1176-453e-8fc1-35364d380206")
+	if err != nil {
+		t.Errorf("Domains.Get returned error: %v", err)
+	}
+	assert.NotNil(t, domain.Capabilities)
+	assert.Equal(t, DomainCapabilityStatusEnabled, domain.Capabilities.Sending)
+	assert.Equal(t, DomainCapabilityStatusEnabled, domain.Capabilities.Receiving)
 }
 
 func TestGetDomainPartiallyVerified(t *testing.T) {

--- a/examples/domains.go
+++ b/examples/domains.go
@@ -19,6 +19,10 @@ func domainsExample() {
 		Name:             "drish.dev",
 		Region:           "us-east-1",
 		CustomReturnPath: "outbound",
+		Capabilities: &resend.DomainCapabilities{
+			Sending:   resend.DomainCapabilityStatusEnabled,
+			Receiving: resend.DomainCapabilityStatusEnabled,
+		},
 	}
 
 	domain, err := client.Domains.CreateWithContext(ctx, params)
@@ -27,6 +31,10 @@ func domainsExample() {
 	}
 	fmt.Println("Created Domain entry id: " + domain.Id)
 	fmt.Println("Status: " + domain.Status)
+	if domain.Capabilities != nil {
+		fmt.Println("Sending: " + domain.Capabilities.Sending)
+		fmt.Println("Receiving: " + domain.Capabilities.Receiving)
+	}
 
 	for _, record := range domain.Records {
 		fmt.Printf("%v\n", record)
@@ -38,6 +46,10 @@ func domainsExample() {
 		panic(err)
 	}
 	fmt.Printf("Retrieved domain: %v", retrievedDomain)
+	if retrievedDomain.Capabilities != nil {
+		fmt.Println("Sending: " + retrievedDomain.Capabilities.Sending)
+		fmt.Println("Receiving: " + retrievedDomain.Capabilities.Receiving)
+	}
 
 	updateDomainParams := &resend.UpdateDomainRequest{
 		OpenTracking:  true,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds domain capability support to `Domain` and `CreateDomainResponse`, exposing `sending` and `receiving` statuses in API responses. Examples and tests updated; the field is optional and omitted when not present.

- **New Features**
  - Added `Capabilities *DomainCapabilities` to `Domain` and `CreateDomainResponse` with JSON support for `sending` and `receiving`.
  - Updated example to set and print capabilities via `resend.DomainCapabilities`.
  - Added tests to verify deserialization and omission when capabilities are absent.

<sup>Written for commit 29711b11dd01d25af735e8cdc5e86f8d4fe2a7c9. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/resend-go/pull/117?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

