### PR TITLE
fix(contacts): properties response shape

### DIFF
--- a/contacts.go
+++ b/contacts.go
@@ -120,15 +120,20 @@ type ListContactsResponse struct {
 	HasMore bool      `json:"has_more"`
 }
 
+type ContactPropertyValue struct {
+	Value any    `json:"value"` // string, number, or boolean, depending on Type
+	Type  string `json:"type"`
+}
+
 type Contact struct {
-	Id           string         `json:"id"`
-	Email        string         `json:"email"`
-	Object       string         `json:"object"`
-	FirstName    string         `json:"first_name"`
-	LastName     string         `json:"last_name"`
-	CreatedAt    string         `json:"created_at"`
-	Unsubscribed bool           `json:"unsubscribed"`
-	Properties   map[string]any `json:"properties,omitempty"` // Custom properties for global contacts (currently API only returns string values)
+	Id           string                          `json:"id"`
+	Email        string                          `json:"email"`
+	Object       string                          `json:"object"`
+	FirstName    string                          `json:"first_name"`
+	LastName     string                          `json:"last_name"`
+	CreatedAt    string                          `json:"created_at"`
+	Unsubscribed bool                            `json:"unsubscribed"`
+	Properties   map[string]ContactPropertyValue `json:"properties,omitempty"` // Custom properties for global contacts, returned as {value, type} objects
 }
 
 // Create creates a new Contact based on the given params

--- a/contacts_test.go
+++ b/contacts_test.go
@@ -522,11 +522,7 @@ func TestListGlobalContacts(t *testing.T) {
 					"first_name": "Global",
 					"last_name": "Contact",
 					"created_at": "2023-10-06 22:59:55.977+00",
-					"unsubscribed": false,
-					"properties": {
-						"tier": "premium",
-						"role": "admin"
-					}
+					"unsubscribed": false
 				}
 			],
 			"has_more": false
@@ -544,8 +540,6 @@ func TestListGlobalContacts(t *testing.T) {
 	assert.Equal(t, "list", contacts.Object)
 	assert.Equal(t, "479e3145-dd38-476b-932c-529ceb705947", contacts.Data[0].Id)
 	assert.Equal(t, "global@example.com", contacts.Data[0].Email)
-	assert.NotNil(t, contacts.Data[0].Properties)
-	assert.Equal(t, "premium", contacts.Data[0].Properties["tier"])
 }
 
 func TestGetGlobalContact(t *testing.T) {
@@ -568,7 +562,7 @@ func TestGetGlobalContact(t *testing.T) {
 			"created_at": "2023-10-06 22:59:55.977+00",
 			"unsubscribed": false,
 			"properties": {
-				"tier": "premium"
+				"tier": {"value": "premium", "type": "string"}
 			}
 		}`
 
@@ -584,7 +578,8 @@ func TestGetGlobalContact(t *testing.T) {
 	assert.Equal(t, contactId, contact.Id)
 	assert.Equal(t, "global@example.com", contact.Email)
 	assert.NotNil(t, contact.Properties)
-	assert.Equal(t, "premium", contact.Properties["tier"])
+	assert.Equal(t, "premium", contact.Properties["tier"].Value)
+	assert.Equal(t, "string", contact.Properties["tier"].Type)
 }
 
 func TestUpdateGlobalContact(t *testing.T) {
@@ -608,7 +603,7 @@ func TestUpdateGlobalContact(t *testing.T) {
 				"created_at": "2023-04-26 20:21:26.347412+00",
 				"unsubscribed": false,
 				"properties": {
-					"tier": "enterprise"
+					"tier": {"value": "enterprise", "type": "string"}
 				}
 			},
 			"error": {}
@@ -636,7 +631,7 @@ func TestUpdateGlobalContact(t *testing.T) {
 	assert.Equal(t, contactId, resp.Data.Id)
 	assert.Equal(t, "updated@example.com", resp.Data.Email)
 	assert.NotNil(t, resp.Data.Properties)
-	assert.Equal(t, "enterprise", resp.Data.Properties["tier"])
+	assert.Equal(t, "enterprise", resp.Data.Properties["tier"].Value)
 }
 
 func TestRemoveGlobalContact(t *testing.T) {


### PR DESCRIPTION
`GET /contacts/:id` returns `properties` where each entry is a `{value, type}` object, not a flat key→string map — the previous `map[string]any` typing (and its comment claiming string-only values) didn't reflect that. Adds `ContactPropertyValue` with `Value` (string, number, or boolean) and `Type`, and removes `properties` from the list-response fixture since only the retrieve endpoint returns it. Create/update request params stay flat maps.

Matches resend-node's `get-contact.interface.ts` and resend-rust's `ContactPropertyResponse`.

docs: https://resend.com/docs/api-reference/contacts/get-contact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the `Contact.Properties` response to match the API: previously a flat `map[string]any` of strings, now `map[string]ContactPropertyValue` where each entry is an object with `value` and `type`. This fixes decoding issues and clarifies that only `GET /contacts/:id` returns `properties`.

- Introduces `ContactPropertyValue` with `Value` (string/number/boolean) and `Type`.
- Removes `properties` from list-response fixtures and expectations; list responses do not include properties.
- Create/update request params remain flat maps; no changes required for write paths.

**Migration**
- Read property values via `contact.Properties["key"].Value` and check `Type` if needed.
- Replace string assertions on `Properties` entries with `ContactPropertyValue`.
- Do not rely on `properties` in list responses; fetch the contact to retrieve them.

<sup>Written for commit 7373404badce6b835c5e5bb979e4bf538a320399. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

