### PR TITLE
fix: allow null contact first_name and last_name

### DIFF
--- a/contacts.go
+++ b/contacts.go
@@ -129,8 +129,8 @@ type Contact struct {
 	Id           string                          `json:"id"`
 	Email        string                          `json:"email"`
 	Object       string                          `json:"object"`
-	FirstName    string                          `json:"first_name"`
-	LastName     string                          `json:"last_name"`
+	FirstName    *string                         `json:"first_name"`
+	LastName     *string                         `json:"last_name"`
 	CreatedAt    string                          `json:"created_at"`
 	Unsubscribed bool                            `json:"unsubscribed"`
 	Properties   map[string]ContactPropertyValue `json:"properties,omitempty"` // Custom properties for global contacts, returned as {value, type} objects

--- a/contacts_test.go
+++ b/contacts_test.go
@@ -79,8 +79,10 @@ func TestListContacts(t *testing.T) {
 
 	assert.Equal(t, len(contacts.Data), 1)
 	assert.Equal(t, contacts.Data[0].Id, "e169aa45-1ecf-4183-9955-b1499d5701d3")
-	assert.Equal(t, contacts.Data[0].FirstName, "Steve")
-	assert.Equal(t, contacts.Data[0].LastName, "Wozniak")
+	assert.NotNil(t, contacts.Data[0].FirstName)
+	assert.Equal(t, *contacts.Data[0].FirstName, "Steve")
+	assert.NotNil(t, contacts.Data[0].LastName)
+	assert.Equal(t, *contacts.Data[0].LastName, "Wozniak")
 	assert.Equal(t, contacts.Data[0].CreatedAt, "2023-10-06 23:47:56.678+00")
 	assert.Equal(t, contacts.Data[0].Unsubscribed, false)
 }
@@ -187,10 +189,47 @@ func TestGetContact(t *testing.T) {
 
 	assert.Equal(t, contact.Id, contactId)
 	assert.Equal(t, contact.Object, "contact")
-	assert.Equal(t, contact.FirstName, "Steve")
-	assert.Equal(t, contact.LastName, "Wozniak")
+	assert.NotNil(t, contact.FirstName)
+	assert.Equal(t, *contact.FirstName, "Steve")
+	assert.NotNil(t, contact.LastName)
+	assert.Equal(t, *contact.LastName, "Wozniak")
 	assert.Equal(t, contact.CreatedAt, "2023-10-06 23:47:56.678+00")
 	assert.Equal(t, contact.Unsubscribed, false)
+}
+
+func TestGetContactWithNullNames(t *testing.T) {
+	setup()
+	defer teardown()
+
+	audienceId := "709d076c-2bb1-4be6-94ed-3f8f32622db6"
+	contactId := "e169aa45-1ecf-4183-9955-b1499d5701d3"
+
+	mux.HandleFunc("/audiences/"+audienceId+"/contacts/"+contactId, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "contact",
+			"id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+			"email": "steve.wozniak@gmail.com",
+			"first_name": null,
+			"last_name": null,
+			"created_at": "2023-10-06 23:47:56.678+00",
+			"unsubscribed": false
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	contact, err := client.Contacts.Get(&GetContactOptions{AudienceId: audienceId, Id: contactId})
+	if err != nil {
+		t.Errorf("Contacts.Get returned error: %v", err)
+	}
+
+	assert.Nil(t, contact.FirstName)
+	assert.Nil(t, contact.LastName)
 }
 
 func TestGetContactByEmail(t *testing.T) {
@@ -226,8 +265,10 @@ func TestGetContactByEmail(t *testing.T) {
 
 	assert.Equal(t, contact.Id, "e169aa45-1ecf-4183-9955-b1499d5701d3")
 	assert.Equal(t, contact.Object, "contact")
-	assert.Equal(t, contact.FirstName, "Steve")
-	assert.Equal(t, contact.LastName, "Wozniak")
+	assert.NotNil(t, contact.FirstName)
+	assert.Equal(t, *contact.FirstName, "Steve")
+	assert.NotNil(t, contact.LastName)
+	assert.Equal(t, *contact.LastName, "Wozniak")
 	assert.Equal(t, contact.Email, contactEmail)
 	assert.Equal(t, contact.CreatedAt, "2023-10-06 23:47:56.678+00")
 	assert.Equal(t, contact.Unsubscribed, false)
@@ -467,7 +508,8 @@ func TestUpdateContactAudienceIdMissing(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, "123123123", resp.Data.Id)
-	assert.Equal(t, "Updated First Name", resp.Data.FirstName)
+	assert.NotNil(t, resp.Data.FirstName)
+	assert.Equal(t, "Updated First Name", *resp.Data.FirstName)
 }
 
 // Global Contacts Tests

--- a/examples/global_contacts.go
+++ b/examples/global_contacts.go
@@ -67,7 +67,15 @@ func globalContactsExample() {
 	}
 	fmt.Printf("Found %d global contacts\n", len(contacts.Data))
 	for _, contact := range contacts.Data {
-		fmt.Printf("  - %s %s (%s)\n", contact.FirstName, contact.LastName, contact.Email)
+		firstName := ""
+		if contact.FirstName != nil {
+			firstName = *contact.FirstName
+		}
+		lastName := ""
+		if contact.LastName != nil {
+			lastName = *contact.LastName
+		}
+		fmt.Printf("  - %s %s (%s)\n", firstName, lastName, contact.Email)
 		if contact.Properties != nil {
 			fmt.Printf("    Properties: %+v\n", contact.Properties)
 		}


### PR DESCRIPTION
`Contact.FirstName` and `Contact.LastName` change from `string` to `*string`.

## Why the type had to change

The API returns `null` for a contact with no name. As a plain `string`, `encoding/json` silently decodes `null` to `""`, so this never errored, it just quietly lost information: callers could not distinguish "this contact has no first name" from "this contact's first name is an empty string". resend-node's recorded live responses contain `"first_name":null` in 12 separate fixtures, so this is routine rather than an edge case.

`*string` is already the convention in this repo for nullable response fields, matching `ApiKey.LastUsedAt`, `OAuthGrant.RevokedAt`, `Suppression.SourceId`, and `Template.PublishedAt`.

Confirmed against the monorepo: the contact record forwarded to webhooks is declared `firstName: z.string().nullish()` at `packages/inngest/src/schemas/contacts.ts:104`, and the REST responses behave the same way.

## What is in the diff

| Change | Files |
|---|---|
| `Contact.FirstName` / `LastName` → `*string` | `contacts.go` |
| null regression test + pointer assertions | `contacts_test.go` |
| nil-safe printing | `examples/global_contacts.go` |

`CreateContactRequest` and `UpdateContactRequest` keep plain `string` with `omitempty`, since those are inputs.

The new `TestGetContactWithNullNames` covers the actual bug. Existing assertions moved to the `assert.NotNil` + dereference pattern this repo already uses in `api_keys_test.go` and `suppressions_test.go`. The example needed nil-safe printing, which doubles as showing callers the pattern.

`go build`, `go vet`, and `go test ./...` all pass.

## Release

This is a source-breaking change, so it ships in v4.0.0 together with the contact properties shape fix (#146). The version bump and the `/v4` module path move are split out into #156 so this PR stays reviewable as a behavior change.

## Related

Spec fix in resend/resend-openapi#91.

Ref DEV-1625
