### PR TITLE
feat: add domain claims endpoints

### DIFF
--- a/domain_claims.go
+++ b/domain_claims.go
@@ -1,0 +1,151 @@
+package resend
+
+import (
+	"context"
+	"errors"
+	"net/http"
+)
+
+type DomainClaimStatus = string
+
+const (
+	DomainClaimStatusPending    DomainClaimStatus = "pending"
+	DomainClaimStatusVerified   DomainClaimStatus = "verified"
+	DomainClaimStatusCompleted  DomainClaimStatus = "completed"
+	DomainClaimStatusBlocked    DomainClaimStatus = "blocked"
+	DomainClaimStatusExpired    DomainClaimStatus = "expired"
+	DomainClaimStatusSuperseded DomainClaimStatus = "superseded"
+	DomainClaimStatusCanceled   DomainClaimStatus = "canceled"
+	DomainClaimStatusFailed     DomainClaimStatus = "failed"
+)
+
+type DomainClaimBlockedReason = string
+
+const (
+	DomainClaimBlockedReasonGracePeriod            DomainClaimBlockedReason = "grace_period"
+	DomainClaimBlockedReasonRecentOwnerActivity    DomainClaimBlockedReason = "recent_owner_activity"
+	DomainClaimBlockedReasonPendingScheduledEmails DomainClaimBlockedReason = "pending_scheduled_emails"
+)
+
+// DomainClaimRecord is the TXT record to add to your DNS to prove ownership of the claimed domain.
+type DomainClaimRecord struct {
+	Type  string `json:"type,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
+	Ttl   string `json:"ttl,omitempty"`
+}
+
+type DomainClaim struct {
+	Object        string             `json:"object,omitempty"`
+	Id            string             `json:"id,omitempty"`
+	Name          string             `json:"name,omitempty"`
+	Status        DomainClaimStatus  `json:"status,omitempty"`
+	DomainId      string             `json:"domain_id,omitempty"`
+	Region        string             `json:"region,omitempty"`
+	Record        *DomainClaimRecord `json:"record,omitempty"`
+	BlockedReason string             `json:"blocked_reason,omitempty"`
+	FailureReason string             `json:"failure_reason,omitempty"`
+	CreatedAt     string             `json:"created_at,omitempty"`
+	ExpiresAt     string             `json:"expires_at,omitempty"`
+}
+
+// CreateDomainClaimRequest contains params for starting a domain claim.
+// Uses the same fields as CreateDomainRequest.
+type CreateDomainClaimRequest struct {
+	Name              string `json:"name"`
+	Region            string `json:"region,omitempty"`
+	CustomReturnPath  string `json:"custom_return_path,omitempty"`
+	TrackingSubdomain string `json:"tracking_subdomain,omitempty"`
+	OpenTracking      *bool  `json:"open_tracking,omitempty"`
+	ClickTracking     *bool  `json:"click_tracking,omitempty"`
+}
+
+type DomainClaimsSvc interface {
+	Create(params *CreateDomainClaimRequest) (DomainClaim, error)
+	CreateWithContext(ctx context.Context, params *CreateDomainClaimRequest) (DomainClaim, error)
+	Get(domainId string) (DomainClaim, error)
+	GetWithContext(ctx context.Context, domainId string) (DomainClaim, error)
+	Verify(domainId string) (DomainClaim, error)
+	VerifyWithContext(ctx context.Context, domainId string) (DomainClaim, error)
+}
+
+type DomainClaimsSvcImpl struct {
+	client *Client
+}
+
+// CreateWithContext starts a claim for a domain that another Resend account has already
+// verified, using the given context.
+// https://resend.com/docs/api-reference/domains/claim-domain
+func (s *DomainClaimsSvcImpl) CreateWithContext(ctx context.Context, params *CreateDomainClaimRequest) (DomainClaim, error) {
+	path := "domains/claim"
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, params)
+	if err != nil {
+		return DomainClaim{}, errors.New("[ERROR]: Failed to create Domains.Claims.Create request")
+	}
+
+	resp := new(DomainClaim)
+	_, err = s.client.Perform(req, resp)
+	if err != nil {
+		return DomainClaim{}, err
+	}
+	return *resp, nil
+}
+
+// Create starts a claim for a domain that another Resend account has already verified.
+// https://resend.com/docs/api-reference/domains/claim-domain
+func (s *DomainClaimsSvcImpl) Create(params *CreateDomainClaimRequest) (DomainClaim, error) {
+	return s.CreateWithContext(context.Background(), params)
+}
+
+// GetWithContext retrieves the latest claim for the placeholder domain created by the claim,
+// using the given context.
+// https://resend.com/docs/api-reference/domains/get-domain-claim
+func (s *DomainClaimsSvcImpl) GetWithContext(ctx context.Context, domainId string) (DomainClaim, error) {
+	path := "domains/" + domainId + "/claim"
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return DomainClaim{}, errors.New("[ERROR]: Failed to create Domains.Claims.Get request")
+	}
+
+	resp := new(DomainClaim)
+	_, err = s.client.Perform(req, resp)
+	if err != nil {
+		return DomainClaim{}, err
+	}
+	return *resp, nil
+}
+
+// Get retrieves the latest claim for the placeholder domain created by the claim.
+// https://resend.com/docs/api-reference/domains/get-domain-claim
+func (s *DomainClaimsSvcImpl) Get(domainId string) (DomainClaim, error) {
+	return s.GetWithContext(context.Background(), domainId)
+}
+
+// VerifyWithContext triggers asynchronous DNS verification and ownership transfer for a
+// domain claim, using the given context. The claim stays "pending" while verification runs;
+// poll GetWithContext for status.
+// https://resend.com/docs/api-reference/domains/verify-domain-claim
+func (s *DomainClaimsSvcImpl) VerifyWithContext(ctx context.Context, domainId string) (DomainClaim, error) {
+	path := "domains/" + domainId + "/claim/verify"
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, nil)
+	if err != nil {
+		return DomainClaim{}, errors.New("[ERROR]: Failed to create Domains.Claims.Verify request")
+	}
+
+	resp := new(DomainClaim)
+	_, err = s.client.Perform(req, resp)
+	if err != nil {
+		return DomainClaim{}, err
+	}
+	return *resp, nil
+}
+
+// Verify triggers asynchronous DNS verification and ownership transfer for a domain claim.
+// The claim stays "pending" while verification runs; poll Get for status.
+// https://resend.com/docs/api-reference/domains/verify-domain-claim
+func (s *DomainClaimsSvcImpl) Verify(domainId string) (DomainClaim, error) {
+	return s.VerifyWithContext(context.Background(), domainId)
+}

--- a/domain_claims.go
+++ b/domain_claims.go
@@ -81,7 +81,7 @@ func (s *DomainClaimsSvcImpl) CreateWithContext(ctx context.Context, params *Cre
 
 	req, err := s.client.NewRequest(ctx, http.MethodPost, path, params)
 	if err != nil {
-		return DomainClaim{}, errors.New("[ERROR]: Failed to create Domains.Claims.Create request")
+		return DomainClaim{}, errors.New("[ERROR]: Failed to create DomainClaims.Create request")
 	}
 
 	resp := new(DomainClaim)
@@ -106,7 +106,7 @@ func (s *DomainClaimsSvcImpl) GetWithContext(ctx context.Context, domainId strin
 
 	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
-		return DomainClaim{}, errors.New("[ERROR]: Failed to create Domains.Claims.Get request")
+		return DomainClaim{}, errors.New("[ERROR]: Failed to create DomainClaims.Get request")
 	}
 
 	resp := new(DomainClaim)
@@ -132,7 +132,7 @@ func (s *DomainClaimsSvcImpl) VerifyWithContext(ctx context.Context, domainId st
 
 	req, err := s.client.NewRequest(ctx, http.MethodPost, path, nil)
 	if err != nil {
-		return DomainClaim{}, errors.New("[ERROR]: Failed to create Domains.Claims.Verify request")
+		return DomainClaim{}, errors.New("[ERROR]: Failed to create DomainClaims.Verify request")
 	}
 
 	resp := new(DomainClaim)

--- a/domain_claims_test.go
+++ b/domain_claims_test.go
@@ -1,0 +1,166 @@
+package resend
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateDomainClaim(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/domains/claim", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprint(w, `{
+			"object": "domain_claim",
+			"id": "dacf4072-4119-4d88-932f-6c6126d3a9d1",
+			"name": "example.com",
+			"status": "pending",
+			"domain_id": "d91cd9bd-1176-453e-8fc1-35364d380206",
+			"region": "us-east-1",
+			"record": {
+				"type": "TXT",
+				"name": "example.com",
+				"value": "resend-domain-verification=3f8a1c2d4e5b6a7f8091a2b3c4d5e6f7",
+				"ttl": "Auto"
+			},
+			"blocked_reason": null,
+			"failure_reason": null,
+			"created_at": "2026-06-16T17:12:02.059593+00:00",
+			"expires_at": "2026-06-23T17:12:02.059593+00:00"
+		}`)
+	})
+
+	req := &CreateDomainClaimRequest{
+		Name:   "example.com",
+		Region: "us-east-1",
+	}
+	resp, err := client.Domains.Claims.Create(req)
+	if err != nil {
+		t.Errorf("Domains.Claims.Create returned error: %v", err)
+	}
+
+	assert.Equal(t, "domain_claim", resp.Object)
+	assert.Equal(t, "dacf4072-4119-4d88-932f-6c6126d3a9d1", resp.Id)
+	assert.Equal(t, "example.com", resp.Name)
+	assert.Equal(t, DomainClaimStatusPending, resp.Status)
+	assert.Equal(t, "d91cd9bd-1176-453e-8fc1-35364d380206", resp.DomainId)
+	assert.Equal(t, "us-east-1", resp.Region)
+	assert.NotNil(t, resp.Record)
+	assert.Equal(t, "TXT", resp.Record.Type)
+	assert.Equal(t, "example.com", resp.Record.Name)
+	assert.Equal(t, "resend-domain-verification=3f8a1c2d4e5b6a7f8091a2b3c4d5e6f7", resp.Record.Value)
+	assert.Equal(t, "Auto", resp.Record.Ttl)
+	assert.Equal(t, "", resp.BlockedReason)
+	assert.Equal(t, "", resp.FailureReason)
+}
+
+func TestCreateDomainClaimSendsAllOptions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/domains/claim", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		assert.Equal(t, "example.com", body["name"])
+		assert.Equal(t, "us-east-1", body["region"])
+		assert.Equal(t, "send", body["custom_return_path"])
+		assert.Equal(t, true, body["open_tracking"])
+		assert.Equal(t, false, body["click_tracking"])
+		assert.Equal(t, "links", body["tracking_subdomain"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{
+			"object": "domain_claim",
+			"id": "dacf4072-4119-4d88-932f-6c6126d3a9d1",
+			"name": "example.com",
+			"status": "pending"
+		}`)
+	})
+
+	req := &CreateDomainClaimRequest{
+		Name:              "example.com",
+		Region:            "us-east-1",
+		CustomReturnPath:  "send",
+		OpenTracking:      Bool(true),
+		ClickTracking:     Bool(false),
+		TrackingSubdomain: "links",
+	}
+	_, err := client.Domains.Claims.Create(req)
+	if err != nil {
+		t.Errorf("Domains.Claims.Create returned error: %v", err)
+	}
+}
+
+func TestGetDomainClaim(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/domains/d91cd9bd-1176-453e-8fc1-35364d380206/claim", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `{
+			"object": "domain_claim",
+			"id": "dacf4072-4119-4d88-932f-6c6126d3a9d1",
+			"name": "example.com",
+			"status": "blocked",
+			"domain_id": "d91cd9bd-1176-453e-8fc1-35364d380206",
+			"region": "us-east-1",
+			"blocked_reason": "grace_period",
+			"failure_reason": null,
+			"created_at": "2026-06-16T17:12:02.059593+00:00",
+			"expires_at": "2026-06-23T17:12:02.059593+00:00"
+		}`)
+	})
+
+	resp, err := client.Domains.Claims.Get("d91cd9bd-1176-453e-8fc1-35364d380206")
+	if err != nil {
+		t.Errorf("Domains.Claims.Get returned error: %v", err)
+	}
+
+	assert.Equal(t, "dacf4072-4119-4d88-932f-6c6126d3a9d1", resp.Id)
+	assert.Equal(t, DomainClaimStatusBlocked, resp.Status)
+	assert.Equal(t, DomainClaimBlockedReasonGracePeriod, resp.BlockedReason)
+}
+
+func TestVerifyDomainClaim(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/domains/d91cd9bd-1176-453e-8fc1-35364d380206/claim/verify", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `{
+			"object": "domain_claim",
+			"id": "dacf4072-4119-4d88-932f-6c6126d3a9d1",
+			"name": "example.com",
+			"status": "pending",
+			"domain_id": "d91cd9bd-1176-453e-8fc1-35364d380206",
+			"region": "us-east-1"
+		}`)
+	})
+
+	resp, err := client.Domains.Claims.Verify("d91cd9bd-1176-453e-8fc1-35364d380206")
+	if err != nil {
+		t.Errorf("Domains.Claims.Verify returned error: %v", err)
+	}
+
+	assert.Equal(t, "dacf4072-4119-4d88-932f-6c6126d3a9d1", resp.Id)
+	assert.Equal(t, DomainClaimStatusPending, resp.Status)
+}

--- a/domain_claims_test.go
+++ b/domain_claims_test.go
@@ -42,9 +42,9 @@ func TestCreateDomainClaim(t *testing.T) {
 		Name:   "example.com",
 		Region: "us-east-1",
 	}
-	resp, err := client.Domains.Claims.Create(req)
+	resp, err := client.DomainClaims.Create(req)
 	if err != nil {
-		t.Errorf("Domains.Claims.Create returned error: %v", err)
+		t.Errorf("DomainClaims.Create returned error: %v", err)
 	}
 
 	assert.Equal(t, "domain_claim", resp.Object)
@@ -98,9 +98,9 @@ func TestCreateDomainClaimSendsAllOptions(t *testing.T) {
 		ClickTracking:     Bool(false),
 		TrackingSubdomain: "links",
 	}
-	_, err := client.Domains.Claims.Create(req)
+	_, err := client.DomainClaims.Create(req)
 	if err != nil {
-		t.Errorf("Domains.Claims.Create returned error: %v", err)
+		t.Errorf("DomainClaims.Create returned error: %v", err)
 	}
 }
 
@@ -127,9 +127,9 @@ func TestGetDomainClaim(t *testing.T) {
 		}`)
 	})
 
-	resp, err := client.Domains.Claims.Get("d91cd9bd-1176-453e-8fc1-35364d380206")
+	resp, err := client.DomainClaims.Get("d91cd9bd-1176-453e-8fc1-35364d380206")
 	if err != nil {
-		t.Errorf("Domains.Claims.Get returned error: %v", err)
+		t.Errorf("DomainClaims.Get returned error: %v", err)
 	}
 
 	assert.Equal(t, "dacf4072-4119-4d88-932f-6c6126d3a9d1", resp.Id)
@@ -156,9 +156,9 @@ func TestVerifyDomainClaim(t *testing.T) {
 		}`)
 	})
 
-	resp, err := client.Domains.Claims.Verify("d91cd9bd-1176-453e-8fc1-35364d380206")
+	resp, err := client.DomainClaims.Verify("d91cd9bd-1176-453e-8fc1-35364d380206")
 	if err != nil {
-		t.Errorf("Domains.Claims.Verify returned error: %v", err)
+		t.Errorf("DomainClaims.Verify returned error: %v", err)
 	}
 
 	assert.Equal(t, "dacf4072-4119-4d88-932f-6c6126d3a9d1", resp.Id)

--- a/domains.go
+++ b/domains.go
@@ -62,6 +62,7 @@ type DomainsSvc interface {
 
 type DomainsSvcImpl struct {
 	client *Client
+	Claims DomainClaimsSvc
 }
 
 type DomainCapabilityStatus = string

--- a/domains.go
+++ b/domains.go
@@ -62,7 +62,6 @@ type DomainsSvc interface {
 
 type DomainsSvcImpl struct {
 	client *Client
-	Claims DomainClaimsSvc
 }
 
 type DomainCapabilityStatus = string

--- a/examples/domain_claims.go
+++ b/examples/domain_claims.go
@@ -20,7 +20,7 @@ func domainClaimsExample() {
 		Region: "us-east-1",
 	}
 
-	claim, err := client.Domains.Claims.CreateWithContext(ctx, claimParams)
+	claim, err := client.DomainClaims.CreateWithContext(ctx, claimParams)
 	if err != nil {
 		panic(err)
 	}
@@ -31,14 +31,14 @@ func domainClaimsExample() {
 	}
 
 	// Get: poll the claim until the TXT record has been added and verification can run.
-	retrievedClaim, err := client.Domains.Claims.GetWithContext(ctx, claim.DomainId)
+	retrievedClaim, err := client.DomainClaims.GetWithContext(ctx, claim.DomainId)
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("Retrieved domain claim: %v\n", retrievedClaim)
 
 	// Verify: trigger asynchronous DNS verification and ownership transfer.
-	verifiedClaim, err := client.Domains.Claims.VerifyWithContext(ctx, claim.DomainId)
+	verifiedClaim, err := client.DomainClaims.VerifyWithContext(ctx, claim.DomainId)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/domain_claims.go
+++ b/examples/domain_claims.go
@@ -1,0 +1,46 @@
+package examples
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/resend/resend-go/v3"
+)
+
+func domainClaimsExample() {
+	ctx := context.TODO()
+	apiKey := os.Getenv("RESEND_API_KEY")
+
+	client := resend.NewClient(apiKey)
+
+	// Start a claim for a domain that another Resend account has already verified.
+	claimParams := &resend.CreateDomainClaimRequest{
+		Name:   "example.com",
+		Region: "us-east-1",
+	}
+
+	claim, err := client.Domains.Claims.CreateWithContext(ctx, claimParams)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Created domain claim id: " + claim.Id)
+	fmt.Println("Status: " + claim.Status)
+	if claim.Record != nil {
+		fmt.Printf("Add this TXT record to prove ownership: %s = %s\n", claim.Record.Name, claim.Record.Value)
+	}
+
+	// Get: poll the claim until the TXT record has been added and verification can run.
+	retrievedClaim, err := client.Domains.Claims.GetWithContext(ctx, claim.DomainId)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Retrieved domain claim: %v\n", retrievedClaim)
+
+	// Verify: trigger asynchronous DNS verification and ownership transfer.
+	verifiedClaim, err := client.Domains.Claims.VerifyWithContext(ctx, claim.DomainId)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Verification triggered, claim status: " + verifiedClaim.Status)
+}

--- a/resend.go
+++ b/resend.go
@@ -53,7 +53,7 @@ type Client struct {
 	Emails   *EmailsSvcImpl
 	Batch    BatchSvc
 	ApiKeys  ApiKeysSvc
-	Domains  DomainsSvc
+	Domains  *DomainsSvcImpl
 	Segments SegmentsSvc
 	// Deprecated: Use Segments instead. Audiences have been renamed to Segments.
 	Audiences         AudiencesSvc
@@ -97,7 +97,9 @@ func NewCustomClient(httpClient *http.Client, apiKey string) *Client {
 
 	c.Batch = &BatchSvcImpl{client: c}
 	c.ApiKeys = &ApiKeysSvcImpl{client: c}
-	c.Domains = &DomainsSvcImpl{client: c}
+	domainsSvc := &DomainsSvcImpl{client: c}
+	domainsSvc.Claims = &DomainClaimsSvcImpl{client: c}
+	c.Domains = domainsSvc
 	segmentsSvc := &SegmentsSvcImpl{client: c}
 	c.Segments = segmentsSvc
 	// Audiences is a deprecated alias for Segments for backward compatibility

--- a/resend.go
+++ b/resend.go
@@ -50,11 +50,12 @@ type Client struct {
 	headers map[string]string
 
 	// Services
-	Emails   *EmailsSvcImpl
-	Batch    BatchSvc
-	ApiKeys  ApiKeysSvc
-	Domains  *DomainsSvcImpl
-	Segments SegmentsSvc
+	Emails       *EmailsSvcImpl
+	Batch        BatchSvc
+	ApiKeys      ApiKeysSvc
+	Domains      DomainsSvc
+	DomainClaims DomainClaimsSvc
+	Segments     SegmentsSvc
 	// Deprecated: Use Segments instead. Audiences have been renamed to Segments.
 	Audiences         AudiencesSvc
 	Contacts          *ContactsSvcImpl
@@ -97,9 +98,8 @@ func NewCustomClient(httpClient *http.Client, apiKey string) *Client {
 
 	c.Batch = &BatchSvcImpl{client: c}
 	c.ApiKeys = &ApiKeysSvcImpl{client: c}
-	domainsSvc := &DomainsSvcImpl{client: c}
-	domainsSvc.Claims = &DomainClaimsSvcImpl{client: c}
-	c.Domains = domainsSvc
+	c.Domains = &DomainsSvcImpl{client: c}
+	c.DomainClaims = &DomainClaimsSvcImpl{client: c}
 	segmentsSvc := &SegmentsSvcImpl{client: c}
 	c.Segments = segmentsSvc
 	// Audiences is a deprecated alias for Segments for backward compatibility

--- a/resend.go
+++ b/resend.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version     = "3.10.1"
+	version     = "3.11.0"
 	userAgent   = "resend-go/" + version
 	contentType = "application/json"
 )


### PR DESCRIPTION
Adds Domains.Claims sub-service with Create, Get, and Verify methods covering the new Domain Claims API:
- POST /domains/claim
- GET /domains/{domain_id}/claim
- POST /domains/{domain_id}/claim/verify

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Domain Claims support via a new top‑level `DomainClaims` service to create, get, and verify claims. Exposed as a sibling service to `Domains` (no breaking changes).

- **New Features**
  - Endpoints: POST `/domains/claim`, GET `/domains/{domain_id}/claim`, POST `/domains/{domain_id}/claim/verify`.
  - SDK: new top‑level `client.DomainClaims` with `Create`, `Get`, `Verify` (+ `WithContext` variants).
  - Typed statuses and blocked reasons.
  - Example added at `examples/domain_claims.go`.

<sup>Written for commit 37a9947117d4881b1f3b2222d15d6da868322940. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

