### PR TITLE
feat!: SendEmailRequest's ReplyTo can be a list

### DIFF
--- a/emails.go
+++ b/emails.go
@@ -31,7 +31,7 @@ type SendEmailRequest struct {
 	Subject     string            `json:"subject"`
 	Bcc         []string          `json:"bcc,omitempty"`
 	Cc          []string          `json:"cc,omitempty"`
-	ReplyTo     string            `json:"reply_to,omitempty"`
+	ReplyTo     []string          `json:"reply_to,omitempty"`
 	Html        string            `json:"html,omitempty"`
 	Text        string            `json:"text,omitempty"`
 	Tags        []Tag             `json:"tags,omitempty"`

--- a/emails_test.go
+++ b/emails_test.go
@@ -660,7 +660,7 @@ func TestSendEmailWithTemplateAndOverrides(t *testing.T) {
 		// Verify overridden fields
 		assert.Equal(t, "custom-sender@example.com", req.From)
 		assert.Equal(t, "Custom Subject Line", req.Subject)
-		assert.Equal(t, "reply@example.com", req.ReplyTo)
+		assert.Equal(t, []string{"reply@example.com"}, req.ReplyTo)
 		assert.Equal(t, []string{"bcc@example.com"}, req.Bcc)
 		assert.Equal(t, 1, len(req.Tags))
 		assert.Equal(t, "campaign", req.Tags[0].Name)
@@ -680,7 +680,7 @@ func TestSendEmailWithTemplateAndOverrides(t *testing.T) {
 		To:      []string{"subscriber@example.com"},
 		Subject: "Custom Subject Line",
 		Bcc:     []string{"bcc@example.com"},
-		ReplyTo: "reply@example.com",
+		ReplyTo: []string{"reply@example.com"},
 		Tags: []Tag{
 			{Name: "campaign", Value: "2024-q1"},
 		},

--- a/examples/send_email.go
+++ b/examples/send_email.go
@@ -22,7 +22,7 @@ func sendEmailExample() {
 		Subject: "Hello from Golang",
 		Cc:      []string{"cc@example.com"},
 		Bcc:     []string{"ccc@example.com"},
-		ReplyTo: "to@example.com",
+		ReplyTo: []string{"to@example.com"},
 	}
 
 	sent, err := client.Emails.SendWithContext(ctx, params)

--- a/examples/send_email_custom_client.go
+++ b/examples/send_email_custom_client.go
@@ -34,7 +34,7 @@ func sendEmailCustomClientExample() {
 		Subject: "Hello from Golang",
 		Cc:      []string{"cc@example.com"},
 		Bcc:     []string{"ccc@example.com"},
-		ReplyTo: "to@example.com",
+		ReplyTo: []string{"to@example.com"},
 	}
 
 	sent, err := client.Emails.SendWithContext(ctx, params)

--- a/examples/send_email_with_template.go
+++ b/examples/send_email_with_template.go
@@ -106,7 +106,7 @@ func sendEmailWithTemplateExample() {
 		To:      []string{"delivered@resend.dev"},
 		Subject: "Custom Subject Override", // Override template's Subject
 		Bcc:     []string{"bcc@example.com"},
-		ReplyTo: "noreply@resend.dev",
+		ReplyTo: []string{"noreply@resend.dev"},
 		Template: &resend.EmailTemplate{
 			Id: template.Id,
 			Variables: map[string]any{


### PR DESCRIPTION
ref - https://resend.com/docs/api-reference/emails/send-email#reply-to

Not sure how this kind of breaking changes should be handled.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Support multiple reply-to addresses by changing `SendEmailRequest.ReplyTo` from `string` to `[]string`, matching the Resend API. This is a breaking change; tests and examples updated.

- **Migration**
  - Replace single string values with a slice, e.g., `ReplyTo: []string{"reply@example.com"}` (for multiple, add more emails).

<sup>Written for commit 21ab983b7f3081dfbc4cb7c30c92751765ed7eb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

