### PR TITLE
test(batch): cover tags and scheduledAt serialization in batch emails

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -127,6 +127,12 @@ func TestBatchSendEmailWithTagsAndScheduledAt(t *testing.T) {
 		tags1, ok := body[1]["tags"].([]any)
 		assert.True(t, ok)
 		assert.Len(t, tags1, 2)
+		tag1a := tags1[0].(map[string]any)
+		assert.Equal(t, "category", tag1a["name"])
+		assert.Equal(t, "confirm", tag1a["value"])
+		tag1b := tags1[1].(map[string]any)
+		assert.Equal(t, "env", tag1b["name"])
+		assert.Equal(t, "prod", tag1b["value"])
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)

--- a/batch_test.go
+++ b/batch_test.go
@@ -100,6 +100,75 @@ func TestBatchSendEmailWithErrors(t *testing.T) {
 	assert.Equal(t, resp.Errors[1].Message, "Invalid email address.")
 }
 
+func TestBatchSendEmailWithTagsAndScheduledAt(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/emails/batch", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+
+		// Decode the request body to verify tags and scheduled_at are serialized per email
+		var body []map[string]any
+		err := json.NewDecoder(r.Body).Decode(&body)
+		assert.NoError(t, err)
+		assert.Len(t, body, 2)
+
+		// First email: relative scheduledAt + tags
+		assert.Equal(t, "in 1 hour", body[0]["scheduled_at"])
+		tags0, ok := body[0]["tags"].([]any)
+		assert.True(t, ok)
+		assert.Len(t, tags0, 1)
+		tag0 := tags0[0].(map[string]any)
+		assert.Equal(t, "category", tag0["name"])
+		assert.Equal(t, "welcome", tag0["value"])
+
+		// Second email: ISO 8601 scheduledAt + multiple tags
+		assert.Equal(t, "2024-08-05T11:52:01.858Z", body[1]["scheduled_at"])
+		tags1, ok := body[1]["tags"].([]any)
+		assert.True(t, ok)
+		assert.Len(t, tags1, 2)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := &BatchEmailResponse{
+			Data: []SendEmailResponse{
+				{Id: "1"},
+				{Id: "2"},
+			},
+		}
+		err = json.NewEncoder(w).Encode(&ret)
+		if err != nil {
+			panic(err)
+		}
+	})
+
+	req := []*SendEmailRequest{
+		{
+			To:          []string{"d@e.com"},
+			ScheduledAt: "in 1 hour",
+			Tags: []Tag{
+				{Name: "category", Value: "welcome"},
+			},
+		},
+		{
+			To:          []string{"d@e.com"},
+			ScheduledAt: "2024-08-05T11:52:01.858Z",
+			Tags: []Tag{
+				{Name: "category", Value: "confirm"},
+				{Name: "env", Value: "prod"},
+			},
+		},
+	}
+
+	resp, err := client.Batch.Send(req)
+	if err != nil {
+		t.Errorf("BatchEmail.Send returned error: %v", err)
+	}
+	assert.Equal(t, resp.Data[0].Id, "1")
+	assert.Equal(t, resp.Data[1].Id, "2")
+}
+
 func TestBatchSendWithOptionsEmail(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
## What

Adds test coverage confirming that `tags` and `scheduled_at` serialize correctly per-email in batch sends.

## Why

Ports the intent of [resend-node#1022](https://github.com/resend/resend-node/pull/1022), which added `tags` and `scheduledAt` support to batch email options.

Unlike resend-node — which has a separate `CreateBatchEmailOptions` type that explicitly omitted `scheduledAt` — the Go SDK's `Batch.Send` already takes `[]*SendEmailRequest`, the same struct used for single sends. That struct already carries both fields:

```go
Tags        []Tag  `json:"tags,omitempty"`
ScheduledAt string `json:"scheduled_at,omitempty"`
```

So no production code change is needed; the fields already flow through. This PR just locks in that behavior with a test that decodes the batch request body and asserts both fields are present per email, covering relative (`"in 1 hour"`) and ISO 8601 scheduling formats plus single/multiple tags.

## Test

- `TestBatchSendEmailWithTagsAndScheduledAt`
- All 7 batch tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds test coverage to ensure `tags` and `scheduled_at` serialize per-email in batch sends. Verifies relative ("in 1 hour") and ISO 8601 scheduling, single/multiple tags, and explicit tag name/value pairs on the second email; no production code changes.

<sup>Written for commit c3700984b19ff6c7fac6c1b09971c53aed79a5f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

