### PR TITLE
chore: bump version to 3.12.0

### DIFF
--- a/resend.go
+++ b/resend.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version     = "3.11.0"
+	version     = "3.12.0"
 	userAgent   = "resend-go/" + version
 	contentType = "application/json"
 )


### PR DESCRIPTION
## Summary
- Bump version to 3.12.0 to release the suppressions endpoints added in #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `resend-go` version to 3.12.0 to release the suppressions endpoints.

<sup>Written for commit d1e2cfdec1daee9845b47fdac993b5685f871566. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

