### PR TITLE
feat: add broadcasts.Cancel() method

### DIFF
--- a/broadcasts.go
+++ b/broadcasts.go
@@ -57,6 +57,11 @@ type SendBroadcastResponse struct {
 	Id string `json:"id"`
 }
 
+type CancelBroadcastResponse struct {
+	Object string `json:"object"`
+	Id     string `json:"id"`
+}
+
 type RemoveBroadcastResponse struct {
 	Object  string `json:"object"`
 	Id      string `json:"id"`
@@ -103,6 +108,9 @@ type BroadcastsSvc interface {
 
 	SendWithContext(ctx context.Context, params *SendBroadcastRequest) (SendBroadcastResponse, error)
 	Send(params *SendBroadcastRequest) (SendBroadcastResponse, error)
+
+	CancelWithContext(ctx context.Context, broadcastId string) (CancelBroadcastResponse, error)
+	Cancel(broadcastId string) (CancelBroadcastResponse, error)
 
 	RemoveWithContext(ctx context.Context, broadcastId string) (RemoveBroadcastResponse, error)
 	Remove(broadcastId string) (RemoveBroadcastResponse, error)
@@ -249,6 +257,35 @@ func (s *BroadcastsSvcImpl) SendWithContext(ctx context.Context, params *SendBro
 // Send sends broadcasts to your audience.
 func (s *BroadcastsSvcImpl) Send(params *SendBroadcastRequest) (SendBroadcastResponse, error) {
 	return s.SendWithContext(context.Background(), params)
+}
+
+func (s *BroadcastsSvcImpl) CancelWithContext(ctx context.Context, broadcastId string) (CancelBroadcastResponse, error) {
+	if broadcastId == "" {
+		return CancelBroadcastResponse{}, errors.New("[ERROR]: broadcastId cannot be empty")
+	}
+
+	path := "broadcasts/" + broadcastId + "/cancel"
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, nil)
+	if err != nil {
+		return CancelBroadcastResponse{}, ErrFailedToCreateBroadcastCancelRequest
+	}
+
+	resp := new(CancelBroadcastResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, resp)
+
+	if err != nil {
+		return CancelBroadcastResponse{}, err
+	}
+
+	return *resp, nil
+}
+
+func (s *BroadcastsSvcImpl) Cancel(broadcastId string) (CancelBroadcastResponse, error) {
+	return s.CancelWithContext(context.Background(), broadcastId)
 }
 
 // RemoveWithContext removes a given broadcast by id

--- a/broadcasts_test.go
+++ b/broadcasts_test.go
@@ -299,6 +299,32 @@ func TestRemoveBroadcast(t *testing.T) {
 	assert.Equal(t, deleted.Object, "broadcast")
 }
 
+func TestCancelBroadcast(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/broadcasts/b6d24b8e-af0b-4c3c-be0c-359bbd97381e/cancel", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.WriteHeader(http.StatusOK)
+
+		var ret any
+		ret = `
+		{
+			"object": "broadcast",
+			"id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	canceled, err := client.Broadcasts.Cancel("b6d24b8e-af0b-4c3c-be0c-359bbd97381e")
+	if err != nil {
+		t.Errorf("Broadcasts.Cancel returned error: %v", err)
+	}
+	assert.Equal(t, canceled.Id, "b6d24b8e-af0b-4c3c-be0c-359bbd97381e")
+	assert.Equal(t, canceled.Object, "broadcast")
+}
+
 func TestListBroadcasts(t *testing.T) {
 	setup()
 	defer teardown()

--- a/errors.go
+++ b/errors.go
@@ -51,6 +51,7 @@ var (
 	ErrFailedToCreateBroadcastUpdateRequest = errors.New("[ERROR]: Failed to create Broadcasts.Update request")
 	ErrFailedToCreateBroadcastSendRequest   = errors.New("[ERROR]: Failed to create Broadcasts.Send request")
 	ErrFailedToCreateBroadcastCreateRequest = errors.New("[ERROR]: Failed to create Broadcasts.Create request")
+	ErrFailedToCreateBroadcastCancelRequest = errors.New("[ERROR]: Failed to create Broadcasts.Cancel request")
 )
 
 // ApiKeySvc errors


### PR DESCRIPTION
## Summary
- Adds `Broadcasts.Cancel(id)` / `CancelWithContext(ctx, id)`, calling `POST /broadcasts/:id/cancel` to cancel a queued or scheduled broadcast.
- Mirrors `Emails.Cancel()`'s shape (no body, id-only).

Part of the broadcast cancel rollout: resend/resend-monorepo#8126, resend/resend-openapi#85, resend/resend-node#1059, resend/resend-docs#1722.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -l` on touched files — clean
- [x] `go test ./... -run Broadcast` — 12/12 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Broadcasts.Cancel` and `CancelWithContext` to cancel queued or scheduled broadcasts via `POST /broadcasts/:id/cancel`. Mirrors `Emails.Cancel` behavior (no body, id-only).

- **New Features**
  - Adds `CancelBroadcastResponse` with `object` and `id`.
  - Adds `ErrFailedToCreateBroadcastCancelRequest`.
  - Tests cover cancel flow.

<sup>Written for commit ba505d037a06211869ef1363a5dbe56e3f2d1fde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

