### PR TITLE
chore: add Go 1.24, 1.25, 1.26 to CI matrix

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,9 +20,12 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.23"
-          - "1.22"
           - "1.21"
+          - "1.22"
+          - "1.23"
+          - "1.24"
+          - "1.25"
+          - "1.26"
     name: "Test: go v${{ matrix.go }}"
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update CI to test Go 1.21–1.26 by adding 1.24, 1.25, and 1.26 to the workflow matrix. This keeps our test coverage current with recent Go releases.

<sup>Written for commit 3ac8c72828b0224c9071cc6b047b69645c299458. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

