### PR TITLE
feat: add contact imports endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+examples/main

--- a/contact_imports.go
+++ b/contact_imports.go
@@ -1,0 +1,255 @@
+package resend
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+)
+
+type ContactImportStatus string
+
+const (
+	ContactImportStatusQueued     ContactImportStatus = "queued"
+	ContactImportStatusInProgress ContactImportStatus = "in_progress"
+	ContactImportStatusCompleted  ContactImportStatus = "completed"
+	ContactImportStatusFailed     ContactImportStatus = "failed"
+)
+
+type ContactImportCounts struct {
+	Total   int `json:"total"`
+	Created int `json:"created"`
+	Updated int `json:"updated"`
+	Skipped int `json:"skipped"`
+	Failed  int `json:"failed"`
+}
+
+type ContactImport struct {
+	Object    string               `json:"object"`
+	Id        string               `json:"id"`
+	Status    ContactImportStatus  `json:"status"`
+	CreatedAt string               `json:"created_at"`
+	Counts    *ContactImportCounts `json:"counts,omitempty"`
+}
+
+// CreateContactImportRequest contains params for creating a contact import.
+// File is required; all other fields are optional.
+type CreateContactImportRequest struct {
+	// CSV file content (required). Maximum size is 50MB.
+	File []byte
+	// Filename to use in the multipart upload. Defaults to "import.csv".
+	Filename string
+	// ColumnMap maps contact fields to CSV column names.
+	// Will be JSON-encoded before sending.
+	// Example: map[string]any{"email": "Email", "first_name": "First Name"}
+	ColumnMap map[string]any
+	// OnConflict strategy: "upsert" or "skip" (default "skip").
+	OnConflict string
+	// Segments is a list of segment IDs to add imported contacts to.
+	// Will be JSON-encoded as [{"id": "..."}] before sending.
+	Segments []string
+}
+
+type CreateContactImportResponse struct {
+	Object string `json:"object"`
+	Id     string `json:"id"`
+}
+
+type ListContactImportsOptions struct {
+	// Status filters imports by status: queued, in_progress, completed, failed.
+	Status string
+	Limit  *int
+	After  *string
+	Before *string
+}
+
+type ListContactImportsResponse struct {
+	Object  string          `json:"object"`
+	HasMore bool            `json:"has_more"`
+	Data    []ContactImport `json:"data"`
+}
+
+type ContactImportsSvc interface {
+	Create(params *CreateContactImportRequest) (CreateContactImportResponse, error)
+	CreateWithContext(ctx context.Context, params *CreateContactImportRequest) (CreateContactImportResponse, error)
+	Get(id string) (ContactImport, error)
+	GetWithContext(ctx context.Context, id string) (ContactImport, error)
+	List(options *ListContactImportsOptions) (ListContactImportsResponse, error)
+	ListWithContext(ctx context.Context, options *ListContactImportsOptions) (ListContactImportsResponse, error)
+}
+
+type ContactImportsSvcImpl struct {
+	client *Client
+}
+
+// Create creates a new contact import from a CSV file.
+// https://resend.com/docs/api-reference/contacts/create-contact-import
+func (s *ContactImportsSvcImpl) Create(params *CreateContactImportRequest) (CreateContactImportResponse, error) {
+	return s.CreateWithContext(context.Background(), params)
+}
+
+// CreateWithContext creates a new contact import from a CSV file with context.
+// https://resend.com/docs/api-reference/contacts/create-contact-import
+func (s *ContactImportsSvcImpl) CreateWithContext(ctx context.Context, params *CreateContactImportRequest) (CreateContactImportResponse, error) {
+	if params == nil || len(params.File) == 0 {
+		return CreateContactImportResponse{}, errors.New("[ERROR]: File is required")
+	}
+
+	filename := params.Filename
+	if filename == "" {
+		filename = "import.csv"
+	}
+
+	fields := make(map[string]string)
+	if params.OnConflict != "" {
+		fields["on_conflict"] = params.OnConflict
+	}
+	if len(params.ColumnMap) > 0 {
+		b, err := json.Marshal(params.ColumnMap)
+		if err != nil {
+			return CreateContactImportResponse{}, fmt.Errorf("[ERROR]: Failed to encode column_map: %w", err)
+		}
+		fields["column_map"] = string(b)
+	}
+	if len(params.Segments) > 0 {
+		segs := make([]map[string]string, len(params.Segments))
+		for i, id := range params.Segments {
+			segs[i] = map[string]string{"id": id}
+		}
+		b, err := json.Marshal(segs)
+		if err != nil {
+			return CreateContactImportResponse{}, fmt.Errorf("[ERROR]: Failed to encode segments: %w", err)
+		}
+		fields["segments"] = string(b)
+	}
+
+	req, err := s.client.NewMultipartRequest(ctx, "contacts/imports", params.File, filename, fields)
+	if err != nil {
+		return CreateContactImportResponse{}, errors.New("[ERROR]: Failed to create ContactImports.Create request")
+	}
+
+	resp := new(CreateContactImportResponse)
+	_, err = s.client.Perform(req, resp)
+	if err != nil {
+		return CreateContactImportResponse{}, err
+	}
+	return *resp, nil
+}
+
+// Get retrieves a single contact import by ID.
+// https://resend.com/docs/api-reference/contacts/get-contact-import
+func (s *ContactImportsSvcImpl) Get(id string) (ContactImport, error) {
+	return s.GetWithContext(context.Background(), id)
+}
+
+// GetWithContext retrieves a single contact import by ID with context.
+// https://resend.com/docs/api-reference/contacts/get-contact-import
+func (s *ContactImportsSvcImpl) GetWithContext(ctx context.Context, id string) (ContactImport, error) {
+	if id == "" {
+		return ContactImport{}, errors.New("[ERROR]: Id is required")
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, "contacts/imports/"+id, nil)
+	if err != nil {
+		return ContactImport{}, errors.New("[ERROR]: Failed to create ContactImports.Get request")
+	}
+
+	resp := new(ContactImport)
+	_, err = s.client.Perform(req, resp)
+	if err != nil {
+		return ContactImport{}, err
+	}
+	return *resp, nil
+}
+
+// List retrieves a list of contact imports.
+// https://resend.com/docs/api-reference/contacts/list-contact-imports
+func (s *ContactImportsSvcImpl) List(options *ListContactImportsOptions) (ListContactImportsResponse, error) {
+	return s.ListWithContext(context.Background(), options)
+}
+
+// ListWithContext retrieves a list of contact imports with context.
+// https://resend.com/docs/api-reference/contacts/list-contact-imports
+func (s *ContactImportsSvcImpl) ListWithContext(ctx context.Context, options *ListContactImportsOptions) (ListContactImportsResponse, error) {
+	if options == nil {
+		options = &ListContactImportsOptions{}
+	}
+
+	query := make(url.Values)
+	if options.Status != "" {
+		query.Set("status", options.Status)
+	}
+	if options.Limit != nil {
+		query.Set("limit", fmt.Sprintf("%d", *options.Limit))
+	}
+	if options.After != nil {
+		query.Set("after", *options.After)
+	}
+	if options.Before != nil {
+		query.Set("before", *options.Before)
+	}
+
+	path := "contacts/imports"
+	if len(query) > 0 {
+		path += "?" + query.Encode()
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return ListContactImportsResponse{}, errors.New("[ERROR]: Failed to create ContactImports.List request")
+	}
+
+	resp := new(ListContactImportsResponse)
+	_, err = s.client.Perform(req, resp)
+	if err != nil {
+		return ListContactImportsResponse{}, err
+	}
+	return *resp, nil
+}
+
+// NewMultipartRequest builds an HTTP multipart/form-data request for file uploads.
+func (c *Client) NewMultipartRequest(ctx context.Context, path string, fileBytes []byte, filename string, fields map[string]string) (*http.Request, error) {
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+
+	fw, err := w.CreateFormFile("file", filename)
+	if err != nil {
+		return nil, err
+	}
+	if _, err = io.Copy(fw, bytes.NewReader(fileBytes)); err != nil {
+		return nil, err
+	}
+
+	for k, v := range fields {
+		if err = w.WriteField(k, v); err != nil {
+			return nil, err
+		}
+	}
+	w.Close()
+
+	u, err := c.BaseURL.Parse(path)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), &buf)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	req.Header.Set("Accept", contentType)
+	req.Header.Set("User-Agent", c.UserAgent)
+	req.Header.Set("Authorization", "Bearer "+c.ApiKey)
+
+	for k, v := range c.headers {
+		req.Header.Add(k, v)
+	}
+
+	return req, nil
+}

--- a/contact_imports_test.go
+++ b/contact_imports_test.go
@@ -1,0 +1,157 @@
+package resend
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateContactImport(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/contacts/imports", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		assert.Contains(t, r.Header.Get("Content-Type"), "multipart/form-data")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"object":"contact_import","id":"479e3145-dd38-476b-932c-529ceb705947"}`)
+	})
+
+	req := &CreateContactImportRequest{
+		File: []byte("email,first_name\nsteve@example.com,Steve"),
+	}
+	resp, err := client.Contacts.Imports.Create(req)
+	if err != nil {
+		t.Errorf("ContactImports.Create returned error: %v", err)
+	}
+	assert.Equal(t, "contact_import", resp.Object)
+	assert.Equal(t, "479e3145-dd38-476b-932c-529ceb705947", resp.Id)
+}
+
+func TestCreateContactImportWithOptions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/contacts/imports", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		r.ParseMultipartForm(10 << 20)
+		assert.Equal(t, "upsert", r.FormValue("on_conflict"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"object":"contact_import","id":"479e3145-dd38-476b-932c-529ceb705947"}`)
+	})
+
+	req := &CreateContactImportRequest{
+		File:       []byte("email\nsteve@example.com"),
+		OnConflict: "upsert",
+		ColumnMap:  map[string]any{"email": "Email"},
+		Segments:   []string{"seg-123"},
+	}
+	resp, err := client.Contacts.Imports.Create(req)
+	if err != nil {
+		t.Errorf("ContactImports.Create returned error: %v", err)
+	}
+	assert.Equal(t, "479e3145-dd38-476b-932c-529ceb705947", resp.Id)
+}
+
+func TestCreateContactImportMissingFile(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, err := client.Contacts.Imports.Create(&CreateContactImportRequest{})
+	assert.Error(t, err)
+}
+
+func TestGetContactImport(t *testing.T) {
+	setup()
+	defer teardown()
+
+	importId := "479e3145-dd38-476b-932c-529ceb705947"
+
+	mux.HandleFunc("/contacts/imports/"+importId, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `{
+			"object": "contact_import",
+			"id": "%s",
+			"status": "completed",
+			"created_at": "2023-10-06T23:47:56.678Z",
+			"counts": {"total": 100, "created": 80, "updated": 10, "skipped": 5, "failed": 5}
+		}`, importId)
+	})
+
+	resp, err := client.Contacts.Imports.Get(importId)
+	if err != nil {
+		t.Errorf("ContactImports.Get returned error: %v", err)
+	}
+	assert.Equal(t, "contact_import", resp.Object)
+	assert.Equal(t, importId, resp.Id)
+	assert.Equal(t, ContactImportStatusCompleted, resp.Status)
+	assert.NotNil(t, resp.Counts)
+	assert.Equal(t, 100, resp.Counts.Total)
+	assert.Equal(t, 80, resp.Counts.Created)
+}
+
+func TestGetContactImportMissingId(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, err := client.Contacts.Imports.Get("")
+	assert.Error(t, err)
+}
+
+func TestListContactImports(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/contacts/imports", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"object": "list",
+			"has_more": false,
+			"data": [
+				{
+					"object": "contact_import",
+					"id": "479e3145-dd38-476b-932c-529ceb705947",
+					"status": "completed",
+					"created_at": "2023-10-06T23:47:56.678Z"
+				}
+			]
+		}`)
+	})
+
+	resp, err := client.Contacts.Imports.List(nil)
+	if err != nil {
+		t.Errorf("ContactImports.List returned error: %v", err)
+	}
+	assert.Equal(t, "list", resp.Object)
+	assert.False(t, resp.HasMore)
+	assert.Len(t, resp.Data, 1)
+	assert.Equal(t, "479e3145-dd38-476b-932c-529ceb705947", resp.Data[0].Id)
+	assert.Equal(t, ContactImportStatusCompleted, resp.Data[0].Status)
+}
+
+func TestListContactImportsWithStatusFilter(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/contacts/imports", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, "completed", r.URL.Query().Get("status"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"object":"list","has_more":false,"data":[]}`)
+	})
+
+	resp, err := client.Contacts.Imports.List(&ListContactImportsOptions{Status: "completed"})
+	if err != nil {
+		t.Errorf("ContactImports.List returned error: %v", err)
+	}
+	assert.Equal(t, "list", resp.Object)
+}

--- a/contacts.go
+++ b/contacts.go
@@ -25,6 +25,7 @@ type ContactsSvcImpl struct {
 	Topics     ContactTopicsSvc
 	Segments   ContactSegmentsSvc
 	Properties ContactPropertiesSvc
+	Imports    ContactImportsSvc
 }
 
 // GetContactOptions contains parameters for retrieving a contact

--- a/examples/contact_imports.go
+++ b/examples/contact_imports.go
@@ -1,0 +1,63 @@
+package examples
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/resend/resend-go/v3"
+)
+
+func contactImportsExample() {
+	ctx := context.TODO()
+	apiKey := os.Getenv("RESEND_API_KEY")
+
+	client := resend.NewClient(apiKey)
+
+	file, err := os.ReadFile("contacts.csv")
+	if err != nil {
+		panic(err)
+	}
+
+	createParams := &resend.CreateContactImportRequest{
+		File:       file,
+		Filename:   "contacts.csv",
+		OnConflict: "upsert",
+		ColumnMap: map[string]any{
+			"email":     "Email",
+			"firstName": "First Name",
+			"lastName":  "Last Name",
+			"properties": map[string]any{
+				"plan": map[string]any{
+					"column": "Plan",
+					"type":   "string",
+				},
+			},
+		},
+		Segments: []string{"78e7a5c6-9a91-4c63-9d1f-3b9c0b5b9ab6"},
+	}
+
+	created, err := client.Contacts.Imports.CreateWithContext(ctx, createParams)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Created contact import with ID: " + created.Id)
+
+	// Get a contact import by ID
+	imported, err := client.Contacts.Imports.GetWithContext(ctx, created.Id)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Contact import status: %s\n", imported.Status)
+
+	// List contact imports
+	limit := 10
+	list, err := client.Contacts.Imports.ListWithContext(ctx, &resend.ListContactImportsOptions{
+		Status: string(resend.ContactImportStatusCompleted),
+		Limit:  &limit,
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("You have %d completed contact import(s)\n", len(list.Data))
+}

--- a/examples/contact_imports.go
+++ b/examples/contact_imports.go
@@ -24,9 +24,9 @@ func contactImportsExample() {
 		Filename:   "contacts.csv",
 		OnConflict: "upsert",
 		ColumnMap: map[string]any{
-			"email":     "Email",
-			"firstName": "First Name",
-			"lastName":  "Last Name",
+			"email":      "Email",
+			"first_name": "First Name",
+			"last_name":  "Last Name",
 			"properties": map[string]any{
 				"plan": map[string]any{
 					"column": "Plan",

--- a/resend.go
+++ b/resend.go
@@ -92,6 +92,7 @@ func NewCustomClient(httpClient *http.Client, apiKey string) *Client {
 	contactsSvc.Topics = &ContactTopicsSvcImpl{client: c}
 	contactsSvc.Segments = &ContactSegmentsSvcImpl{client: c}
 	contactsSvc.Properties = &ContactPropertiesSvcImpl{client: c}
+	contactsSvc.Imports = &ContactImportsSvcImpl{client: c}
 	c.Contacts = contactsSvc
 
 	c.Batch = &BatchSvcImpl{client: c}

--- a/resend.go
+++ b/resend.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version     = "3.8.0"
+	version     = "3.9.0"
 	userAgent   = "resend-go/" + version
 	contentType = "application/json"
 )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add contact import endpoints to the Go client to create imports from CSV, fetch by ID, and list with filters. Also bumps the SDK version to v3.9.0.

- **New Features**
  - Added `ContactImports` service with `Create`, `Get`, `List` (+ context) at `client.Contacts.Imports`.
  - CSV upload via `Client.NewMultipartRequest`; validates required `file` and defaults filename to `import.csv`.
  - Supports `column_map`, `on_conflict`, `segments`; list filters: `status`, `limit`, `after`, `before`.
  - Added `examples/contact_imports.go` and tests for create/get/list and validation errors.

- **Bug Fixes**
  - Example now uses snake_case keys in `column_map`.

<sup>Written for commit fdc7821d6bb38ceb93ee5609f189436a1c50f033. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

