### PR TITLE
feat: add suppressions endpoints

### DIFF
--- a/examples/suppressions.go
+++ b/examples/suppressions.go
@@ -1,0 +1,75 @@
+package examples
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/resend/resend-go/v3"
+)
+
+func suppressionsExample() {
+	ctx := context.TODO()
+	apiKey := os.Getenv("RESEND_API_KEY")
+
+	client := resend.NewClient(apiKey)
+
+	// Add a single email address to the suppression list.
+	suppression, err := client.Suppressions.AddWithContext(ctx, &resend.AddSuppressionRequest{
+		Email: "steve.wozniak@gmail.com",
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Created suppression id: " + suppression.Id)
+
+	// List suppressions, optionally filtered by origin.
+	limit := 20
+	list, err := client.Suppressions.ListWithContext(ctx, &resend.ListSuppressionsOptions{
+		Origin: resend.SuppressionOriginBounce,
+		Limit:  &limit,
+	})
+	if err != nil {
+		panic(err)
+	}
+	for _, entry := range list.Data {
+		sourceId := "none"
+		if entry.SourceId != nil {
+			sourceId = *entry.SourceId
+		}
+		fmt.Printf("%s (%s) source: %s\n", entry.Email, entry.Origin, sourceId)
+	}
+	fmt.Printf("Has more: %v\n", list.HasMore)
+
+	// Get accepts either a suppression ID or an email address.
+	retrieved, err := client.Suppressions.GetWithContext(ctx, "steve.wozniak@gmail.com")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Retrieved suppression: %v\n", retrieved)
+
+	// Remove accepts either a suppression ID or an email address.
+	removed, err := client.Suppressions.RemoveWithContext(ctx, suppression.Id)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Removed suppression %s: %v\n", removed.Id, removed.Deleted)
+
+	// Add up to 100 suppressions at once.
+	batchAdded, err := client.Suppressions.Batch.AddWithContext(ctx, &resend.BatchAddSuppressionsRequest{
+		Emails: []string{"steve.wozniak@gmail.com", "steve.jobs@gmail.com"},
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Batch added %d suppressions\n", len(batchAdded.Data))
+
+	// Remove up to 100 suppressions at once, by email address or by ID.
+	batchRemoved, err := client.Suppressions.Batch.RemoveWithContext(ctx, &resend.BatchRemoveSuppressionsRequest{
+		Emails: []string{"steve.wozniak@gmail.com", "steve.jobs@gmail.com"},
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Batch removed %d suppressions\n", len(batchRemoved.Data))
+}

--- a/resend.go
+++ b/resend.go
@@ -68,6 +68,7 @@ type Client struct {
 	Automations       AutomationsSvc
 	Events            EventsSvc
 	OAuthGrants       OAuthGrantsSvc
+	Suppressions      *SuppressionsSvcImpl
 }
 
 // NewClient is the default client constructor
@@ -96,6 +97,10 @@ func NewCustomClient(httpClient *http.Client, apiKey string) *Client {
 	contactsSvc.Properties = &ContactPropertiesSvcImpl{client: c}
 	contactsSvc.Imports = &ContactImportsSvcImpl{client: c}
 	c.Contacts = contactsSvc
+
+	suppressionsSvc := &SuppressionsSvcImpl{client: c}
+	suppressionsSvc.Batch = &SuppressionsBatchSvcImpl{client: c}
+	c.Suppressions = suppressionsSvc
 
 	c.Batch = &BatchSvcImpl{client: c}
 	c.ApiKeys = &ApiKeysSvcImpl{client: c}

--- a/suppressions.go
+++ b/suppressions.go
@@ -1,0 +1,319 @@
+package resend
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+type SuppressionOrigin = string
+
+const (
+	SuppressionOriginBounce    SuppressionOrigin = "bounce"
+	SuppressionOriginComplaint SuppressionOrigin = "complaint"
+	SuppressionOriginManual    SuppressionOrigin = "manual"
+)
+
+// SuppressionListEntry is a suppressed email address as returned by List. It has no Object field
+// because the list endpoint does not send one; only Get does.
+type SuppressionListEntry struct {
+	Id     string            `json:"id"`
+	Email  string            `json:"email"`
+	Origin SuppressionOrigin `json:"origin"`
+	// SourceId identifies the event that caused the suppression, such as the email that
+	// bounced or complained. It is null for manual suppressions.
+	SourceId  *string `json:"source_id"`
+	CreatedAt string  `json:"created_at"`
+}
+
+// Suppression is a suppressed email address as returned by Get.
+type Suppression struct {
+	Object string            `json:"object"`
+	Id     string            `json:"id"`
+	Email  string            `json:"email"`
+	Origin SuppressionOrigin `json:"origin"`
+	// SourceId identifies the event that caused the suppression, such as the email that
+	// bounced or complained. It is null for manual suppressions.
+	SourceId  *string `json:"source_id"`
+	CreatedAt string  `json:"created_at"`
+}
+
+// AddSuppressionRequest contains params for suppressing an email address.
+type AddSuppressionRequest struct {
+	Email string `json:"email"`
+}
+
+type AddSuppressionResponse struct {
+	Object string `json:"object"`
+	Id     string `json:"id"`
+}
+
+// ListSuppressionsOptions contains parameters for listing suppressions.
+type ListSuppressionsOptions struct {
+	// Origin filters suppressions by origin: bounce, complaint, manual.
+	Origin SuppressionOrigin
+	Limit  *int
+	After  *string
+	Before *string
+}
+
+type ListSuppressionsResponse struct {
+	Object  string                 `json:"object"`
+	HasMore bool                   `json:"has_more"`
+	Data    []SuppressionListEntry `json:"data"`
+}
+
+type RemoveSuppressionResponse struct {
+	Object  string `json:"object"`
+	Id      string `json:"id"`
+	Deleted bool   `json:"deleted"`
+}
+
+// BatchAddSuppressionsRequest contains params for suppressing up to 100 email addresses at once.
+type BatchAddSuppressionsRequest struct {
+	Emails []string `json:"emails"`
+}
+
+type BatchAddSuppressionsResponse struct {
+	Data []AddSuppressionResponse `json:"data"`
+}
+
+// BatchRemoveSuppressionsRequest contains params for removing up to 100 suppressions at once.
+// Provide either Emails or Ids, but not both. Ids must be suppression IDs in UUID form. The unset
+// field is omitted from the request body; the API rejects it being sent as null.
+type BatchRemoveSuppressionsRequest struct {
+	Emails []string `json:"emails,omitempty"`
+	Ids    []string `json:"ids,omitempty"`
+}
+
+type BatchRemoveSuppressionsResponse struct {
+	Data []RemoveSuppressionResponse `json:"data"`
+}
+
+type SuppressionsSvc interface {
+	Add(params *AddSuppressionRequest) (AddSuppressionResponse, error)
+	AddWithContext(ctx context.Context, params *AddSuppressionRequest) (AddSuppressionResponse, error)
+	List(options *ListSuppressionsOptions) (ListSuppressionsResponse, error)
+	ListWithContext(ctx context.Context, options *ListSuppressionsOptions) (ListSuppressionsResponse, error)
+	Get(idOrEmail string) (Suppression, error)
+	GetWithContext(ctx context.Context, idOrEmail string) (Suppression, error)
+	Remove(idOrEmail string) (RemoveSuppressionResponse, error)
+	RemoveWithContext(ctx context.Context, idOrEmail string) (RemoveSuppressionResponse, error)
+}
+
+type SuppressionsSvcImpl struct {
+	client *Client
+	Batch  SuppressionsBatchSvc
+}
+
+// Add suppresses an email address. The API lowercases and trims the address, and the call is an
+// upsert: re-adding an already-suppressed address succeeds and returns the existing ID.
+// https://resend.com/docs/api-reference/suppressions/add-suppression
+func (s *SuppressionsSvcImpl) Add(params *AddSuppressionRequest) (AddSuppressionResponse, error) {
+	return s.AddWithContext(context.Background(), params)
+}
+
+// AddWithContext suppresses an email address with context. The API lowercases and trims the
+// address, and the call is an upsert: re-adding an already-suppressed address succeeds and returns
+// the existing ID.
+// https://resend.com/docs/api-reference/suppressions/add-suppression
+func (s *SuppressionsSvcImpl) AddWithContext(ctx context.Context, params *AddSuppressionRequest) (AddSuppressionResponse, error) {
+	if params == nil || params.Email == "" {
+		return AddSuppressionResponse{}, errors.New("[ERROR]: Email is required")
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, "suppressions", params)
+	if err != nil {
+		return AddSuppressionResponse{}, errors.New("[ERROR]: Failed to create Suppressions.Add request")
+	}
+
+	resp := new(AddSuppressionResponse)
+	_, err = s.client.Perform(req, resp)
+	if err != nil {
+		return AddSuppressionResponse{}, err
+	}
+	return *resp, nil
+}
+
+// List retrieves a list of suppressions.
+// https://resend.com/docs/api-reference/suppressions/list-suppressions
+func (s *SuppressionsSvcImpl) List(options *ListSuppressionsOptions) (ListSuppressionsResponse, error) {
+	return s.ListWithContext(context.Background(), options)
+}
+
+// ListWithContext retrieves a list of suppressions with context.
+// https://resend.com/docs/api-reference/suppressions/list-suppressions
+func (s *SuppressionsSvcImpl) ListWithContext(ctx context.Context, options *ListSuppressionsOptions) (ListSuppressionsResponse, error) {
+	if options == nil {
+		options = &ListSuppressionsOptions{}
+	}
+
+	query := make(url.Values)
+	if options.Origin != "" {
+		query.Set("origin", options.Origin)
+	}
+	if options.Limit != nil {
+		query.Set("limit", fmt.Sprintf("%d", *options.Limit))
+	}
+	if options.After != nil {
+		query.Set("after", *options.After)
+	}
+	if options.Before != nil {
+		query.Set("before", *options.Before)
+	}
+
+	path := "suppressions"
+	if len(query) > 0 {
+		path += "?" + query.Encode()
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return ListSuppressionsResponse{}, errors.New("[ERROR]: Failed to create Suppressions.List request")
+	}
+
+	resp := new(ListSuppressionsResponse)
+	_, err = s.client.Perform(req, resp)
+	if err != nil {
+		return ListSuppressionsResponse{}, err
+	}
+	return *resp, nil
+}
+
+// Get retrieves a single suppression. The idOrEmail param can be either a suppression ID or an
+// email address. An unknown identifier returns a 404 "Suppression not found" error.
+// https://resend.com/docs/api-reference/suppressions/get-suppression
+func (s *SuppressionsSvcImpl) Get(idOrEmail string) (Suppression, error) {
+	return s.GetWithContext(context.Background(), idOrEmail)
+}
+
+// GetWithContext retrieves a single suppression with context. The idOrEmail param can be either a
+// suppression ID or an email address. An unknown identifier returns a 404 "Suppression not found"
+// error.
+// https://resend.com/docs/api-reference/suppressions/get-suppression
+func (s *SuppressionsSvcImpl) GetWithContext(ctx context.Context, idOrEmail string) (Suppression, error) {
+	if idOrEmail == "" {
+		return Suppression{}, errors.New("[ERROR]: Id or email is required")
+	}
+
+	path := "suppressions/" + url.PathEscape(idOrEmail)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return Suppression{}, errors.New("[ERROR]: Failed to create Suppressions.Get request")
+	}
+
+	resp := new(Suppression)
+	_, err = s.client.Perform(req, resp)
+	if err != nil {
+		return Suppression{}, err
+	}
+	return *resp, nil
+}
+
+// Remove removes a single suppression. The idOrEmail param can be either a suppression ID or an
+// email address. An unknown identifier returns a 404 "Suppression not found" error.
+// https://resend.com/docs/api-reference/suppressions/remove-suppression
+func (s *SuppressionsSvcImpl) Remove(idOrEmail string) (RemoveSuppressionResponse, error) {
+	return s.RemoveWithContext(context.Background(), idOrEmail)
+}
+
+// RemoveWithContext removes a single suppression with context. The idOrEmail param can be either a
+// suppression ID or an email address. An unknown identifier returns a 404 "Suppression not found"
+// error.
+// https://resend.com/docs/api-reference/suppressions/remove-suppression
+func (s *SuppressionsSvcImpl) RemoveWithContext(ctx context.Context, idOrEmail string) (RemoveSuppressionResponse, error) {
+	if idOrEmail == "" {
+		return RemoveSuppressionResponse{}, errors.New("[ERROR]: Id or email is required")
+	}
+
+	path := "suppressions/" + url.PathEscape(idOrEmail)
+
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return RemoveSuppressionResponse{}, errors.New("[ERROR]: Failed to create Suppressions.Remove request")
+	}
+
+	resp := new(RemoveSuppressionResponse)
+	_, err = s.client.Perform(req, resp)
+	if err != nil {
+		return RemoveSuppressionResponse{}, err
+	}
+	return *resp, nil
+}
+
+type SuppressionsBatchSvc interface {
+	Add(params *BatchAddSuppressionsRequest) (BatchAddSuppressionsResponse, error)
+	AddWithContext(ctx context.Context, params *BatchAddSuppressionsRequest) (BatchAddSuppressionsResponse, error)
+	Remove(params *BatchRemoveSuppressionsRequest) (BatchRemoveSuppressionsResponse, error)
+	RemoveWithContext(ctx context.Context, params *BatchRemoveSuppressionsRequest) (BatchRemoveSuppressionsResponse, error)
+}
+
+type SuppressionsBatchSvcImpl struct {
+	client *Client
+}
+
+// Add suppresses up to 100 email addresses at once. The API lowercases, trims and dedupes the
+// addresses, and upserts them, so already-suppressed addresses succeed and return their existing
+// IDs. The returned data can therefore be shorter than Emails.
+// https://resend.com/docs/api-reference/suppressions/add-suppressions
+func (s *SuppressionsBatchSvcImpl) Add(params *BatchAddSuppressionsRequest) (BatchAddSuppressionsResponse, error) {
+	return s.AddWithContext(context.Background(), params)
+}
+
+// AddWithContext suppresses up to 100 email addresses at once with context. The API lowercases,
+// trims and dedupes the addresses, and upserts them, so already-suppressed addresses succeed and
+// return their existing IDs. The returned data can therefore be shorter than Emails.
+// https://resend.com/docs/api-reference/suppressions/add-suppressions
+func (s *SuppressionsBatchSvcImpl) AddWithContext(ctx context.Context, params *BatchAddSuppressionsRequest) (BatchAddSuppressionsResponse, error) {
+	if params == nil || len(params.Emails) == 0 {
+		return BatchAddSuppressionsResponse{}, errors.New("[ERROR]: Emails is required")
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, "suppressions/batch/add", params)
+	if err != nil {
+		return BatchAddSuppressionsResponse{}, errors.New("[ERROR]: Failed to create Suppressions.Batch.Add request")
+	}
+
+	resp := new(BatchAddSuppressionsResponse)
+	_, err = s.client.Perform(req, resp)
+	if err != nil {
+		return BatchAddSuppressionsResponse{}, err
+	}
+	return *resp, nil
+}
+
+// Remove removes up to 100 suppressions at once, by email address or by ID. Unlike the single
+// Remove, identifiers that are not suppressed are not an error: the returned data only covers the
+// entries that were actually deleted.
+// https://resend.com/docs/api-reference/suppressions/remove-suppressions
+func (s *SuppressionsBatchSvcImpl) Remove(params *BatchRemoveSuppressionsRequest) (BatchRemoveSuppressionsResponse, error) {
+	return s.RemoveWithContext(context.Background(), params)
+}
+
+// RemoveWithContext removes up to 100 suppressions at once with context, by email address or by ID.
+// Unlike the single RemoveWithContext, identifiers that are not suppressed are not an error: the
+// returned data only covers the entries that were actually deleted.
+// https://resend.com/docs/api-reference/suppressions/remove-suppressions
+func (s *SuppressionsBatchSvcImpl) RemoveWithContext(ctx context.Context, params *BatchRemoveSuppressionsRequest) (BatchRemoveSuppressionsResponse, error) {
+	if params == nil || (len(params.Emails) == 0 && len(params.Ids) == 0) {
+		return BatchRemoveSuppressionsResponse{}, errors.New("[ERROR]: Either Emails or Ids is required")
+	}
+	if len(params.Emails) > 0 && len(params.Ids) > 0 {
+		return BatchRemoveSuppressionsResponse{}, errors.New("[ERROR]: Provide either `emails` or `ids`, but not both.")
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, "suppressions/batch/remove", params)
+	if err != nil {
+		return BatchRemoveSuppressionsResponse{}, errors.New("[ERROR]: Failed to create Suppressions.Batch.Remove request")
+	}
+
+	resp := new(BatchRemoveSuppressionsResponse)
+	_, err = s.client.Perform(req, resp)
+	if err != nil {
+		return BatchRemoveSuppressionsResponse{}, err
+	}
+	return *resp, nil
+}

--- a/suppressions_test.go
+++ b/suppressions_test.go
@@ -1,0 +1,397 @@
+package resend
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddSuppression(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/suppressions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		assert.Equal(t, "steve.wozniak@gmail.com", body["email"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprint(w, `{
+			"object": "suppression",
+			"id": "e169aa45-1ecf-4183-9955-b1499d5701d3"
+		}`)
+	})
+
+	req := &AddSuppressionRequest{Email: "steve.wozniak@gmail.com"}
+	resp, err := client.Suppressions.Add(req)
+	if err != nil {
+		t.Errorf("Suppressions.Add returned error: %v", err)
+	}
+
+	assert.Equal(t, "suppression", resp.Object)
+	assert.Equal(t, "e169aa45-1ecf-4183-9955-b1499d5701d3", resp.Id)
+}
+
+func TestAddSuppressionMissingEmail(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, err := client.Suppressions.Add(&AddSuppressionRequest{})
+	assert.Error(t, err)
+	assert.Equal(t, "[ERROR]: Email is required", err.Error())
+}
+
+func TestListSuppressions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/suppressions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `{
+			"object": "list",
+			"has_more": true,
+			"data": [
+				{
+					"id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+					"email": "steve.wozniak@gmail.com",
+					"origin": "bounce",
+					"source_id": "479e3145-dd38-476b-932c-529ceb705947",
+					"created_at": "2023-10-06T23:47:56.678Z"
+				},
+				{
+					"id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+					"email": "steve.jobs@gmail.com",
+					"origin": "manual",
+					"source_id": null,
+					"created_at": "2023-10-07T10:12:31.001Z"
+				}
+			]
+		}`)
+	})
+
+	resp, err := client.Suppressions.List(nil)
+	if err != nil {
+		t.Errorf("Suppressions.List returned error: %v", err)
+	}
+
+	assert.Equal(t, "list", resp.Object)
+	assert.True(t, resp.HasMore)
+	assert.Len(t, resp.Data, 2)
+
+	assert.Equal(t, "e169aa45-1ecf-4183-9955-b1499d5701d3", resp.Data[0].Id)
+	assert.Equal(t, "steve.wozniak@gmail.com", resp.Data[0].Email)
+	assert.Equal(t, SuppressionOriginBounce, resp.Data[0].Origin)
+	assert.NotNil(t, resp.Data[0].SourceId)
+	assert.Equal(t, "479e3145-dd38-476b-932c-529ceb705947", *resp.Data[0].SourceId)
+	assert.Equal(t, "2023-10-06T23:47:56.678Z", resp.Data[0].CreatedAt)
+
+	assert.Equal(t, SuppressionOriginManual, resp.Data[1].Origin)
+	assert.Nil(t, resp.Data[1].SourceId)
+}
+
+func TestListSuppressionsWithOptions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/suppressions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, "complaint", r.URL.Query().Get("origin"))
+		assert.Equal(t, "20", r.URL.Query().Get("limit"))
+		assert.Equal(t, "e169aa45-1ecf-4183-9955-b1499d5701d3", r.URL.Query().Get("after"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"object":"list","has_more":false,"data":[]}`)
+	})
+
+	limit := 20
+	after := "e169aa45-1ecf-4183-9955-b1499d5701d3"
+	resp, err := client.Suppressions.List(&ListSuppressionsOptions{
+		Origin: SuppressionOriginComplaint,
+		Limit:  &limit,
+		After:  &after,
+	})
+	if err != nil {
+		t.Errorf("Suppressions.List returned error: %v", err)
+	}
+
+	assert.Equal(t, "list", resp.Object)
+	assert.False(t, resp.HasMore)
+	assert.Empty(t, resp.Data)
+}
+
+func TestSuppressionListEntryHasNoObjectField(t *testing.T) {
+	entry, err := json.Marshal(SuppressionListEntry{Id: "e169aa45-1ecf-4183-9955-b1499d5701d3"})
+	if err != nil {
+		t.Fatalf("failed to marshal list entry: %v", err)
+	}
+	assert.NotContains(t, string(entry), "object")
+
+	single, err := json.Marshal(Suppression{Object: "suppression", Id: "e169aa45-1ecf-4183-9955-b1499d5701d3"})
+	if err != nil {
+		t.Fatalf("failed to marshal suppression: %v", err)
+	}
+	assert.Contains(t, string(single), `"object":"suppression"`)
+}
+
+func TestGetSuppression(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/suppressions/e169aa45-1ecf-4183-9955-b1499d5701d3", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `{
+			"object": "suppression",
+			"id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+			"email": "steve.wozniak@gmail.com",
+			"origin": "complaint",
+			"source_id": "479e3145-dd38-476b-932c-529ceb705947",
+			"created_at": "2023-10-06T23:47:56.678Z"
+		}`)
+	})
+
+	resp, err := client.Suppressions.Get("e169aa45-1ecf-4183-9955-b1499d5701d3")
+	if err != nil {
+		t.Errorf("Suppressions.Get returned error: %v", err)
+	}
+
+	assert.Equal(t, "suppression", resp.Object)
+	assert.Equal(t, "e169aa45-1ecf-4183-9955-b1499d5701d3", resp.Id)
+	assert.Equal(t, "steve.wozniak@gmail.com", resp.Email)
+	assert.Equal(t, SuppressionOriginComplaint, resp.Origin)
+	assert.NotNil(t, resp.SourceId)
+	assert.Equal(t, "479e3145-dd38-476b-932c-529ceb705947", *resp.SourceId)
+	assert.Equal(t, "2023-10-06T23:47:56.678Z", resp.CreatedAt)
+}
+
+func TestGetSuppressionByEmail(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/suppressions/steve.wozniak+news@gmail.com", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, "/suppressions/steve.wozniak+news@gmail.com", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `{
+			"object": "suppression",
+			"id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+			"email": "steve.wozniak+news@gmail.com",
+			"origin": "manual",
+			"source_id": null,
+			"created_at": "2023-10-06T23:47:56.678Z"
+		}`)
+	})
+
+	resp, err := client.Suppressions.Get("steve.wozniak+news@gmail.com")
+	if err != nil {
+		t.Errorf("Suppressions.Get returned error: %v", err)
+	}
+
+	assert.Equal(t, "steve.wozniak+news@gmail.com", resp.Email)
+	assert.Equal(t, SuppressionOriginManual, resp.Origin)
+	assert.Nil(t, resp.SourceId)
+}
+
+func TestGetSuppressionMissingIdentifier(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, err := client.Suppressions.Get("")
+	assert.Error(t, err)
+	assert.Equal(t, "[ERROR]: Id or email is required", err.Error())
+}
+
+func TestRemoveSuppression(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/suppressions/e169aa45-1ecf-4183-9955-b1499d5701d3", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `{
+			"object": "suppression",
+			"id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+			"deleted": true
+		}`)
+	})
+
+	resp, err := client.Suppressions.Remove("e169aa45-1ecf-4183-9955-b1499d5701d3")
+	if err != nil {
+		t.Errorf("Suppressions.Remove returned error: %v", err)
+	}
+
+	assert.Equal(t, "suppression", resp.Object)
+	assert.Equal(t, "e169aa45-1ecf-4183-9955-b1499d5701d3", resp.Id)
+	assert.True(t, resp.Deleted)
+}
+
+func TestRemoveSuppressionMissingIdentifier(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, err := client.Suppressions.Remove("")
+	assert.Error(t, err)
+	assert.Equal(t, "[ERROR]: Id or email is required", err.Error())
+}
+
+func TestBatchAddSuppressions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/suppressions/batch/add", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		assert.Equal(t, []any{"steve.wozniak@gmail.com", "steve.jobs@gmail.com"}, body["emails"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprint(w, `{
+			"data": [
+				{ "object": "suppression", "id": "e169aa45-1ecf-4183-9955-b1499d5701d3" },
+				{ "object": "suppression", "id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e" }
+			]
+		}`)
+	})
+
+	req := &BatchAddSuppressionsRequest{
+		Emails: []string{"steve.wozniak@gmail.com", "steve.jobs@gmail.com"},
+	}
+	resp, err := client.Suppressions.Batch.Add(req)
+	if err != nil {
+		t.Errorf("Suppressions.Batch.Add returned error: %v", err)
+	}
+
+	assert.Len(t, resp.Data, 2)
+	assert.Equal(t, "suppression", resp.Data[0].Object)
+	assert.Equal(t, "e169aa45-1ecf-4183-9955-b1499d5701d3", resp.Data[0].Id)
+	assert.Equal(t, "b6d24b8e-af0b-4c3c-be0c-359bbd97381e", resp.Data[1].Id)
+}
+
+func TestBatchAddSuppressionsMissingEmails(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, err := client.Suppressions.Batch.Add(&BatchAddSuppressionsRequest{})
+	assert.Error(t, err)
+	assert.Equal(t, "[ERROR]: Emails is required", err.Error())
+}
+
+func TestBatchRemoveSuppressionsWithEmails(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/suppressions/batch/remove", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		assert.Equal(t, []any{"steve.wozniak@gmail.com"}, body["emails"])
+		assert.NotContains(t, body, "ids")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `{
+			"data": [
+				{ "object": "suppression", "id": "e169aa45-1ecf-4183-9955-b1499d5701d3", "deleted": true }
+			]
+		}`)
+	})
+
+	req := &BatchRemoveSuppressionsRequest{Emails: []string{"steve.wozniak@gmail.com"}}
+	resp, err := client.Suppressions.Batch.Remove(req)
+	if err != nil {
+		t.Errorf("Suppressions.Batch.Remove returned error: %v", err)
+	}
+
+	assert.Len(t, resp.Data, 1)
+	assert.Equal(t, "suppression", resp.Data[0].Object)
+	assert.Equal(t, "e169aa45-1ecf-4183-9955-b1499d5701d3", resp.Data[0].Id)
+	assert.True(t, resp.Data[0].Deleted)
+}
+
+func TestBatchRemoveSuppressionsWithIds(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/suppressions/batch/remove", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		assert.Equal(t, []any{"e169aa45-1ecf-4183-9955-b1499d5701d3"}, body["ids"])
+		assert.NotContains(t, body, "emails")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `{
+			"data": [
+				{ "object": "suppression", "id": "e169aa45-1ecf-4183-9955-b1499d5701d3", "deleted": true }
+			]
+		}`)
+	})
+
+	req := &BatchRemoveSuppressionsRequest{Ids: []string{"e169aa45-1ecf-4183-9955-b1499d5701d3"}}
+	resp, err := client.Suppressions.Batch.Remove(req)
+	if err != nil {
+		t.Errorf("Suppressions.Batch.Remove returned error: %v", err)
+	}
+
+	assert.Len(t, resp.Data, 1)
+	assert.True(t, resp.Data[0].Deleted)
+}
+
+func TestBatchRemoveSuppressionsOmitsUnsetKey(t *testing.T) {
+	body, err := json.Marshal(&BatchRemoveSuppressionsRequest{Ids: []string{"e169aa45-1ecf-4183-9955-b1499d5701d3"}})
+	if err != nil {
+		t.Fatalf("failed to marshal request: %v", err)
+	}
+
+	assert.JSONEq(t, `{"ids":["e169aa45-1ecf-4183-9955-b1499d5701d3"]}`, string(body))
+	assert.NotContains(t, string(body), "emails")
+}
+
+func TestBatchRemoveSuppressionsRequiresOneOf(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, err := client.Suppressions.Batch.Remove(&BatchRemoveSuppressionsRequest{})
+	assert.Error(t, err)
+	assert.Equal(t, "[ERROR]: Either Emails or Ids is required", err.Error())
+
+	_, err = client.Suppressions.Batch.Remove(&BatchRemoveSuppressionsRequest{
+		Emails: []string{"steve.wozniak@gmail.com"},
+		Ids:    []string{"e169aa45-1ecf-4183-9955-b1499d5701d3"},
+	})
+	assert.Error(t, err)
+	assert.Equal(t, "[ERROR]: Provide either `emails` or `ids`, but not both.", err.Error())
+}

--- a/suppressions_test.go
+++ b/suppressions_test.go
@@ -1,9 +1,12 @@
 package resend
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,6 +38,33 @@ func TestAddSuppression(t *testing.T) {
 	resp, err := client.Suppressions.Add(req)
 	if err != nil {
 		t.Errorf("Suppressions.Add returned error: %v", err)
+	}
+
+	assert.Equal(t, "suppression", resp.Object)
+	assert.Equal(t, "e169aa45-1ecf-4183-9955-b1499d5701d3", resp.Id)
+}
+
+func TestAddSuppressionWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/suppressions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprint(w, `{
+			"object": "suppression",
+			"id": "e169aa45-1ecf-4183-9955-b1499d5701d3"
+		}`)
+	})
+
+	ctx := context.Background()
+	resp, err := client.Suppressions.AddWithContext(ctx, &AddSuppressionRequest{
+		Email: "steve.wozniak@gmail.com",
+	})
+	if err != nil {
+		t.Errorf("Suppressions.AddWithContext returned error: %v", err)
 	}
 
 	assert.Equal(t, "suppression", resp.Object)
@@ -110,6 +140,7 @@ func TestListSuppressionsWithOptions(t *testing.T) {
 		assert.Equal(t, "complaint", r.URL.Query().Get("origin"))
 		assert.Equal(t, "20", r.URL.Query().Get("limit"))
 		assert.Equal(t, "e169aa45-1ecf-4183-9955-b1499d5701d3", r.URL.Query().Get("after"))
+		assert.Equal(t, "b6d24b8e-af0b-4c3c-be0c-359bbd97381e", r.URL.Query().Get("before"))
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -118,10 +149,12 @@ func TestListSuppressionsWithOptions(t *testing.T) {
 
 	limit := 20
 	after := "e169aa45-1ecf-4183-9955-b1499d5701d3"
+	before := "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
 	resp, err := client.Suppressions.List(&ListSuppressionsOptions{
 		Origin: SuppressionOriginComplaint,
 		Limit:  &limit,
 		After:  &after,
+		Before: &before,
 	})
 	if err != nil {
 		t.Errorf("Suppressions.List returned error: %v", err)
@@ -130,6 +163,42 @@ func TestListSuppressionsWithOptions(t *testing.T) {
 	assert.Equal(t, "list", resp.Object)
 	assert.False(t, resp.HasMore)
 	assert.Empty(t, resp.Data)
+}
+
+func TestListSuppressionsWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/suppressions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `{
+			"object": "list",
+			"has_more": false,
+			"data": [
+				{
+					"id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+					"email": "steve.wozniak@gmail.com",
+					"origin": "bounce",
+					"source_id": "479e3145-dd38-476b-932c-529ceb705947",
+					"created_at": "2023-10-06T23:47:56.678Z"
+				}
+			]
+		}`)
+	})
+
+	ctx := context.Background()
+	resp, err := client.Suppressions.ListWithContext(ctx, nil)
+	if err != nil {
+		t.Errorf("Suppressions.ListWithContext returned error: %v", err)
+	}
+
+	assert.Equal(t, "list", resp.Object)
+	assert.False(t, resp.HasMore)
+	assert.Len(t, resp.Data, 1)
+	assert.Equal(t, "e169aa45-1ecf-4183-9955-b1499d5701d3", resp.Data[0].Id)
 }
 
 func TestSuppressionListEntryHasNoObjectField(t *testing.T) {
@@ -179,6 +248,37 @@ func TestGetSuppression(t *testing.T) {
 	assert.Equal(t, "2023-10-06T23:47:56.678Z", resp.CreatedAt)
 }
 
+func TestGetSuppressionWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/suppressions/e169aa45-1ecf-4183-9955-b1499d5701d3", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `{
+			"object": "suppression",
+			"id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+			"email": "steve.wozniak@gmail.com",
+			"origin": "complaint",
+			"source_id": "479e3145-dd38-476b-932c-529ceb705947",
+			"created_at": "2023-10-06T23:47:56.678Z"
+		}`)
+	})
+
+	ctx := context.Background()
+	resp, err := client.Suppressions.GetWithContext(ctx, "e169aa45-1ecf-4183-9955-b1499d5701d3")
+	if err != nil {
+		t.Errorf("Suppressions.GetWithContext returned error: %v", err)
+	}
+
+	assert.Equal(t, "suppression", resp.Object)
+	assert.Equal(t, "e169aa45-1ecf-4183-9955-b1499d5701d3", resp.Id)
+	assert.Equal(t, "steve.wozniak@gmail.com", resp.Email)
+	assert.Equal(t, SuppressionOriginComplaint, resp.Origin)
+}
+
 func TestGetSuppressionByEmail(t *testing.T) {
 	setup()
 	defer teardown()
@@ -209,6 +309,65 @@ func TestGetSuppressionByEmail(t *testing.T) {
 	assert.Nil(t, resp.SourceId)
 }
 
+func TestGetSuppressionEscapesReservedPathCharacters(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/suppressions/", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+
+		assert.Equal(t, "/suppressions/steve%2Fwoz%20iak@gmail.com", r.URL.EscapedPath())
+		assert.Equal(t, []string{"", "suppressions", "steve%2Fwoz%20iak@gmail.com"}, strings.Split(r.URL.EscapedPath(), "/"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `{
+			"object": "suppression",
+			"id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+			"email": "steve/woz iak@gmail.com",
+			"origin": "manual",
+			"source_id": null,
+			"created_at": "2023-10-06T23:47:56.678Z"
+		}`)
+	})
+
+	resp, err := client.Suppressions.Get("steve/woz iak@gmail.com")
+	if err != nil {
+		t.Errorf("Suppressions.Get returned error: %v", err)
+	}
+
+	assert.Equal(t, "steve/woz iak@gmail.com", resp.Email)
+}
+
+func TestRemoveSuppressionEscapesReservedPathCharacters(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/suppressions/", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+
+		assert.Equal(t, "/suppressions/steve%2Fwozniak@gmail.com", r.URL.EscapedPath())
+		assert.Equal(t, []string{"", "suppressions", "steve%2Fwozniak@gmail.com"}, strings.Split(r.URL.EscapedPath(), "/"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `{
+			"object": "suppression",
+			"id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+			"deleted": true
+		}`)
+	})
+
+	resp, err := client.Suppressions.Remove("steve/wozniak@gmail.com")
+	if err != nil {
+		t.Errorf("Suppressions.Remove returned error: %v", err)
+	}
+
+	assert.True(t, resp.Deleted)
+}
+
 func TestGetSuppressionMissingIdentifier(t *testing.T) {
 	setup()
 	defer teardown()
@@ -237,6 +396,33 @@ func TestRemoveSuppression(t *testing.T) {
 	resp, err := client.Suppressions.Remove("e169aa45-1ecf-4183-9955-b1499d5701d3")
 	if err != nil {
 		t.Errorf("Suppressions.Remove returned error: %v", err)
+	}
+
+	assert.Equal(t, "suppression", resp.Object)
+	assert.Equal(t, "e169aa45-1ecf-4183-9955-b1499d5701d3", resp.Id)
+	assert.True(t, resp.Deleted)
+}
+
+func TestRemoveSuppressionWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/suppressions/e169aa45-1ecf-4183-9955-b1499d5701d3", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `{
+			"object": "suppression",
+			"id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+			"deleted": true
+		}`)
+	})
+
+	ctx := context.Background()
+	resp, err := client.Suppressions.RemoveWithContext(ctx, "e169aa45-1ecf-4183-9955-b1499d5701d3")
+	if err != nil {
+		t.Errorf("Suppressions.RemoveWithContext returned error: %v", err)
 	}
 
 	assert.Equal(t, "suppression", resp.Object)
@@ -289,6 +475,35 @@ func TestBatchAddSuppressions(t *testing.T) {
 	assert.Equal(t, "suppression", resp.Data[0].Object)
 	assert.Equal(t, "e169aa45-1ecf-4183-9955-b1499d5701d3", resp.Data[0].Id)
 	assert.Equal(t, "b6d24b8e-af0b-4c3c-be0c-359bbd97381e", resp.Data[1].Id)
+}
+
+func TestBatchAddSuppressionsWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/suppressions/batch/add", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+
+		fmt.Fprint(w, `{
+			"data": [
+				{ "object": "suppression", "id": "e169aa45-1ecf-4183-9955-b1499d5701d3" }
+			]
+		}`)
+	})
+
+	ctx := context.Background()
+	resp, err := client.Suppressions.Batch.AddWithContext(ctx, &BatchAddSuppressionsRequest{
+		Emails: []string{"steve.wozniak@gmail.com"},
+	})
+	if err != nil {
+		t.Errorf("Suppressions.Batch.AddWithContext returned error: %v", err)
+	}
+
+	assert.Len(t, resp.Data, 1)
+	assert.Equal(t, "suppression", resp.Data[0].Object)
+	assert.Equal(t, "e169aa45-1ecf-4183-9955-b1499d5701d3", resp.Data[0].Id)
 }
 
 func TestBatchAddSuppressionsMissingEmails(t *testing.T) {
@@ -370,6 +585,35 @@ func TestBatchRemoveSuppressionsWithIds(t *testing.T) {
 	assert.True(t, resp.Data[0].Deleted)
 }
 
+func TestBatchRemoveSuppressionsWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/suppressions/batch/remove", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, `{
+			"data": [
+				{ "object": "suppression", "id": "e169aa45-1ecf-4183-9955-b1499d5701d3", "deleted": true }
+			]
+		}`)
+	})
+
+	ctx := context.Background()
+	resp, err := client.Suppressions.Batch.RemoveWithContext(ctx, &BatchRemoveSuppressionsRequest{
+		Emails: []string{"steve.wozniak@gmail.com"},
+	})
+	if err != nil {
+		t.Errorf("Suppressions.Batch.RemoveWithContext returned error: %v", err)
+	}
+
+	assert.Len(t, resp.Data, 1)
+	assert.Equal(t, "e169aa45-1ecf-4183-9955-b1499d5701d3", resp.Data[0].Id)
+	assert.True(t, resp.Data[0].Deleted)
+}
+
 func TestBatchRemoveSuppressionsOmitsUnsetKey(t *testing.T) {
 	body, err := json.Marshal(&BatchRemoveSuppressionsRequest{Ids: []string{"e169aa45-1ecf-4183-9955-b1499d5701d3"}})
 	if err != nil {
@@ -394,4 +638,72 @@ func TestBatchRemoveSuppressionsRequiresOneOf(t *testing.T) {
 	})
 	assert.Error(t, err)
 	assert.Equal(t, "[ERROR]: Provide either `emails` or `ids`, but not both.", err.Error())
+}
+
+func TestSuppressionsShouldReturnErrorIfContextIsCancelled(t *testing.T) {
+	setup()
+	defer teardown()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cases := []struct {
+		desc string
+		call func() error
+	}{
+		{
+			desc: "Add",
+			call: func() error {
+				_, err := client.Suppressions.AddWithContext(ctx, &AddSuppressionRequest{Email: "steve.wozniak@gmail.com"})
+				return err
+			},
+		},
+		{
+			desc: "List",
+			call: func() error {
+				_, err := client.Suppressions.ListWithContext(ctx, nil)
+				return err
+			},
+		},
+		{
+			desc: "Get",
+			call: func() error {
+				_, err := client.Suppressions.GetWithContext(ctx, "e169aa45-1ecf-4183-9955-b1499d5701d3")
+				return err
+			},
+		},
+		{
+			desc: "Remove",
+			call: func() error {
+				_, err := client.Suppressions.RemoveWithContext(ctx, "e169aa45-1ecf-4183-9955-b1499d5701d3")
+				return err
+			},
+		},
+		{
+			desc: "Batch.Add",
+			call: func() error {
+				_, err := client.Suppressions.Batch.AddWithContext(ctx, &BatchAddSuppressionsRequest{
+					Emails: []string{"steve.wozniak@gmail.com"},
+				})
+				return err
+			},
+		},
+		{
+			desc: "Batch.Remove",
+			call: func() error {
+				_, err := client.Suppressions.Batch.RemoveWithContext(ctx, &BatchRemoveSuppressionsRequest{
+					Emails: []string{"steve.wozniak@gmail.com"},
+				})
+				return err
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			err := c.call()
+			assert.Error(t, err)
+			assert.True(t, errors.Is(err, context.Canceled))
+		})
+	}
 }


### PR DESCRIPTION
## What

Adds suppression-list support: `Add`, `List`, `Get`, `Remove` plus a nested `Batch` sub-service with `Add` / `Remove`, each with a `WithContext` variant.

```go
client.Suppressions.Add(&resend.AddSuppressionRequest{Email: "..."})
client.Suppressions.List(&resend.ListSuppressionsOptions{Origin: resend.SuppressionOriginManual})
client.Suppressions.Get(idOrEmail)
client.Suppressions.Remove(idOrEmail)
client.Suppressions.Batch.Add(&resend.BatchAddSuppressionsRequest{Emails: []string{...}})
client.Suppressions.Batch.Remove(&resend.BatchRemoveSuppressionsRequest{Ids: []string{...}})
```

The nested sub-service follows the `Contacts.Segments` / `Contacts.Imports` precedent for operation-only groupings, so `Client.Suppressions` is `*SuppressionsSvcImpl` like the existing `Contacts` and `Emails` fields. `url.PathEscape` for the id-or-email segment, `omitempty` on both batch-remove slices, nullable `source_id` as `*string`, and `CreatedAt string` matching every sibling.

Two structs rather than one: `SuppressionListEntry` (no `Object` field) for list entries and `Suppression` (with it) for `Get`.

## Contract verification

Verified in order of authority: the API server implementation (`apps/public-api/src/routes/suppressions/` in the monorepo), then `resend-openapi` `resend.yaml`, then the docs — and finally end-to-end against the live API with a real team key (read-only operations).

**One deliberate divergence, flagged so it does not look like a bug in review:** list entries do **not** carry the `object` field; only the single-`get` response does. `list.ts` selects exactly `{id, email, origin, source_id, created_at}` and adds nothing, while `get.ts` returns `{object: "suppression", ...}`. Confirmed on live wire output.

Two upstream artifacts disagree with the server here and are being tracked separately, so please do not use them as the reference when reviewing:
- the `list-suppressions` docs example shows a per-entry `object` that the API never sends
- `resend-node` `SuppressionListEntry` declares the same nonexistent field, and is shipped in `resend@6.18.0`

The OpenAPI spec is correct on this point and agrees with the implementation.

Other behaviour confirmed at the server and reflected in docs/tests, not reimplemented client-side:
- `batch/remove` accepts `emails` XOR `ids`; the unset key must be **omitted**, since the server validation accepts undefined but rejects an explicit `null`
- the API lowercases, trims and **deduplicates** emails, and `batch/add` upserts — so batch responses can contain **fewer** entries than were sent; callers must not pair results to inputs by index
- `batch/remove` returns only rows actually deleted (misses are absent, no error), whereas single `remove` returns 404 on a miss
- `source_id` is nullable and is `null` for `manual`-origin suppressions

## Release timing

These endpoints are in beta and gated behind a server-side feature flag: a team without access receives **404 on every suppression endpoint**. Merging is safe, but worth a deliberate decision on whether this ships in the next release or waits for wider flag rollout, since otherwise a documented SDK method returns 404 for most users.

## Verification

```
go build ./...                          # 0 errors
go clean -testcache && go test ./...    # ok
go vet ./...                            # clean
gofmt -l <changed files>                # clean
```
16 suppression tests covering all six operations, null `source_id` in both list and get, the `ids` variant, a marshalling assertion that the unset batch-remove key is absent, a `+`-addressed email path, and a guard that `SuppressionListEntry` emits no `object` key (the fixture change alone would not fail if the field were re-added, since a missing JSON key silently yields `""`).

Note: this repo has no linter configured (`.github/workflows/go.yml` runs only build and test), so `go vet` and `gofmt` were used as the closest equivalent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add suppression-list support to the Go SDK with single and batch operations to add, list, get, and remove suppressions. This lets teams manage suppressed emails programmatically.

- **New Features**
  - `client.Suppressions` with `Add`, `List`, `Get`, `Remove`, and `Batch.Add` / `Batch.Remove` (all have `WithContext`).
  - `List` supports `origin` filter and pagination (`limit`, `after`, `before`).
  - `Get`/`Remove` accept a suppression ID or an email.
  - Escapes reserved path characters with `url.PathEscape`; `WithContext` variants honor cancellation.

- **Migration**
  - Endpoints are beta and feature-flagged; teams without access get 404 on all suppression calls.
  - `Batch.Remove` requires either `emails` or `ids` (not both); the unset field is omitted. `Batch.Add` upserts/dedupes, so responses can be shorter than inputs.
  - Models: list uses `SuppressionListEntry` (no `object`); `Get` returns `Suppression` with `object`. `source_id` can be null.

<sup>Written for commit d39ac17ae15dad6448e7bfe8ce2408dce600e58c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

