### PR TITLE
feat(automations): duplicate endpoint

### DIFF
--- a/automations.go
+++ b/automations.go
@@ -66,9 +66,9 @@ type AutomationConnection struct {
 }
 
 type CreateAutomationRequest struct {
-	Name        string           `json:"name"`
-	Status      AutomationStatus `json:"status,omitempty"`
-	Steps       []AutomationStep `json:"steps"`
+	Name        string                 `json:"name"`
+	Status      AutomationStatus       `json:"status,omitempty"`
+	Steps       []AutomationStep       `json:"steps"`
 	Connections []AutomationConnection `json:"connections"`
 }
 
@@ -78,9 +78,9 @@ type CreateAutomationResponse struct {
 }
 
 type UpdateAutomationRequest struct {
-	Name        string           `json:"name,omitempty"`
-	Status      AutomationStatus `json:"status,omitempty"`
-	Steps       []AutomationStep `json:"steps,omitempty"`
+	Name        string                 `json:"name,omitempty"`
+	Status      AutomationStatus       `json:"status,omitempty"`
+	Steps       []AutomationStep       `json:"steps,omitempty"`
 	Connections []AutomationConnection `json:"connections,omitempty"`
 }
 
@@ -93,6 +93,11 @@ type DeleteAutomationResponse struct {
 	Object  string `json:"object"`
 	Id      string `json:"id"`
 	Deleted bool   `json:"deleted"`
+}
+
+type DuplicateAutomationResponse struct {
+	Object string `json:"object"`
+	Id     string `json:"id"`
 }
 
 type StopAutomationResponse struct {
@@ -123,7 +128,7 @@ type Automation struct {
 	CreatedAt   string                   `json:"created_at"`
 	UpdatedAt   string                   `json:"updated_at"`
 	Steps       []AutomationStepResponse `json:"steps"`
-	Connections []AutomationConnection         `json:"connections"`
+	Connections []AutomationConnection   `json:"connections"`
 }
 
 type AutomationRunListItem struct {
@@ -189,6 +194,8 @@ type AutomationsSvc interface {
 	Update(automationId string, params *UpdateAutomationRequest) (UpdateAutomationResponse, error)
 	RemoveWithContext(ctx context.Context, automationId string) (DeleteAutomationResponse, error)
 	Remove(automationId string) (DeleteAutomationResponse, error)
+	DuplicateWithContext(ctx context.Context, automationId string) (DuplicateAutomationResponse, error)
+	Duplicate(automationId string) (DuplicateAutomationResponse, error)
 	StopWithContext(ctx context.Context, automationId string) (StopAutomationResponse, error)
 	Stop(automationId string) (StopAutomationResponse, error)
 	ListRunsWithContext(ctx context.Context, automationId string, options *ListAutomationRunsOptions) (ListAutomationRunsResponse, error)
@@ -373,6 +380,30 @@ func (s *AutomationsSvcImpl) RemoveWithContext(ctx context.Context, automationId
 // Remove deletes an Automation by ID
 func (s *AutomationsSvcImpl) Remove(automationId string) (DeleteAutomationResponse, error) {
 	return s.RemoveWithContext(context.Background(), automationId)
+}
+
+// DuplicateWithContext duplicates an Automation by ID
+// https://resend.com/docs/api-reference/automations/duplicate-automation
+func (s *AutomationsSvcImpl) DuplicateWithContext(ctx context.Context, automationId string) (DuplicateAutomationResponse, error) {
+	path := "automations/" + automationId + "/duplicate"
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, nil)
+	if err != nil {
+		return DuplicateAutomationResponse{}, ErrFailedToCreateAutomationDuplicateRequest
+	}
+
+	resp := new(DuplicateAutomationResponse)
+	_, err = s.client.Perform(req, resp)
+	if err != nil {
+		return DuplicateAutomationResponse{}, err
+	}
+
+	return *resp, nil
+}
+
+// Duplicate duplicates an Automation by ID
+func (s *AutomationsSvcImpl) Duplicate(automationId string) (DuplicateAutomationResponse, error) {
+	return s.DuplicateWithContext(context.Background(), automationId)
 }
 
 // StopWithContext stops a running Automation by ID

--- a/automations_test.go
+++ b/automations_test.go
@@ -183,6 +183,25 @@ func TestRemoveAutomation(t *testing.T) {
 	assert.Equal(t, true, resp.Deleted)
 }
 
+func TestDuplicateAutomation(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/automations/aut_123/duplicate", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"object":"automation","id":"aut_456"}`)
+	})
+
+	resp, err := client.Automations.Duplicate("aut_123")
+	if err != nil {
+		t.Fatalf("Automations.Duplicate returned error: %v", err)
+	}
+	assert.Equal(t, "automation", resp.Object)
+	assert.Equal(t, "aut_456", resp.Id)
+}
+
 func TestStopAutomation(t *testing.T) {
 	setup()
 	defer teardown()

--- a/errors.go
+++ b/errors.go
@@ -107,14 +107,15 @@ var (
 
 // AutomationsSvc errors
 var (
-	ErrFailedToCreateAutomationCreateRequest   = errors.New("[ERROR]: Failed to create Automations.Create request")
-	ErrFailedToCreateAutomationGetRequest      = errors.New("[ERROR]: Failed to create Automations.Get request")
-	ErrFailedToCreateAutomationListRequest     = errors.New("[ERROR]: Failed to create Automations.List request")
-	ErrFailedToCreateAutomationUpdateRequest   = errors.New("[ERROR]: Failed to create Automations.Update request")
-	ErrFailedToCreateAutomationRemoveRequest   = errors.New("[ERROR]: Failed to create Automations.Remove request")
-	ErrFailedToCreateAutomationStopRequest     = errors.New("[ERROR]: Failed to create Automations.Stop request")
-	ErrFailedToCreateAutomationListRunsRequest = errors.New("[ERROR]: Failed to create Automations.ListRuns request")
-	ErrFailedToCreateAutomationGetRunRequest   = errors.New("[ERROR]: Failed to create Automations.GetRun request")
+	ErrFailedToCreateAutomationCreateRequest    = errors.New("[ERROR]: Failed to create Automations.Create request")
+	ErrFailedToCreateAutomationGetRequest       = errors.New("[ERROR]: Failed to create Automations.Get request")
+	ErrFailedToCreateAutomationListRequest      = errors.New("[ERROR]: Failed to create Automations.List request")
+	ErrFailedToCreateAutomationUpdateRequest    = errors.New("[ERROR]: Failed to create Automations.Update request")
+	ErrFailedToCreateAutomationRemoveRequest    = errors.New("[ERROR]: Failed to create Automations.Remove request")
+	ErrFailedToCreateAutomationDuplicateRequest = errors.New("[ERROR]: Failed to create Automations.Duplicate request")
+	ErrFailedToCreateAutomationStopRequest      = errors.New("[ERROR]: Failed to create Automations.Stop request")
+	ErrFailedToCreateAutomationListRunsRequest  = errors.New("[ERROR]: Failed to create Automations.ListRuns request")
+	ErrFailedToCreateAutomationGetRunRequest    = errors.New("[ERROR]: Failed to create Automations.GetRun request")
 )
 
 // EventsSvc errors


### PR DESCRIPTION
Adds `Automations.Duplicate(automationId)` and `Automations.DuplicateWithContext(ctx, automationId)` for `POST /automations/{id}/duplicate`.

Resolves DEV-1709. Mirrors the existing `Stop` pattern and resend-node https://github.com/resend/resend-node/pull/1071.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Automation duplicate support to the Go SDK so clients can duplicate an automation by ID. Previously unsupported; now `Automations.Duplicate(...)` and `Automations.DuplicateWithContext(...)` wrap POST /automations/{id}/duplicate to satisfy DEV-1709 and maintain parity with `resend-node`.

**Changes and review notes**
- Add `DuplicateAutomationResponse` and POST path `automations/{id}/duplicate`.
- Extend `AutomationsSvc` and `AutomationsSvcImpl` with `Duplicate`/`DuplicateWithContext`.
- Add `ErrFailedToCreateAutomationDuplicateRequest`.
- Add `TestDuplicateAutomation`.
- Minor struct field alignment; no behavior change.

**Migration**
- If you implement `AutomationsSvc` (e.g., custom mocks), add `Duplicate` and `DuplicateWithContext` to your implementation.

<sup>Written for commit 969cb34240c4335900be14f1885104e51ff91f28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

