### PR TITLE
fix(contacts): add segments and topics to create contact request

### DIFF
--- a/contacts.go
+++ b/contacts.go
@@ -48,6 +48,11 @@ type RemoveContactOptions struct {
 	Id         string // Required - can be contact ID or email address
 }
 
+// ContactSegmentRef is a minimal reference to a segment for embedding in CreateContactRequest
+type ContactSegmentRef struct {
+	Id string `json:"id"`
+}
+
 type CreateContactRequest struct {
 	Email        string `json:"email"`
 	AudienceId   string `json:"audience_id,omitempty"` // Deprecated: Optional, use Segments API for contact organization
@@ -59,6 +64,12 @@ type CreateContactRequest struct {
 	// Non-string values (numbers, booleans, etc.) will be rejected by the API with a validation error.
 	// Example: Properties: map[string]any{"tier": "premium", "age": "30", "active": "true"}
 	Properties map[string]any `json:"properties,omitempty"`
+	// Segments is an array of segment IDs to add the contact to (when audience_id is omitted).
+	// This field is only used when AudienceId is not set.
+	Segments []ContactSegmentRef `json:"segments,omitempty"`
+	// Topics is an array of topic subscriptions for the contact (when audience_id is omitted).
+	// This field is only used when AudienceId is not set.
+	Topics []TopicSubscriptionUpdate `json:"topics,omitempty"`
 }
 
 type UpdateContactRequest struct {

--- a/contacts_test.go
+++ b/contacts_test.go
@@ -667,3 +667,50 @@ func TestRemoveGlobalContact(t *testing.T) {
 	assert.Equal(t, contactId, deleted.Id)
 	assert.Equal(t, "contact", deleted.Object)
 }
+
+func TestCreateGlobalContactWithSegmentsAndTopics(t *testing.T) {
+	setup()
+	defer teardown()
+
+	segmentId := "seg-123abc"
+	topicId := "top-456def"
+
+	mux.HandleFunc("/contacts", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		// Verify that segments and topics are in the request body
+		bodyBytes, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		bodyStr := string(bodyBytes)
+		assert.Contains(t, bodyStr, `"segments"`)
+		assert.Contains(t, bodyStr, segmentId)
+		assert.Contains(t, bodyStr, `"topics"`)
+		assert.Contains(t, bodyStr, topicId)
+		assert.Contains(t, bodyStr, `"opt_in"`)
+
+		fmt.Fprint(w, `{
+			"object": "contact",
+			"id": "seg-contact-001"
+		}`)
+	})
+
+	req := &CreateContactRequest{
+		Email:     "segmented@example.com",
+		FirstName: "Segmented",
+		LastName:  "Contact",
+		Segments: []ContactSegmentRef{
+			{Id: segmentId},
+		},
+		Topics: []TopicSubscriptionUpdate{
+			{Id: topicId, Subscription: "opt_in"},
+		},
+	}
+	resp, err := client.Contacts.Create(req)
+	if err != nil {
+		t.Errorf("Contacts.Create returned error: %v", err)
+	}
+	assert.Equal(t, "contact", resp.Object)
+	assert.Equal(t, "seg-contact-001", resp.Id)
+}

--- a/examples/contacts.go
+++ b/examples/contacts.go
@@ -159,17 +159,57 @@ func contactsExample() {
 
 	// ====================================
 
+	// Create a global contact with segments and topics (atomic operation)
+	// This demonstrates adding a contact to segments and subscribing to topics in a single request
+	segmentParams := &resend.CreateSegmentRequest{
+		Name: "Premium Users",
+	}
+	segment, err := client.Segments.CreateWithContext(ctx, segmentParams)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("\nCreated segment with ID: " + segment.Id)
+
+	globalContactParams := &resend.CreateContactRequest{
+		Email:     "premium@example.com",
+		FirstName: "Premium",
+		LastName:  "User",
+		Segments: []resend.ContactSegmentRef{
+			{Id: segment.Id},
+		},
+		Topics: []resend.TopicSubscriptionUpdate{
+			{Id: topic.Id, Subscription: "opt_in"},
+		},
+	}
+	globalContact, err := client.Contacts.CreateWithContext(ctx, globalContactParams)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Created global contact with segments and topics: %s\n", globalContact.Id)
+
+	// Clean up: remove the segment we created
+	removedSegment, err := client.Segments.RemoveWithContext(ctx, segment.Id)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Segment deleted: %v\n", removedSegment.Deleted)
+
+	// Remove by email
+	removedContact, err := client.Contacts.RemoveWithContext(ctx, &resend.RemoveContactOptions{
+		Id: "hi@example.com",
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("\nGlobal contact deleted: %v\n", removedContact.Deleted)
+
+	// ====================================
+
 	// Remove by id
 	removed, err := client.Contacts.RemoveWithContext(ctx, &resend.RemoveContactOptions{
 		AudienceId: audienceId,
 		Id:         contact.Id,
 	})
-
-	// Remove by email
-	// removed, err := client.Contacts.RemoveWithContext(ctx, &resend.RemoveContactOptions{
-	//   AudienceId: audienceId,
-	//   Id:         "hi@example.com",
-	// })
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
fixes #122 

includes also a new test case for adding a contact with segments and topics, and a new example snippet.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support to create a global contact with segments and topic subscriptions in one request by extending `CreateContactRequest`. Addresses #122.

- **New Features**
  - `CreateContactRequest`: added `Segments []ContactSegmentRef` and `Topics []TopicSubscriptionUpdate` (used only when `AudienceId` is omitted).
  - Test: `TestCreateGlobalContactWithSegmentsAndTopics` validates segments/topics are included and accepted.
  - Example: shows creating a segment, creating a contact with segments/topics, and cleanup.

<sup>Written for commit 0519d0b8e92fa912aec8ffd58d0a4f1f21285c28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

