### PR TITLE
chore: revert SendEmailRequest's ReplyTo can be a list

### DIFF
--- a/emails.go
+++ b/emails.go
@@ -31,7 +31,7 @@ type SendEmailRequest struct {
 	Subject     string            `json:"subject"`
 	Bcc         []string          `json:"bcc,omitempty"`
 	Cc          []string          `json:"cc,omitempty"`
-	ReplyTo     []string          `json:"reply_to,omitempty"`
+	ReplyTo     string            `json:"reply_to,omitempty"`
 	Html        string            `json:"html,omitempty"`
 	Text        string            `json:"text,omitempty"`
 	Tags        []Tag             `json:"tags,omitempty"`

--- a/emails_test.go
+++ b/emails_test.go
@@ -665,7 +665,7 @@ func TestSendEmailWithTemplateAndOverrides(t *testing.T) {
 		// Verify overridden fields
 		assert.Equal(t, "custom-sender@example.com", req.From)
 		assert.Equal(t, "Custom Subject Line", req.Subject)
-		assert.Equal(t, []string{"reply@example.com"}, req.ReplyTo)
+		assert.Equal(t, "reply@example.com", req.ReplyTo)
 		assert.Equal(t, []string{"bcc@example.com"}, req.Bcc)
 		assert.Equal(t, 1, len(req.Tags))
 		assert.Equal(t, "campaign", req.Tags[0].Name)
@@ -685,7 +685,7 @@ func TestSendEmailWithTemplateAndOverrides(t *testing.T) {
 		To:      []string{"subscriber@example.com"},
 		Subject: "Custom Subject Line",
 		Bcc:     []string{"bcc@example.com"},
-		ReplyTo: []string{"reply@example.com"},
+		ReplyTo: "reply@example.com",
 		Tags: []Tag{
 			{Name: "campaign", Value: "2024-q1"},
 		},

--- a/examples/send_email.go
+++ b/examples/send_email.go
@@ -22,7 +22,7 @@ func sendEmailExample() {
 		Subject: "Hello from Golang",
 		Cc:      []string{"cc@example.com"},
 		Bcc:     []string{"ccc@example.com"},
-		ReplyTo: []string{"to@example.com"},
+		ReplyTo: "to@example.com",
 	}
 
 	sent, err := client.Emails.SendWithContext(ctx, params)

--- a/examples/send_email_custom_client.go
+++ b/examples/send_email_custom_client.go
@@ -34,7 +34,7 @@ func sendEmailCustomClientExample() {
 		Subject: "Hello from Golang",
 		Cc:      []string{"cc@example.com"},
 		Bcc:     []string{"ccc@example.com"},
-		ReplyTo: []string{"to@example.com"},
+		ReplyTo: "to@example.com",
 	}
 
 	sent, err := client.Emails.SendWithContext(ctx, params)

--- a/examples/send_email_with_template.go
+++ b/examples/send_email_with_template.go
@@ -106,7 +106,7 @@ func sendEmailWithTemplateExample() {
 		To:      []string{"delivered@resend.dev"},
 		Subject: "Custom Subject Override", // Override template's Subject
 		Bcc:     []string{"bcc@example.com"},
-		ReplyTo: []string{"noreply@resend.dev"},
+		ReplyTo: "noreply@resend.dev",
 		Template: &resend.EmailTemplate{
 			Id: template.Id,
 			Variables: map[string]any{

--- a/resend.go
+++ b/resend.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version     = "3.10.0"
+	version     = "3.10.1"
 	userAgent   = "resend-go/" + version
 	contentType = "application/json"
 )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reverts #133, which changed `SendEmailRequest.ReplyTo` from `string` to `[]string`. That was a breaking change that was accidentally released in v3.10.0.

This PR:

- Reverts commit a44426005219b2ca5d192a64adb5d66058396017, restoring `ReplyTo` to `string` (along with the affected tests and examples).
- Bumps the version to `3.10.1` for a patch release.

## Testing

- `go build ./...` passes
- `go test ./...` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://resend.slack.com/archives/C0AG3A0TP7W/p1783628814487889?thread_ts=1783628814.487889&cid=C0AG3A0TP7W)

<div><a href="https://cursor.com/agents/bc-ecb25e25-63f1-5abf-8175-9f0f97b1f62f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ecb25e25-63f1-5abf-8175-9f0f97b1f62f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the accidental breaking change in v3.10.0 that made `SendEmailRequest.ReplyTo` a list. Restores it to `string` and publishes a `3.10.1` patch.

- **Bug Fixes**
  - Restore `SendEmailRequest.ReplyTo` to `string` and update tests and examples.

- **Migration**
  - If you used `[]string` in v3.10.0, change it back to a single `string`.

<sup>Written for commit 73e85cf36ea7fe592c532f60b68383c9688997a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

