### PR TITLE
feat: add OAuth grants endpoints

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -125,3 +125,9 @@ var (
 	ErrFailedToCreateEventRemoveRequest = errors.New("[ERROR]: Failed to create Events.Remove request")
 	ErrFailedToCreateEventSendRequest   = errors.New("[ERROR]: Failed to create Events.Send request")
 )
+
+// OAuthGrantsSvc errors
+var (
+	ErrFailedToCreateOAuthGrantsListRequest   = errors.New("[ERROR]: Failed to create OAuthGrants.List request")
+	ErrFailedToCreateOAuthGrantsRevokeRequest = errors.New("[ERROR]: Failed to create OAuthGrants.Revoke request")
+)

--- a/examples/oauth_grants.go
+++ b/examples/oauth_grants.go
@@ -14,7 +14,6 @@ func oauthGrantsExample() {
 
 	client := resend.NewClient(apiKey)
 
-	// List OAuth grants
 	grants, err := client.OAuthGrants.ListWithContext(ctx)
 	if err != nil {
 		panic(err)
@@ -25,7 +24,6 @@ func oauthGrantsExample() {
 		return
 	}
 
-	// Revoke the first grant
 	revoked, err := client.OAuthGrants.RevokeWithContext(ctx, grants.Data[0].Id)
 	if err != nil {
 		panic(err)

--- a/examples/oauth_grants.go
+++ b/examples/oauth_grants.go
@@ -1,0 +1,34 @@
+package examples
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/resend/resend-go/v3"
+)
+
+func oauthGrantsExample() {
+	ctx := context.TODO()
+	apiKey := os.Getenv("RESEND_API_KEY")
+
+	client := resend.NewClient(apiKey)
+
+	// List OAuth grants
+	grants, err := client.OAuthGrants.ListWithContext(ctx)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("You have %d OAuth grants\n", len(grants.Data))
+
+	if len(grants.Data) == 0 {
+		return
+	}
+
+	// Revoke the first grant
+	revoked, err := client.OAuthGrants.RevokeWithContext(ctx, grants.Data[0].Id)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Revoked OAuth grant %s (reason: %s)\n", revoked.Id, revoked.RevokedReason)
+}

--- a/examples/oauth_grants.go
+++ b/examples/oauth_grants.go
@@ -30,5 +30,9 @@ func oauthGrantsExample() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("Revoked OAuth grant %s (reason: %s)\n", revoked.Id, revoked.RevokedReason)
+	reason := "unknown"
+	if revoked.RevokedReason != nil {
+		reason = *revoked.RevokedReason
+	}
+	fmt.Printf("Revoked OAuth grant %s (reason: %s)\n", revoked.Id, reason)
 }

--- a/oauth_grants.go
+++ b/oauth_grants.go
@@ -5,13 +5,11 @@ import (
 	"net/http"
 )
 
-// OAuthGrantClient represents the OAuth client that a grant was issued to.
 type OAuthGrantClient struct {
 	Name    string  `json:"name"`
 	LogoUri *string `json:"logo_uri"`
 }
 
-// OAuthGrant represents an OAuth grant.
 type OAuthGrant struct {
 	Id            string           `json:"id"`
 	ClientId      string           `json:"client_id"`
@@ -47,8 +45,6 @@ type OAuthGrantsSvcImpl struct {
 	client *Client
 }
 
-// ListWithOptions lists all of the team's OAuth grants with pagination options
-// https://resend.com/docs/api-reference/oauth/list-grants
 func (s *OAuthGrantsSvcImpl) ListWithOptions(ctx context.Context, options *ListOptions) (ListOAuthGrantsResponse, error) {
 	path := "oauth/grants" + buildPaginationQuery(options)
 
@@ -67,19 +63,14 @@ func (s *OAuthGrantsSvcImpl) ListWithOptions(ctx context.Context, options *ListO
 	return *grantsResp, nil
 }
 
-// ListWithContext lists all of the team's OAuth grants
-// https://resend.com/docs/api-reference/oauth/list-grants
 func (s *OAuthGrantsSvcImpl) ListWithContext(ctx context.Context) (ListOAuthGrantsResponse, error) {
 	return s.ListWithOptions(ctx, nil)
 }
 
-// List lists all of the team's OAuth grants
 func (s *OAuthGrantsSvcImpl) List() (ListOAuthGrantsResponse, error) {
 	return s.ListWithContext(context.Background())
 }
 
-// RevokeWithContext revokes a given OAuth grant by id
-// https://resend.com/docs/api-reference/oauth/revoke-grant
 func (s *OAuthGrantsSvcImpl) RevokeWithContext(ctx context.Context, oauthGrantId string) (RevokeOAuthGrantResponse, error) {
 	path := "oauth/grants/" + oauthGrantId
 
@@ -98,7 +89,6 @@ func (s *OAuthGrantsSvcImpl) RevokeWithContext(ctx context.Context, oauthGrantId
 	return *grantResp, nil
 }
 
-// Revoke revokes a given OAuth grant by id
 func (s *OAuthGrantsSvcImpl) Revoke(oauthGrantId string) (RevokeOAuthGrantResponse, error) {
 	return s.RevokeWithContext(context.Background(), oauthGrantId)
 }

--- a/oauth_grants.go
+++ b/oauth_grants.go
@@ -29,10 +29,10 @@ type ListOAuthGrantsResponse struct {
 }
 
 type RevokeOAuthGrantResponse struct {
-	Object        string `json:"object"`
-	Id            string `json:"id"`
-	RevokedAt     string `json:"revoked_at"`
-	RevokedReason string `json:"revoked_reason"`
+	Object        string  `json:"object"`
+	Id            string  `json:"id"`
+	RevokedAt     *string `json:"revoked_at"`
+	RevokedReason *string `json:"revoked_reason"`
 }
 
 type OAuthGrantsSvc interface {

--- a/oauth_grants.go
+++ b/oauth_grants.go
@@ -52,18 +52,14 @@ type OAuthGrantsSvcImpl struct {
 func (s *OAuthGrantsSvcImpl) ListWithOptions(ctx context.Context, options *ListOptions) (ListOAuthGrantsResponse, error) {
 	path := "oauth/grants" + buildPaginationQuery(options)
 
-	// Prepare request
 	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return ListOAuthGrantsResponse{}, ErrFailedToCreateOAuthGrantsListRequest
 	}
 
-	// Build response recipient obj
 	grantsResp := new(ListOAuthGrantsResponse)
 
-	// Send Request
 	_, err = s.client.Perform(req, grantsResp)
-
 	if err != nil {
 		return ListOAuthGrantsResponse{}, err
 	}
@@ -87,18 +83,14 @@ func (s *OAuthGrantsSvcImpl) List() (ListOAuthGrantsResponse, error) {
 func (s *OAuthGrantsSvcImpl) RevokeWithContext(ctx context.Context, oauthGrantId string) (RevokeOAuthGrantResponse, error) {
 	path := "oauth/grants/" + oauthGrantId
 
-	// Prepare request
 	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
 	if err != nil {
 		return RevokeOAuthGrantResponse{}, ErrFailedToCreateOAuthGrantsRevokeRequest
 	}
 
-	// Build response recipient obj
 	grantResp := new(RevokeOAuthGrantResponse)
 
-	// Send Request
 	_, err = s.client.Perform(req, grantResp)
-
 	if err != nil {
 		return RevokeOAuthGrantResponse{}, err
 	}

--- a/oauth_grants.go
+++ b/oauth_grants.go
@@ -1,0 +1,112 @@
+package resend
+
+import (
+	"context"
+	"net/http"
+)
+
+// OAuthGrantClient represents the OAuth client that a grant was issued to.
+type OAuthGrantClient struct {
+	Name    string  `json:"name"`
+	LogoUri *string `json:"logo_uri"`
+}
+
+// OAuthGrant represents an OAuth grant.
+type OAuthGrant struct {
+	Id            string           `json:"id"`
+	ClientId      string           `json:"client_id"`
+	Scopes        []string         `json:"scopes"`
+	CreatedAt     string           `json:"created_at"`
+	RevokedAt     *string          `json:"revoked_at"`
+	RevokedReason *string          `json:"revoked_reason"`
+	Client        OAuthGrantClient `json:"client"`
+}
+
+type ListOAuthGrantsResponse struct {
+	Object  string       `json:"object"`
+	Data    []OAuthGrant `json:"data"`
+	HasMore bool         `json:"has_more"`
+}
+
+type RevokeOAuthGrantResponse struct {
+	Object        string `json:"object"`
+	Id            string `json:"id"`
+	RevokedAt     string `json:"revoked_at"`
+	RevokedReason string `json:"revoked_reason"`
+}
+
+type OAuthGrantsSvc interface {
+	ListWithOptions(ctx context.Context, options *ListOptions) (ListOAuthGrantsResponse, error)
+	ListWithContext(ctx context.Context) (ListOAuthGrantsResponse, error)
+	List() (ListOAuthGrantsResponse, error)
+	RevokeWithContext(ctx context.Context, oauthGrantId string) (RevokeOAuthGrantResponse, error)
+	Revoke(oauthGrantId string) (RevokeOAuthGrantResponse, error)
+}
+
+type OAuthGrantsSvcImpl struct {
+	client *Client
+}
+
+// ListWithOptions lists all of the team's OAuth grants with pagination options
+// https://resend.com/docs/api-reference/oauth/list-grants
+func (s *OAuthGrantsSvcImpl) ListWithOptions(ctx context.Context, options *ListOptions) (ListOAuthGrantsResponse, error) {
+	path := "oauth/grants" + buildPaginationQuery(options)
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return ListOAuthGrantsResponse{}, ErrFailedToCreateOAuthGrantsListRequest
+	}
+
+	// Build response recipient obj
+	grantsResp := new(ListOAuthGrantsResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, grantsResp)
+
+	if err != nil {
+		return ListOAuthGrantsResponse{}, err
+	}
+
+	return *grantsResp, nil
+}
+
+// ListWithContext lists all of the team's OAuth grants
+// https://resend.com/docs/api-reference/oauth/list-grants
+func (s *OAuthGrantsSvcImpl) ListWithContext(ctx context.Context) (ListOAuthGrantsResponse, error) {
+	return s.ListWithOptions(ctx, nil)
+}
+
+// List lists all of the team's OAuth grants
+func (s *OAuthGrantsSvcImpl) List() (ListOAuthGrantsResponse, error) {
+	return s.ListWithContext(context.Background())
+}
+
+// RevokeWithContext revokes a given OAuth grant by id
+// https://resend.com/docs/api-reference/oauth/revoke-grant
+func (s *OAuthGrantsSvcImpl) RevokeWithContext(ctx context.Context, oauthGrantId string) (RevokeOAuthGrantResponse, error) {
+	path := "oauth/grants/" + oauthGrantId
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return RevokeOAuthGrantResponse{}, ErrFailedToCreateOAuthGrantsRevokeRequest
+	}
+
+	// Build response recipient obj
+	grantResp := new(RevokeOAuthGrantResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, grantResp)
+
+	if err != nil {
+		return RevokeOAuthGrantResponse{}, err
+	}
+
+	return *grantResp, nil
+}
+
+// Revoke revokes a given OAuth grant by id
+func (s *OAuthGrantsSvcImpl) Revoke(oauthGrantId string) (RevokeOAuthGrantResponse, error) {
+	return s.RevokeWithContext(context.Background(), oauthGrantId)
+}

--- a/oauth_grants_test.go
+++ b/oauth_grants_test.go
@@ -101,6 +101,36 @@ func TestRevokeOAuthGrant(t *testing.T) {
 	}
 	assert.Equal(t, resp.Object, "oauth_grant")
 	assert.Equal(t, resp.Id, "650e8400-e29b-41d4-a716-446655440001")
-	assert.Equal(t, resp.RevokedAt, "2026-04-08T00:11:13.110Z")
-	assert.Equal(t, resp.RevokedReason, "revoked_from_api")
+	assert.NotNil(t, resp.RevokedAt)
+	assert.Equal(t, *resp.RevokedAt, "2026-04-08T00:11:13.110Z")
+	assert.NotNil(t, resp.RevokedReason)
+	assert.Equal(t, *resp.RevokedReason, "revoked_from_api")
+}
+
+func TestRevokeOAuthGrantNullFields(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/oauth/grants/650e8400-e29b-41d4-a716-446655440001", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "oauth_grant",
+			"id": "650e8400-e29b-41d4-a716-446655440001",
+			"revoked_at": null,
+			"revoked_reason": null
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	resp, err := client.OAuthGrants.Revoke("650e8400-e29b-41d4-a716-446655440001")
+	if err != nil {
+		t.Errorf("OAuthGrants.Revoke returned error: %v", err)
+	}
+	assert.Equal(t, resp.Id, "650e8400-e29b-41d4-a716-446655440001")
+	assert.Nil(t, resp.RevokedAt)
+	assert.Nil(t, resp.RevokedReason)
 }

--- a/oauth_grants_test.go
+++ b/oauth_grants_test.go
@@ -1,0 +1,106 @@
+package resend
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListOAuthGrants(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/oauth/grants", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "list",
+			"has_more": false,
+			"data": [
+				{
+					"id": "650e8400-e29b-41d4-a716-446655440001",
+					"client_id": "430eed87-632a-4ea6-90db-0aace67ec228",
+					"scopes": ["emails:send"],
+					"created_at": "2023-06-21T06:10:36.144Z",
+					"revoked_at": null,
+					"revoked_reason": null,
+					"client": {
+						"name": "Resend CLI",
+						"logo_uri": "https://example.com/logo.png"
+					}
+				},
+				{
+					"id": "650e8400-e29b-41d4-a716-446655440002",
+					"client_id": "430eed87-632a-4ea6-90db-0aace67ec228",
+					"scopes": ["emails:send", "domains:read"],
+					"created_at": "2023-06-20T06:10:36.144Z",
+					"revoked_at": "2023-06-22T06:10:36.144Z",
+					"revoked_reason": "revoked_from_api",
+					"client": {
+						"name": "Resend CLI",
+						"logo_uri": null
+					}
+				}
+			]
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	resp, err := client.OAuthGrants.List()
+	if err != nil {
+		t.Errorf("OAuthGrants.List returned error: %v", err)
+	}
+	assert.Equal(t, "list", resp.Object)
+	assert.False(t, resp.HasMore)
+	assert.Equal(t, len(resp.Data), 2)
+
+	assert.Equal(t, resp.Data[0].Id, "650e8400-e29b-41d4-a716-446655440001")
+	assert.Equal(t, resp.Data[0].ClientId, "430eed87-632a-4ea6-90db-0aace67ec228")
+	assert.Equal(t, resp.Data[0].Scopes, []string{"emails:send"})
+	assert.Nil(t, resp.Data[0].RevokedAt)
+	assert.Nil(t, resp.Data[0].RevokedReason)
+	assert.Equal(t, resp.Data[0].Client.Name, "Resend CLI")
+	assert.NotNil(t, resp.Data[0].Client.LogoUri)
+	assert.Equal(t, *resp.Data[0].Client.LogoUri, "https://example.com/logo.png")
+
+	assert.Equal(t, resp.Data[1].Scopes, []string{"emails:send", "domains:read"})
+	assert.NotNil(t, resp.Data[1].RevokedAt)
+	assert.Equal(t, *resp.Data[1].RevokedAt, "2023-06-22T06:10:36.144Z")
+	assert.NotNil(t, resp.Data[1].RevokedReason)
+	assert.Equal(t, *resp.Data[1].RevokedReason, "revoked_from_api")
+	assert.Nil(t, resp.Data[1].Client.LogoUri)
+}
+
+func TestRevokeOAuthGrant(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/oauth/grants/650e8400-e29b-41d4-a716-446655440001", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "oauth_grant",
+			"id": "650e8400-e29b-41d4-a716-446655440001",
+			"revoked_at": "2026-04-08T00:11:13.110Z",
+			"revoked_reason": "revoked_from_api"
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	resp, err := client.OAuthGrants.Revoke("650e8400-e29b-41d4-a716-446655440001")
+	if err != nil {
+		t.Errorf("OAuthGrants.Revoke returned error: %v", err)
+	}
+	assert.Equal(t, resp.Object, "oauth_grant")
+	assert.Equal(t, resp.Id, "650e8400-e29b-41d4-a716-446655440001")
+	assert.Equal(t, resp.RevokedAt, "2026-04-08T00:11:13.110Z")
+	assert.Equal(t, resp.RevokedReason, "revoked_from_api")
+}

--- a/resend.go
+++ b/resend.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version     = "3.9.2"
+	version     = "3.10.0"
 	userAgent   = "resend-go/" + version
 	contentType = "application/json"
 )

--- a/resend.go
+++ b/resend.go
@@ -66,6 +66,7 @@ type Client struct {
 	Logs              LogsSvc
 	Automations       AutomationsSvc
 	Events            EventsSvc
+	OAuthGrants       OAuthGrantsSvc
 }
 
 // NewClient is the default client constructor
@@ -110,6 +111,7 @@ func NewCustomClient(httpClient *http.Client, apiKey string) *Client {
 	c.Logs = &LogsSvcImpl{client: c}
 	c.Automations = &AutomationsSvcImpl{client: c}
 	c.Events = &EventsSvcImpl{client: c}
+	c.OAuthGrants = &OAuthGrantsSvcImpl{client: c}
 
 	c.ApiKey = apiKey
 	c.headers = make(map[string]string)


### PR DESCRIPTION
## Summary

Adds support for the two new OAuth grants API endpoints

- **List** — `GET /oauth/grants` (paginated) → `client.OAuthGrants.List()` / `ListWithContext` / `ListWithOptions`
- **Revoke** — `DELETE /oauth/grants/:oauthGrantId` → `client.OAuthGrants.Revoke(id)` / `RevokeWithContext`

Only these two endpoints are in scope; the remaining OAuth endpoints are deferred pending the API RFC.

## Notes

- The `Revoke` method mirrors the API/other SDKs' naming (vs. the Go SDK's usual `Remove`) and returns a `RevokeOAuthGrantResponse` struct exposing `revoked_at` / `revoked_reason`, consistent with newer struct-returning services (`Events`, `Automations`).
- The `resource` field is **intentionally omitted** — it's a dead field being removed from the API.
- `revoked_at`, `revoked_reason`, and `client.logo_uri` are modeled as nullable (`*string`).

## References

- resend-node: https://github.com/resend/resend-node/pull/998
- resend-openapi: https://github.com/resend/resend-openapi/pull/70
- Docs: [list-grants](https://resend.com/docs/api-reference/oauth/list-grants) · [revoke-grant](https://resend.com/docs/api-reference/oauth/revoke-grant)

## Testing

- `go build ./...`, `go vet ./...`, `gofmt` clean
- New tests `TestListOAuthGrants` + `TestRevokeOAuthGrant`; full suite (232 tests) passes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OAuth Grants support to the Go SDK so teams can list and revoke OAuth grants. Adds pagination and typed responses.

- **New Features**
  - New `OAuthGrants` service with `List`/`ListWithContext`/`ListWithOptions` and `Revoke`/`RevokeWithContext`.
  - `GET /oauth/grants` (paginated) and `DELETE /oauth/grants/:oauthGrantId`.
  - Typed models: nullable `revoked_at`, `revoked_reason` (also in `RevokeOAuthGrantResponse`), and `client.logo_uri`; omit deprecated `resource`.
  - Examples, tests (incl. null decoding), and new errors `ErrFailedToCreateOAuthGrantsListRequest`, `ErrFailedToCreateOAuthGrantsRevokeRequest`.

- **Refactors**
  - Removed verbose/doc comments. Bumped SDK version to 3.10.0.

<sup>Written for commit b84303f396951bfbb16aef0245ed3601b50063b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



