### PR TITLE
feat: add received_for to the received email type

### DIFF
--- a/receiving.go
+++ b/receiving.go
@@ -19,6 +19,7 @@ type ReceivedEmail struct {
 	Bcc         []string             `json:"bcc"`
 	Cc          []string             `json:"cc"`
 	ReplyTo     []string             `json:"reply_to"`
+	ReceivedFor []string             `json:"received_for"`
 	Headers     map[string]string    `json:"headers"`
 	MessageId   string               `json:"message_id"`
 	Attachments []ReceivedAttachment `json:"attachments"`

--- a/receiving_test.go
+++ b/receiving_test.go
@@ -33,6 +33,7 @@ func TestGetReceivedEmail(t *testing.T) {
 			"bcc": [],
 			"cc": ["cc@example.com"],
 			"reply_to": ["reply@example.com"],
+			"received_for": ["forwarded@example.com"],
 			"headers": {
 				"X-Custom-Header": "value"
 			},
@@ -69,6 +70,8 @@ func TestGetReceivedEmail(t *testing.T) {
 	assert.Equal(t, "cc@example.com", resp.Cc[0])
 	assert.Equal(t, 1, len(resp.ReplyTo))
 	assert.Equal(t, "reply@example.com", resp.ReplyTo[0])
+	assert.Equal(t, 1, len(resp.ReceivedFor))
+	assert.Equal(t, "forwarded@example.com", resp.ReceivedFor[0])
 	assert.Equal(t, 1, len(resp.Headers))
 	assert.Equal(t, "value", resp.Headers["X-Custom-Header"])
 	assert.Equal(t, "<test-message-id@example.com>", resp.MessageId)


### PR DESCRIPTION
The [retrieve received email](https://resend.com/docs/api-reference/emails/retrieve-received-email) endpoint returns a `received_for` array — "the recipient addresses the email was forwarded for, taken from the `for` clause of the message's `Received` headers" — but `ReceivedEmail` had no field for it, so the value was silently dropped on decode.

Adds the field and extends the existing `TestGetReceivedEmail` fixture and assertions to cover it.

Two things worth noting:

`ListReceivedEmail` is intentionally left alone. The [list endpoint docs](https://resend.com/docs/api-reference/emails/list-received-emails) do not document `received_for` on list items, so only the retrieve struct changes here.

The field is also still missing from [the OpenAPI spec](https://github.com/resend/resend-openapi/blob/main/resend.yaml), which is what [DEV-1626](https://linear.app/resend/issue/DEV-1626/investigate-missing-received-for-field-in-openapi-spec) is about. The docs and five other SDKs (Java, Node, PHP, Python, Rust) already have it, so the spec looks like the thing that is out of date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose received_for on retrieved received emails so forwarded recipient addresses are no longer dropped. Previously the retrieve endpoint returned this array but `ReceivedEmail` ignored it; now it decodes into the struct with no other behavior changes.

- Add `ReceivedFor []string` (json:"received_for") to `ReceivedEmail` and extend `TestGetReceivedEmail` to cover it.
- Leave `ListReceivedEmail` unchanged; the list endpoint does not document `received_for`.
- Align SDK with docs and other SDKs; OpenAPI gap is tracked in Linear DEV-1626. No migration required.

<sup>Written for commit 44942a49def84cd03c85157a5d322f2467e835b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




Ref DEV-1626
