### PR TITLE
chore: bump version to 3.8.0

### DIFF
--- a/resend.go
+++ b/resend.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version     = "3.7.0"
+	version     = "3.8.0"
 	userAgent   = "resend-go/" + version
 	contentType = "application/json"
 )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update SDK version to 3.8.0. This also updates the `userAgent` to `resend-go/3.8.0` so requests report the correct version.

<sup>Written for commit e5b3ac1606ab811d36460d67ac4f35842998cccd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

