### PR TITLE
fix(emails): include missing TopicId to SendEmailRequest

### DIFF
--- a/emails.go
+++ b/emails.go
@@ -39,6 +39,7 @@ type SendEmailRequest struct {
 	Headers     map[string]string `json:"headers,omitempty"`
 	ScheduledAt string            `json:"scheduled_at,omitempty"`
 	Template    *EmailTemplate    `json:"template,omitempty"`
+	TopicId     string            `json:"topic_id,omitempty"`
 }
 
 // CancelScheduledEmailResponse is the response from the Cancel call.


### PR DESCRIPTION
This PR fixes #119 

Simple fix for missing struct field. Enables use case for sending welcome emails with unsubscribe url as described in the issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing TopicId field to SendEmailRequest (json: "topic_id") to support topic-scoped sends and enable unsubscribe URLs in welcome emails.

<sup>Written for commit 513be258ef5e6e074ebc9c5e6352a1af2acd4d14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

