### PR TITLE
test(emails): test case and example for issue 119

### DIFF
--- a/emails_test.go
+++ b/emails_test.go
@@ -792,3 +792,42 @@ func TestSendEmailWithTemplateComplexVariables(t *testing.T) {
 	}
 	assert.Equal(t, "complex-vars-email-222", resp.Id)
 }
+
+func TestSendEmailWithTopicId(t *testing.T) {
+	setup()
+	defer teardown()
+
+	topicId := "1234567890abcdef"
+
+	mux.HandleFunc("/emails", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		// Verify that topic_id is in the request body
+		bodyBytes, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.Contains(t, string(bodyBytes), `"topic_id"`+":"+`"`+topicId+`"`)
+
+		ret := &SendEmailResponse{
+			Id: "topic-email-001",
+		}
+		err = json.NewEncoder(w).Encode(&ret)
+		if err != nil {
+			panic(err)
+		}
+	})
+
+	req := &SendEmailRequest{
+		From:    "sender@example.com",
+		To:      []string{"recipient@example.com"},
+		Subject: "Email with Topic",
+		Html:    "<p>This email is sent to a topic subscriber</p>",
+		TopicId: topicId,
+	}
+	resp, err := client.Emails.Send(req)
+	if err != nil {
+		t.Errorf("Emails.Send returned error: %v", err)
+	}
+	assert.Equal(t, "topic-email-001", resp.Id)
+}

--- a/examples/send_email.go
+++ b/examples/send_email.go
@@ -94,4 +94,24 @@ func sendEmailExample() {
 
 		fmt.Printf("Found %d more emails in next page\n", len(nextPage.Data))
 	}
+
+	// Sending email with a topic_id
+	// The topic_id field allows you to send emails only to contacts who have subscribed to that topic.
+	// - If recipient is a contact and opted-in: email is sent
+	// - If recipient is a contact and opted-out: email is NOT sent (marked as failed)
+	// - If recipient is not a contact: email is sent if topic's default_subscription is "opt_in"
+	fmt.Println("\n--- Sending with Topic ID ---")
+	topicParams := &resend.SendEmailRequest{
+		From:    "onboarding@resend.dev",
+		To:      []string{"delivered@resend.dev"},
+		Subject: "Newsletter for subscribers",
+		Html:    "<p>This is sent only to topic subscribers</p>",
+		TopicId: "1234567890abcdef", // Replace with actual topic ID
+	}
+
+	topicResp, err := client.Emails.SendWithContext(ctx, topicParams)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Sent email with topic_id: %s\n", topicResp.Id)
 }


### PR DESCRIPTION
In my PR for fixing issue #119 I forgot to add a test case and an example. Here they are for your review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add test coverage and an example for sending emails with `topic_id`, addressing issue #119. This verifies the request includes `topic_id` and shows how to send topic-scoped emails with `resend`.

<sup>Written for commit 6c45a105a40bbbb020bf90817cc1aa28304f9145. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

