### PR TITLE
fix: contact imports segments accept objects instead of string IDs

### DIFF
--- a/contact_imports.go
+++ b/contact_imports.go
@@ -37,6 +37,11 @@ type ContactImport struct {
 	Counts    *ContactImportCounts `json:"counts,omitempty"`
 }
 
+// ContactImportSegment represents a segment reference for a contact import.
+type ContactImportSegment struct {
+	Id string `json:"id"`
+}
+
 // CreateContactImportRequest contains params for creating a contact import.
 // File is required; all other fields are optional.
 type CreateContactImportRequest struct {
@@ -50,9 +55,9 @@ type CreateContactImportRequest struct {
 	ColumnMap map[string]any
 	// OnConflict strategy: "upsert" or "skip" (default "skip").
 	OnConflict string
-	// Segments is a list of segment IDs to add imported contacts to.
-	// Will be JSON-encoded as [{"id": "..."}] before sending.
-	Segments []string
+	// Segments is a list of segment objects to add imported contacts to.
+	// Example: []ContactImportSegment{{Id: "60a2ac5e-0774-456e-817d-ebf40f6dba31"}}
+	Segments []ContactImportSegment
 	// Topics is a list of topic subscriptions to apply to imported contacts.
 	// Will be JSON-encoded as [{"id": "...", "subscription": "opt_in|opt_out"}] before sending.
 	Topics []TopicSubscriptionUpdate
@@ -120,11 +125,7 @@ func (s *ContactImportsSvcImpl) CreateWithContext(ctx context.Context, params *C
 		fields["column_map"] = string(b)
 	}
 	if len(params.Segments) > 0 {
-		segs := make([]map[string]string, len(params.Segments))
-		for i, id := range params.Segments {
-			segs[i] = map[string]string{"id": id}
-		}
-		b, err := json.Marshal(segs)
+		b, err := json.Marshal(params.Segments)
 		if err != nil {
 			return CreateContactImportResponse{}, fmt.Errorf("[ERROR]: Failed to encode segments: %w", err)
 		}

--- a/contact_imports_test.go
+++ b/contact_imports_test.go
@@ -48,7 +48,7 @@ func TestCreateContactImportWithOptions(t *testing.T) {
 		File:       []byte("email\nsteve@example.com"),
 		OnConflict: "upsert",
 		ColumnMap:  map[string]any{"email": "Email"},
-		Segments:   []string{"seg-123"},
+		Segments:   []ContactImportSegment{{Id: "seg-123"}},
 	}
 	resp, err := client.Contacts.Imports.Create(req)
 	if err != nil {

--- a/examples/contact_imports.go
+++ b/examples/contact_imports.go
@@ -34,7 +34,7 @@ func contactImportsExample() {
 				},
 			},
 		},
-		Segments: []string{"78e7a5c6-9a91-4c63-9d1f-3b9c0b5b9ab6"},
+		Segments: []resend.ContactImportSegment{{Id: "78e7a5c6-9a91-4c63-9d1f-3b9c0b5b9ab6"}},
 		Topics: []resend.TopicSubscriptionUpdate{
 			{Id: "284edd7e-b042-46dd-b5ee-a8a88a9ec65f", Subscription: "opt_in"},
 		},

--- a/resend.go
+++ b/resend.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version     = "3.9.1"
+	version     = "3.9.2"
 	userAgent   = "resend-go/" + version
 	contentType = "application/json"
 )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes contact import segments to accept segment objects instead of string IDs, matching the API contract. Bumps SDK version to 3.9.2.

- **Bug Fixes**
  - Replaced `Segments []string` with `Segments []ContactImportSegment` in `CreateContactImportRequest`.
  - Marshal `Segments` directly as objects.
  - Updated tests and `examples/contact_imports.go` to use the object form.

- **Migration**
  - Update calls from `Segments: []string{"seg-123"}` to `Segments: []resend.ContactImportSegment{{Id: "seg-123"}}`.

<sup>Written for commit 71a068f3c01358f881dd9562190e18bee1e10405. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

