### PR TITLE
feat: receiving html format param

### DIFF
--- a/receiving.go
+++ b/receiving.go
@@ -3,6 +3,7 @@ package resend
 import (
 	"context"
 	"net/http"
+	"net/url"
 )
 
 // ReceivedEmail provides the structure for the response from the Receiving.Get call.
@@ -60,8 +61,14 @@ type RawEmail struct {
 	ExpiresAt   string `json:"expires_at"`
 }
 
+// GetReceivedEmailParams contains optional query parameters for Receiving.GetWithOptions
+type GetReceivedEmailParams struct {
+	HtmlFormat *string
+}
+
 // ReceivingSvc handles operations for received/inbound emails
 type ReceivingSvc interface {
+	GetWithOptions(ctx context.Context, emailId string, params *GetReceivedEmailParams) (*ReceivedEmail, error)
 	GetWithContext(ctx context.Context, emailId string) (*ReceivedEmail, error)
 	Get(emailId string) (*ReceivedEmail, error)
 	ListWithOptions(ctx context.Context, options *ListOptions) (ListReceivedEmailsResponse, error)
@@ -79,12 +86,17 @@ type ReceivingSvcImpl struct {
 	client *Client
 }
 
-// GetWithContext retrieves a received email with the given emailId
+// GetWithOptions retrieves a received email with the given emailId and optional query parameters
 // https://resend.com/docs/api-reference/emails/retrieve-received-email
-func (s *ReceivingSvcImpl) GetWithContext(ctx context.Context, emailId string) (*ReceivedEmail, error) {
+func (s *ReceivingSvcImpl) GetWithOptions(ctx context.Context, emailId string, params *GetReceivedEmailParams) (*ReceivedEmail, error) {
 	path := "emails/receiving/" + emailId
 
-	// Prepare request
+	if params != nil && params.HtmlFormat != nil {
+		query := url.Values{}
+		query.Set("html_format", *params.HtmlFormat)
+		path += "?" + query.Encode()
+	}
+
 	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, ErrFailedToCreateReceivingGetRequest
@@ -92,9 +104,7 @@ func (s *ReceivingSvcImpl) GetWithContext(ctx context.Context, emailId string) (
 
 	emailResponse := new(ReceivedEmail)
 
-	// Send Request
 	_, err = s.client.Perform(req, emailResponse)
-
 	if err != nil {
 		return nil, err
 	}
@@ -102,10 +112,16 @@ func (s *ReceivingSvcImpl) GetWithContext(ctx context.Context, emailId string) (
 	return emailResponse, nil
 }
 
+// GetWithContext retrieves a received email with the given emailId
+// https://resend.com/docs/api-reference/emails/retrieve-received-email
+func (s *ReceivingSvcImpl) GetWithContext(ctx context.Context, emailId string) (*ReceivedEmail, error) {
+	return s.GetWithOptions(ctx, emailId, nil)
+}
+
 // Get retrieves a received email with the given emailId
 // https://resend.com/docs/api-reference/emails/retrieve-received-email
 func (s *ReceivingSvcImpl) Get(emailId string) (*ReceivedEmail, error) {
-	return s.GetWithContext(context.Background(), emailId)
+	return s.GetWithOptions(context.Background(), emailId, nil)
 }
 
 // ListWithOptions retrieves a list of received emails with pagination options

--- a/receiving_test.go
+++ b/receiving_test.go
@@ -82,6 +82,46 @@ func TestGetReceivedEmail(t *testing.T) {
 	assert.Equal(t, "2023-04-20T16:23:29.315Z", resp.Raw.ExpiresAt)
 }
 
+func TestGetReceivedEmailWithOptions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/emails/receiving/8136d3fb-0439-4b09-b939-b8436a3524b6", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, "sanitized", r.URL.Query().Get("html_format"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "email",
+			"id": "8136d3fb-0439-4b09-b939-b8436a3524b6",
+			"to": ["delivered@resend.dev"],
+			"from": "Acme <onboarding@resend.dev>",
+			"created_at": "2023-04-03T22:13:42.674981+00:00",
+			"subject": "Hello World",
+			"html": "<p>Congrats on sending your first email!</p>",
+			"text": "Congrats on sending your first email!",
+			"bcc": [],
+			"cc": [],
+			"reply_to": [],
+			"headers": {},
+			"attachments": []
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	htmlFormat := "sanitized"
+	resp, err := client.Emails.Receiving.GetWithOptions(context.Background(), "8136d3fb-0439-4b09-b939-b8436a3524b6", &GetReceivedEmailParams{
+		HtmlFormat: &htmlFormat,
+	})
+	if err != nil {
+		t.Errorf("Emails.Receiving.GetWithOptions returned error: %v", err)
+	}
+	assert.Equal(t, "8136d3fb-0439-4b09-b939-b8436a3524b6", resp.Id)
+	assert.Equal(t, "<p>Congrats on sending your first email!</p>", resp.Html)
+}
+
 func TestGetReceivedEmailWithNullFields(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds optional `html_format` support when retrieving received emails so clients can request sanitized HTML. Introduces `GetWithOptions` with params while keeping existing `Get` and `GetWithContext` behavior unchanged.

- **New Features**
  - Added `ReceivingSvc.GetWithOptions(ctx, emailId, params)` and `GetReceivedEmailParams{ HtmlFormat *string }`.
  - When `HtmlFormat` is set, appends `html_format` to the request query.
  - Added `TestGetReceivedEmailWithOptions` to verify query handling and response HTML.

<sup>Written for commit 00d48a9f2bf1e51af484646f570d9f8a8bcd6fa1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

