### PR TITLE
feat: add received_for to received email type

### DIFF
--- a/receiving.go
+++ b/receiving.go
@@ -18,6 +18,7 @@ type ReceivedEmail struct {
 	Bcc         []string             `json:"bcc"`
 	Cc          []string             `json:"cc"`
 	ReplyTo     []string             `json:"reply_to"`
+	ReceivedFor []string             `json:"received_for"`
 	Headers     map[string]string    `json:"headers"`
 	MessageId   string               `json:"message_id"`
 	Attachments []ReceivedAttachment `json:"attachments"`

--- a/receiving_test.go
+++ b/receiving_test.go
@@ -33,6 +33,7 @@ func TestGetReceivedEmail(t *testing.T) {
 			"bcc": [],
 			"cc": ["cc@example.com"],
 			"reply_to": ["reply@example.com"],
+			"received_for": ["forwarded@example.com"],
 			"headers": {
 				"X-Custom-Header": "value"
 			},
@@ -69,6 +70,8 @@ func TestGetReceivedEmail(t *testing.T) {
 	assert.Equal(t, "cc@example.com", resp.Cc[0])
 	assert.Equal(t, 1, len(resp.ReplyTo))
 	assert.Equal(t, "reply@example.com", resp.ReplyTo[0])
+	assert.Equal(t, 1, len(resp.ReceivedFor))
+	assert.Equal(t, "forwarded@example.com", resp.ReceivedFor[0])
 	assert.Equal(t, 1, len(resp.Headers))
 	assert.Equal(t, "value", resp.Headers["X-Custom-Header"])
 	assert.Equal(t, "<test-message-id@example.com>", resp.MessageId)


### PR DESCRIPTION
Adds the received_for field to the received email response type, matching the API.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `received_for` to the `ReceivedEmail` response to match the API and expose the original recipient(s). Updated tests to parse and assert the new field.

<sup>Written for commit c2b645c30a5591ee5570f3db4cdd4cb6019aacf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

