### PR TITLE
feat: add topics support to contact imports

### DIFF
--- a/contact_imports.go
+++ b/contact_imports.go
@@ -53,6 +53,9 @@ type CreateContactImportRequest struct {
 	// Segments is a list of segment IDs to add imported contacts to.
 	// Will be JSON-encoded as [{"id": "..."}] before sending.
 	Segments []string
+	// Topics is a list of topic subscriptions to apply to imported contacts.
+	// Will be JSON-encoded as [{"id": "...", "subscription": "opt_in|opt_out"}] before sending.
+	Topics []TopicSubscriptionUpdate
 }
 
 type CreateContactImportResponse struct {
@@ -126,6 +129,13 @@ func (s *ContactImportsSvcImpl) CreateWithContext(ctx context.Context, params *C
 			return CreateContactImportResponse{}, fmt.Errorf("[ERROR]: Failed to encode segments: %w", err)
 		}
 		fields["segments"] = string(b)
+	}
+	if len(params.Topics) > 0 {
+		b, err := json.Marshal(params.Topics)
+		if err != nil {
+			return CreateContactImportResponse{}, fmt.Errorf("[ERROR]: Failed to encode topics: %w", err)
+		}
+		fields["topics"] = string(b)
 	}
 
 	req, err := s.client.NewMultipartRequest(ctx, "contacts/imports", params.File, filename, fields)

--- a/contact_imports_test.go
+++ b/contact_imports_test.go
@@ -57,6 +57,34 @@ func TestCreateContactImportWithOptions(t *testing.T) {
 	assert.Equal(t, "479e3145-dd38-476b-932c-529ceb705947", resp.Id)
 }
 
+func TestCreateContactImportWithTopics(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/contacts/imports", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		r.ParseMultipartForm(10 << 20)
+		topicsVal := r.FormValue("topics")
+		assert.Contains(t, topicsVal, `"059ac693-2fc8-4c13-8b27-01350d638a17"`)
+		assert.Contains(t, topicsVal, `"opt_in"`)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"object":"contact_import","id":"479e3145-dd38-476b-932c-529ceb705947"}`)
+	})
+
+	req := &CreateContactImportRequest{
+		File: []byte("email\nsteve@example.com"),
+		Topics: []TopicSubscriptionUpdate{
+			{Id: "059ac693-2fc8-4c13-8b27-01350d638a17", Subscription: "opt_in"},
+		},
+	}
+	resp, err := client.Contacts.Imports.Create(req)
+	if err != nil {
+		t.Errorf("ContactImports.Create returned error: %v", err)
+	}
+	assert.Equal(t, "479e3145-dd38-476b-932c-529ceb705947", resp.Id)
+}
+
 func TestCreateContactImportMissingFile(t *testing.T) {
 	setup()
 	defer teardown()

--- a/examples/contact_imports.go
+++ b/examples/contact_imports.go
@@ -35,6 +35,9 @@ func contactImportsExample() {
 			},
 		},
 		Segments: []string{"78e7a5c6-9a91-4c63-9d1f-3b9c0b5b9ab6"},
+		Topics: []resend.TopicSubscriptionUpdate{
+			{Id: "284edd7e-b042-46dd-b5ee-a8a88a9ec65f", Subscription: "opt_in"},
+		},
 	}
 
 	created, err := client.Contacts.Imports.CreateWithContext(ctx, createParams)

--- a/resend.go
+++ b/resend.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version     = "3.9.0"
+	version     = "3.9.1"
 	userAgent   = "resend-go/" + version
 	contentType = "application/json"
 )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add topics support to contact imports so you can set topic subscriptions during uploads. Contacts can be opted in or out of topics as part of the import.

- **New Features**
  - Add `Topics []TopicSubscriptionUpdate` to `CreateContactImportRequest` and send as `topics` in the multipart payload (supports `opt_in`/`opt_out` per topic).
  - Add test and example showing topics usage; bump version to `3.9.1`.

<sup>Written for commit 75b7cf47936593492bcb237e45bfdd6f58964ddd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

