### PR TITLE
feat: add emails.Share() method

### DIFF
--- a/emails.go
+++ b/emails.go
@@ -48,6 +48,18 @@ type CancelScheduledEmailResponse struct {
 	Object string `json:"object"`
 }
 
+// ShareEmailRequest is the request object for the Share call.
+type ShareEmailRequest struct {
+	ExpiresIn string `json:"expires_in,omitempty"`
+}
+
+// ShareEmailResponse is the response from the Share call.
+type ShareEmailResponse struct {
+	Id     string `json:"id"`
+	Object string `json:"object"`
+	Url    string `json:"url"`
+}
+
 // SendEmailResponse is the response from the Send call.
 type SendEmailResponse struct {
 	Id string `json:"id"`
@@ -171,6 +183,8 @@ func (a *Attachment) MarshalJSON() ([]byte, error) {
 type EmailsSvc interface {
 	CancelWithContext(ctx context.Context, emailId string) (*CancelScheduledEmailResponse, error)
 	Cancel(emailId string) (*CancelScheduledEmailResponse, error)
+	ShareWithContext(ctx context.Context, emailId string, params *ShareEmailRequest) (*ShareEmailResponse, error)
+	Share(emailId string, params *ShareEmailRequest) (*ShareEmailResponse, error)
 	UpdateWithContext(ctx context.Context, params *UpdateEmailRequest) (*UpdateEmailResponse, error)
 	Update(params *UpdateEmailRequest) (*UpdateEmailResponse, error)
 	SendWithOptions(ctx context.Context, params *SendEmailRequest, options *SendEmailOptions) (*SendEmailResponse, error)
@@ -220,6 +234,37 @@ func (s *EmailsSvcImpl) CancelWithContext(ctx context.Context, emailId string) (
 	resp := new(CancelScheduledEmailResponse)
 
 	// Send Request
+	_, err = s.client.Perform(req, resp)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// Share creates a shareable link for a sent or received email by ID
+// https://resend.com/docs/api-reference/emails/share-email
+func (s *EmailsSvcImpl) Share(emailId string, params *ShareEmailRequest) (*ShareEmailResponse, error) {
+	return s.ShareWithContext(context.Background(), emailId, params)
+}
+
+// ShareWithContext creates a shareable link for a sent or received email by ID
+// https://resend.com/docs/api-reference/emails/share-email
+func (s *EmailsSvcImpl) ShareWithContext(ctx context.Context, emailId string, params *ShareEmailRequest) (*ShareEmailResponse, error) {
+	path := "emails/" + emailId + "/share"
+
+	var body any
+	if params != nil {
+		body = params
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, body)
+	if err != nil {
+		return nil, ErrFailedToCreateEmailsShareRequest
+	}
+
+	resp := new(ShareEmailResponse)
 	_, err = s.client.Perform(req, resp)
 
 	if err != nil {

--- a/emails_test.go
+++ b/emails_test.go
@@ -323,6 +323,154 @@ func TestCancelScheduledEmail(t *testing.T) {
 	assert.Equal(t, resp.Object, "email")
 }
 
+func TestShareEmailDefaultExpiresIn(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/emails/dacf4072-4119-4d88-932f-6202748ac7c8/share", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+
+		content, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+		}
+		if len(content) != 0 {
+			t.Errorf("expected an empty request body when params is nil, got: %s", string(content))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"id": "dacf4072-4119-4d88-932f-6202748ac7c8",
+			"object": "email",
+			"url": "https://resend.com/share/dacf4072-4119-4d88-932f-6202748ac7c8"
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	resp, err := client.Emails.Share("dacf4072-4119-4d88-932f-6202748ac7c8", nil)
+	if err != nil {
+		t.Errorf("Emails.Share returned error: %v", err)
+	}
+	assert.Equal(t, resp.Id, "dacf4072-4119-4d88-932f-6202748ac7c8")
+	assert.Equal(t, resp.Object, "email")
+	assert.Equal(t, resp.Url, "https://resend.com/share/dacf4072-4119-4d88-932f-6202748ac7c8")
+}
+
+func TestShareEmailWithCustomExpiresIn(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/emails/dacf4072-4119-4d88-932f-6202748ac7c8/share", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+
+		var req ShareEmailRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		assert.Equal(t, "1h 30m", req.ExpiresIn)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"id": "dacf4072-4119-4d88-932f-6202748ac7c8",
+			"object": "email",
+			"url": "https://resend.com/share/dacf4072-4119-4d88-932f-6202748ac7c8"
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	resp, err := client.Emails.Share("dacf4072-4119-4d88-932f-6202748ac7c8", &ShareEmailRequest{
+		ExpiresIn: "1h 30m",
+	})
+	if err != nil {
+		t.Errorf("Emails.Share returned error: %v", err)
+	}
+	assert.Equal(t, resp.Id, "dacf4072-4119-4d88-932f-6202748ac7c8")
+	assert.Equal(t, resp.Object, "email")
+	assert.Equal(t, resp.Url, "https://resend.com/share/dacf4072-4119-4d88-932f-6202748ac7c8")
+}
+
+func TestShareEmailWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/emails/dacf4072-4119-4d88-932f-6202748ac7c8/share", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"id": "dacf4072-4119-4d88-932f-6202748ac7c8",
+			"object": "email",
+			"url": "https://resend.com/share/dacf4072-4119-4d88-932f-6202748ac7c8"
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	ctx := context.Background()
+	resp, err := client.Emails.ShareWithContext(ctx, "dacf4072-4119-4d88-932f-6202748ac7c8", nil)
+	if err != nil {
+		t.Errorf("Emails.ShareWithContext returned error: %v", err)
+	}
+	assert.Equal(t, resp.Id, "dacf4072-4119-4d88-932f-6202748ac7c8")
+}
+
+func TestShareEmailMalformedExpiresInReturnsError(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/emails/dacf4072-4119-4d88-932f-6202748ac7c8/share", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+
+		ret := `
+		{
+			"statusCode": 422,
+			"name": "validation_error",
+			"message": "expires_in must not exceed 48 hours"
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	resp, err := client.Emails.Share("dacf4072-4119-4d88-932f-6202748ac7c8", &ShareEmailRequest{
+		ExpiresIn: "72h",
+	})
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expires_in must not exceed 48 hours")
+}
+
+func TestShareEmailNotFound(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/emails/00000000-0000-0000-0000-000000000000/share", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+
+		ret := `
+		{
+			"statusCode": 404,
+			"name": "not_found",
+			"message": "Email not found"
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	resp, err := client.Emails.Share("00000000-0000-0000-0000-000000000000", nil)
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Email not found")
+}
+
 func TestSendEmailWithOptions(t *testing.T) {
 	ctx := context.TODO()
 	client := NewClient("123")

--- a/errors.go
+++ b/errors.go
@@ -69,6 +69,7 @@ var (
 	ErrFailedToCreateEmailsListRequest            = errors.New("[ERROR]: Failed to create ListEmails request")
 	ErrFailedToCreateEmailsGetAttachmentRequest   = errors.New("[ERROR]: Failed to create Emails.GetAttachment request")
 	ErrFailedToCreateEmailsListAttachmentsRequest = errors.New("[ERROR]: Failed to create Emails.ListAttachments request")
+	ErrFailedToCreateEmailsShareRequest           = errors.New("[ERROR]: Failed to create Emails.Share request")
 )
 
 // TemplatesSvc errors


### PR DESCRIPTION
Adds `Emails.Share`/`ShareWithContext`, calling the new `POST /emails/{id}/share` endpoint that creates a shareable link for a sent or received email. See the spec PR resend/resend-openapi#92.

`ShareEmailRequest.ExpiresIn` is an optional human-readable duration (e.g. `10m`, `2 hours`, `1 day`; server defaults to `48h`, capped at 48h).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds email sharing so callers can create a public link for a sent or received email. Previously there was no share flow; now `Emails.Share`/`Emails.ShareWithContext` POST to `/emails/{id}/share` and return the link URL.

- Adds `ShareEmailRequest` with optional `ExpiresIn` (human-readable). Server defaults to and caps at 48h; invalid or over-cap values return 422.
- Omits the request body when `params` is nil to avoid sending a typed-nil null.
- Returns `ShareEmailResponse` with `id`, `object`, and `url`; adds `ErrFailedToCreateEmailsShareRequest`.
- Extends `EmailsSvc` with share methods, mirroring existing cancel/update patterns. Tests cover nil body, custom expiry, context, 422, and 404.

<sup>Written for commit d753772aa171753648ce3d3b979b084424ef2603. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

