### PR TITLE
fix(contacts): guard audience_id against segments and topics

### DIFF
--- a/contacts.go
+++ b/contacts.go
@@ -143,6 +143,10 @@ func (s *ContactsSvcImpl) Create(params *CreateContactRequest) (CreateContactRes
 // Global contacts support custom properties while audience-specific contacts do not.
 // https://resend.com/docs/api-reference/contacts/create-contact
 func (s *ContactsSvcImpl) CreateWithContext(ctx context.Context, params *CreateContactRequest) (CreateContactResponse, error) {
+	if params.AudienceId != "" && (len(params.Segments) > 0 || len(params.Topics) > 0) {
+		return CreateContactResponse{}, errors.New("[ERROR]: `audience_id` is deprecated and cannot be used together with `segments` or `topics`. Use `segments` to add one or more segments to the new contact.")
+	}
+
 	var path string
 	if params.AudienceId != "" {
 		// Audience-specific contact (legacy path, no properties support)

--- a/contacts.go
+++ b/contacts.go
@@ -143,8 +143,11 @@ func (s *ContactsSvcImpl) Create(params *CreateContactRequest) (CreateContactRes
 // Global contacts support custom properties while audience-specific contacts do not.
 // https://resend.com/docs/api-reference/contacts/create-contact
 func (s *ContactsSvcImpl) CreateWithContext(ctx context.Context, params *CreateContactRequest) (CreateContactResponse, error) {
+	if params == nil {
+		return CreateContactResponse{}, errors.New("[ERROR]: params cannot be nil")
+	}
 	if params.AudienceId != "" && (len(params.Segments) > 0 || len(params.Topics) > 0) {
-		return CreateContactResponse{}, errors.New("[ERROR]: `audience_id` is deprecated and cannot be used together with `segments` or `topics`. Use `segments` to add one or more segments to the new contact.")
+		return CreateContactResponse{}, errors.New("[ERROR]: `audience_id` is deprecated and cannot be used together with `segments` or `topics`.")
 	}
 
 	var path string

--- a/contacts_test.go
+++ b/contacts_test.go
@@ -715,16 +715,23 @@ func TestCreateGlobalContactWithSegmentsAndTopics(t *testing.T) {
 	assert.Equal(t, "seg-contact-001", resp.Id)
 }
 
+func TestCreateContactNilParamsReturnsError(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, err := client.Contacts.Create(nil)
+	assert.Error(t, err)
+}
+
 func TestCreateContactWithAudienceIdAndSegmentsReturnsError(t *testing.T) {
 	setup()
 	defer teardown()
 
-	req := &CreateContactRequest{
+	_, err := client.Contacts.Create(&CreateContactRequest{
 		Email:      "test@example.com",
 		AudienceId: "aud-123",
 		Segments:   []ContactSegmentRef{{Id: "seg-456"}},
-	}
-	_, err := client.Contacts.Create(req)
+	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "audience_id")
 	assert.Contains(t, err.Error(), "segments")
@@ -734,12 +741,11 @@ func TestCreateContactWithAudienceIdAndTopicsReturnsError(t *testing.T) {
 	setup()
 	defer teardown()
 
-	req := &CreateContactRequest{
+	_, err := client.Contacts.Create(&CreateContactRequest{
 		Email:      "test@example.com",
 		AudienceId: "aud-123",
 		Topics:     []TopicSubscriptionUpdate{{Id: "top-456", Subscription: "opt_in"}},
-	}
-	_, err := client.Contacts.Create(req)
+	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "audience_id")
 	assert.Contains(t, err.Error(), "topics")

--- a/contacts_test.go
+++ b/contacts_test.go
@@ -714,3 +714,33 @@ func TestCreateGlobalContactWithSegmentsAndTopics(t *testing.T) {
 	assert.Equal(t, "contact", resp.Object)
 	assert.Equal(t, "seg-contact-001", resp.Id)
 }
+
+func TestCreateContactWithAudienceIdAndSegmentsReturnsError(t *testing.T) {
+	setup()
+	defer teardown()
+
+	req := &CreateContactRequest{
+		Email:      "test@example.com",
+		AudienceId: "aud-123",
+		Segments:   []ContactSegmentRef{{Id: "seg-456"}},
+	}
+	_, err := client.Contacts.Create(req)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "audience_id")
+	assert.Contains(t, err.Error(), "segments")
+}
+
+func TestCreateContactWithAudienceIdAndTopicsReturnsError(t *testing.T) {
+	setup()
+	defer teardown()
+
+	req := &CreateContactRequest{
+		Email:      "test@example.com",
+		AudienceId: "aud-123",
+		Topics:     []TopicSubscriptionUpdate{{Id: "top-456", Subscription: "opt_in"}},
+	}
+	_, err := client.Contacts.Create(req)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "audience_id")
+	assert.Contains(t, err.Error(), "topics")
+}

--- a/examples/contacts.go
+++ b/examples/contacts.go
@@ -194,9 +194,9 @@ func contactsExample() {
 	}
 	fmt.Printf("Segment deleted: %v\n", removedSegment.Deleted)
 
-	// Remove by email
+	// Remove by id
 	removedContact, err := client.Contacts.RemoveWithContext(ctx, &resend.RemoveContactOptions{
-		Id: "hi@example.com",
+		Id: globalContact.Id,
 	})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Block invalid contact create requests that mix deprecated `audience_id` with `segments` or `topics`. Add a nil-params guard and clearer errors.

- **Bug Fixes**
  - Return a clear error when `audience_id` is used with `segments` or `topics`.
  - Guard against `nil` params and return an explicit error.
  - Add tests for both error cases; update example to remove a contact by id.

<sup>Written for commit 45ed44eb154a83636a14d0b6be88183b8176d789. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

