### PR TITLE
feat(batch): add BatchSendEmailRequest with tags support

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -26,6 +26,13 @@ func (b BatchValidationMode) String() string {
 	return string(b)
 }
 
+// BatchSendEmailRequest is the request object for each email in a Batch.Send call.
+//
+// Each email in a batch supports scheduled_at, tags, and attachments.
+//
+// See https://resend.com/docs/api-reference/emails/send-batch-emails
+type BatchSendEmailRequest = SendEmailRequest
+
 // BatchSendEmailOptions is the additional options struct for the Batch.SendEmail call.
 type BatchSendEmailOptions struct {
 	IdempotencyKey string `json:"idempotency_key,omitempty"`
@@ -61,9 +68,9 @@ type BatchEmailResponse struct {
 }
 
 type BatchSvc interface {
-	Send([]*SendEmailRequest) (*BatchEmailResponse, error)
-	SendWithContext(ctx context.Context, params []*SendEmailRequest) (*BatchEmailResponse, error)
-	SendWithOptions(ctx context.Context, params []*SendEmailRequest, options *BatchSendEmailOptions) (*BatchEmailResponse, error)
+	Send([]*BatchSendEmailRequest) (*BatchEmailResponse, error)
+	SendWithContext(ctx context.Context, params []*BatchSendEmailRequest) (*BatchEmailResponse, error)
+	SendWithOptions(ctx context.Context, params []*BatchSendEmailRequest, options *BatchSendEmailOptions) (*BatchEmailResponse, error)
 }
 
 type BatchSvcImpl struct {
@@ -72,12 +79,12 @@ type BatchSvcImpl struct {
 
 // Send send a batch of emails
 // https://resend.com/docs/api-reference/emails/send-batch-emails
-func (s *BatchSvcImpl) Send(params []*SendEmailRequest) (*BatchEmailResponse, error) {
+func (s *BatchSvcImpl) Send(params []*BatchSendEmailRequest) (*BatchEmailResponse, error) {
 	return s.SendWithContext(context.Background(), params)
 }
 
 // SendWithContext is the same as Send but accepts a ctx as argument
-func (s *BatchSvcImpl) SendWithContext(ctx context.Context, params []*SendEmailRequest) (*BatchEmailResponse, error) {
+func (s *BatchSvcImpl) SendWithContext(ctx context.Context, params []*BatchSendEmailRequest) (*BatchEmailResponse, error) {
 	path := "emails/batch"
 
 	// Prepare request
@@ -100,7 +107,7 @@ func (s *BatchSvcImpl) SendWithContext(ctx context.Context, params []*SendEmailR
 }
 
 // SendWithOptions is the same as Send but accepts a ctx and options as arguments
-func (s *BatchSvcImpl) SendWithOptions(ctx context.Context, params []*SendEmailRequest, options *BatchSendEmailOptions) (*BatchEmailResponse, error) {
+func (s *BatchSvcImpl) SendWithOptions(ctx context.Context, params []*BatchSendEmailRequest, options *BatchSendEmailOptions) (*BatchEmailResponse, error) {
 	// Validate BatchValidation field if provided
 	if options != nil && options.BatchValidation != "" {
 		if !options.BatchValidation.IsValid() {

--- a/batch.go
+++ b/batch.go
@@ -28,8 +28,7 @@ func (b BatchValidationMode) String() string {
 
 // BatchSendEmailRequest is the request object for each email in a Batch.Send call.
 //
-// Tags are supported per email. Attachments and scheduled_at are not supported
-// by the batch API; use SendEmailRequest with Emails.Send for those features.
+// Tags are supported per email.
 //
 // See https://resend.com/docs/api-reference/emails/send-batch-emails
 type BatchSendEmailRequest struct {

--- a/batch.go
+++ b/batch.go
@@ -28,10 +28,24 @@ func (b BatchValidationMode) String() string {
 
 // BatchSendEmailRequest is the request object for each email in a Batch.Send call.
 //
-// Each email in a batch supports scheduled_at, tags, and attachments.
+// Tags are supported per email. Attachments and scheduled_at are not supported
+// by the batch API; use SendEmailRequest with Emails.Send for those features.
 //
 // See https://resend.com/docs/api-reference/emails/send-batch-emails
-type BatchSendEmailRequest = SendEmailRequest
+type BatchSendEmailRequest struct {
+	From     string            `json:"from"`
+	To       []string          `json:"to"`
+	Subject  string            `json:"subject"`
+	Bcc      []string          `json:"bcc,omitempty"`
+	Cc       []string          `json:"cc,omitempty"`
+	ReplyTo  string            `json:"reply_to,omitempty"`
+	Html     string            `json:"html,omitempty"`
+	Text     string            `json:"text,omitempty"`
+	Tags     []Tag             `json:"tags,omitempty"`
+	Headers  map[string]string `json:"headers,omitempty"`
+	Template *EmailTemplate    `json:"template,omitempty"`
+	TopicId  string            `json:"topic_id,omitempty"`
+}
 
 // BatchSendEmailOptions is the additional options struct for the Batch.SendEmail call.
 type BatchSendEmailOptions struct {

--- a/batch_test.go
+++ b/batch_test.go
@@ -1,8 +1,10 @@
 package resend
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"testing"
 
@@ -264,4 +266,59 @@ func TestBatchSendWithInvalidValidationMode(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Nil(t, resp)
 	assert.Contains(t, err.Error(), "BatchValidation must be either BatchValidationStrict or BatchValidationPermissive")
+}
+
+func TestBatchSendEmailWithTagsScheduledAtAndAttachments(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/emails/batch", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		content, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+		}
+
+		assert.True(t, bytes.Contains(content, []byte(`"scheduled_at":"2024-09-05T11:52:01.858Z"`)))
+		assert.True(t, bytes.Contains(content, []byte(`"tags":[{"name":"category","value":"confirm_email"}]`)))
+		assert.True(t, bytes.Contains(content, []byte(`"attachments":[{"content":[104,101,108,108,111],"filename":"hello.txt","content_type":"text/plain"}]`)))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := &BatchEmailResponse{
+			Data: []SendEmailResponse{
+				{Id: "batch-scheduled-1"},
+			},
+		}
+		if err := json.NewEncoder(w).Encode(&ret); err != nil {
+			panic(err)
+		}
+	})
+
+	req := []*BatchSendEmailRequest{
+		{
+			From:        "onboarding@resend.dev",
+			To:          []string{"delivered@resend.dev"},
+			Subject:     "Scheduled batch email",
+			Html:        "<p>Hello</p>",
+			ScheduledAt: "2024-09-05T11:52:01.858Z",
+			Tags: []Tag{
+				{Name: "category", Value: "confirm_email"},
+			},
+			Attachments: []*Attachment{
+				{
+					Content:     []byte("hello"),
+					Filename:    "hello.txt",
+					ContentType: "text/plain",
+				},
+			},
+		},
+	}
+
+	resp, err := client.Batch.Send(req)
+	if err != nil {
+		t.Errorf("Batch.Send returned error: %v", err)
+	}
+	assert.Equal(t, "batch-scheduled-1", resp.Data[0].Id)
 }

--- a/batch_test.go
+++ b/batch_test.go
@@ -32,7 +32,7 @@ func TestBatchSendEmail(t *testing.T) {
 		}
 	})
 
-	req := []*SendEmailRequest{
+	req := []*BatchSendEmailRequest{
 		{
 			To: []string{"d@e.com"},
 		},
@@ -76,7 +76,7 @@ func TestBatchSendEmailWithErrors(t *testing.T) {
 		}
 	})
 
-	req := []*SendEmailRequest{
+	req := []*BatchSendEmailRequest{
 		{To: []string{"valid1@example.com"}},
 		{To: []string{"valid2@example.com"}},
 		{To: []string{}},                // Missing 'to' field
@@ -127,7 +127,7 @@ func TestBatchSendWithOptionsEmail(t *testing.T) {
 		}
 	})
 
-	req := []*SendEmailRequest{
+	req := []*BatchSendEmailRequest{
 		{
 			To: []string{"d@e.com"},
 		},
@@ -178,7 +178,7 @@ func TestBatchSendWithValidationMode(t *testing.T) {
 		}
 	})
 
-	req := []*SendEmailRequest{
+	req := []*BatchSendEmailRequest{
 		{To: []string{"valid@example.com"}},
 		{To: []string{"invalid"}},
 	}
@@ -228,7 +228,7 @@ func TestBatchSendWithStrictValidation(t *testing.T) {
 		}
 	})
 
-	req := []*SendEmailRequest{
+	req := []*BatchSendEmailRequest{
 		{To: []string{"test1@example.com"}},
 		{To: []string{"test2@example.com"}},
 	}
@@ -251,7 +251,7 @@ func TestBatchSendWithInvalidValidationMode(t *testing.T) {
 	defer teardown()
 	ctx := context.Background()
 
-	req := []*SendEmailRequest{
+	req := []*BatchSendEmailRequest{
 		{To: []string{"test@example.com"}},
 	}
 
@@ -268,7 +268,7 @@ func TestBatchSendWithInvalidValidationMode(t *testing.T) {
 	assert.Contains(t, err.Error(), "BatchValidation must be either BatchValidationStrict or BatchValidationPermissive")
 }
 
-func TestBatchSendEmailWithTagsScheduledAtAndAttachments(t *testing.T) {
+func TestBatchSendEmailWithTags(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -279,16 +279,16 @@ func TestBatchSendEmailWithTagsScheduledAtAndAttachments(t *testing.T) {
 			t.Errorf("failed to read request body: %v", err)
 		}
 
-		assert.True(t, bytes.Contains(content, []byte(`"scheduled_at":"2024-09-05T11:52:01.858Z"`)))
 		assert.True(t, bytes.Contains(content, []byte(`"tags":[{"name":"category","value":"confirm_email"}]`)))
-		assert.True(t, bytes.Contains(content, []byte(`"attachments":[{"content":[104,101,108,108,111],"filename":"hello.txt","content_type":"text/plain"}]`)))
+		assert.False(t, bytes.Contains(content, []byte(`"attachments"`)))
+		assert.False(t, bytes.Contains(content, []byte(`"scheduled_at"`)))
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
 		ret := &BatchEmailResponse{
 			Data: []SendEmailResponse{
-				{Id: "batch-scheduled-1"},
+				{Id: "batch-tagged-1"},
 			},
 		}
 		if err := json.NewEncoder(w).Encode(&ret); err != nil {
@@ -298,20 +298,12 @@ func TestBatchSendEmailWithTagsScheduledAtAndAttachments(t *testing.T) {
 
 	req := []*BatchSendEmailRequest{
 		{
-			From:        "onboarding@resend.dev",
-			To:          []string{"delivered@resend.dev"},
-			Subject:     "Scheduled batch email",
-			Html:        "<p>Hello</p>",
-			ScheduledAt: "2024-09-05T11:52:01.858Z",
+			From:    "onboarding@resend.dev",
+			To:      []string{"delivered@resend.dev"},
+			Subject: "Tagged batch email",
+			Html:    "<p>Hello</p>",
 			Tags: []Tag{
 				{Name: "category", Value: "confirm_email"},
-			},
-			Attachments: []*Attachment{
-				{
-					Content:     []byte("hello"),
-					Filename:    "hello.txt",
-					ContentType: "text/plain",
-				},
 			},
 		},
 	}
@@ -320,5 +312,5 @@ func TestBatchSendEmailWithTagsScheduledAtAndAttachments(t *testing.T) {
 	if err != nil {
 		t.Errorf("Batch.Send returned error: %v", err)
 	}
-	assert.Equal(t, "batch-scheduled-1", resp.Data[0].Id)
+	assert.Equal(t, "batch-tagged-1", resp.Data[0].Id)
 }

--- a/batch_test.go
+++ b/batch_test.go
@@ -280,8 +280,6 @@ func TestBatchSendEmailWithTags(t *testing.T) {
 		}
 
 		assert.True(t, bytes.Contains(content, []byte(`"tags":[{"name":"category","value":"confirm_email"}]`)))
-		assert.False(t, bytes.Contains(content, []byte(`"attachments"`)))
-		assert.False(t, bytes.Contains(content, []byte(`"scheduled_at"`)))
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)

--- a/examples/send_batch_email.go
+++ b/examples/send_batch_email.go
@@ -16,7 +16,7 @@ func sendBatchEmails() {
 	client := resend.NewClient(apiKey)
 
 	// Batch Send
-	var batchEmails = []*resend.SendEmailRequest{
+	var batchEmails = []*resend.BatchSendEmailRequest{
 		{
 			To:      []string{"delivered@resend.dev"},
 			From:    "onboarding@resend.dev",
@@ -52,7 +52,7 @@ func sendBatchEmails() {
 
 	// Send with permissive validation mode
 	// This allows partial success - valid emails will be sent even if some are invalid
-	batchEmailsWithErrors := []*resend.SendEmailRequest{
+	batchEmailsWithErrors := []*resend.BatchSendEmailRequest{
 		{
 			To:      []string{"delivered@resend.dev"},
 			From:    "onboarding@resend.dev",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The batch send API supports `tags` per email. This PR adds a dedicated `BatchSendEmailRequest` type to reflect that.

- Adds `BatchSendEmailRequest` as a separate struct with `tags` support
- Updates `BatchSvc` method signatures to use `[]*BatchSendEmailRequest`
- Adds a test verifying tags are serialized in batch request bodies
- Updates the batch send example to use `BatchSendEmailRequest`

## Breaking change

`Batch.Send` no longer accepts `[]*SendEmailRequest`. Use `[]*BatchSendEmailRequest` instead.

## Test plan

- [x] `go test ./...`
- [x] `go build ./examples/...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8c0e5e7-149c-421c-aa5d-554684f3e0ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8c0e5e7-149c-421c-aa5d-554684f3e0ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-email tag support to batch send in the Go SDK with a dedicated `BatchSendEmailRequest`. Aligns the SDK with the batch API by excluding `attachments` and `scheduled_at`.

- **New Features**
  - Added `BatchSendEmailRequest` (tags supported; no `attachments` or `scheduled_at`).
  - Updated `BatchSvc` `Send`/`WithContext`/`WithOptions` to use `[]*BatchSendEmailRequest`.
  - Updated example and tests (tag serialization in batch requests).

- **Migration**
  - Update batch calls to use `[]*BatchSendEmailRequest`. For attachments or scheduling, use `Emails.Send` with `SendEmailRequest`.

<sup>Written for commit 1699245c88eaf95601effff61807433f3fb916a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

