### PR TITLE
feat: add Update method to api keys

### DIFF
--- a/api_keys.go
+++ b/api_keys.go
@@ -22,6 +22,15 @@ type ListApiKeysResponse struct {
 	HasMore bool     `json:"has_more"`
 }
 
+type UpdateApiKeyRequest struct {
+	Name string `json:"name"`
+}
+
+type UpdateApiKeyResponse struct {
+	Object string `json:"object"`
+	Id     string `json:"id"`
+}
+
 type ApiKey struct {
 	Id         string  `json:"id"`
 	Name       string  `json:"name"`
@@ -37,6 +46,8 @@ type ApiKeysSvc interface {
 	List() (ListApiKeysResponse, error)
 	RemoveWithContext(ctx context.Context, apiKeyId string) (bool, error)
 	Remove(apiKeyId string) (bool, error)
+	UpdateWithContext(ctx context.Context, apiKeyId string, params *UpdateApiKeyRequest) (UpdateApiKeyResponse, error)
+	Update(apiKeyId string, params *UpdateApiKeyRequest) (UpdateApiKeyResponse, error)
 }
 
 type ApiKeysSvcImpl struct {
@@ -131,4 +142,33 @@ func (s *ApiKeysSvcImpl) RemoveWithContext(ctx context.Context, apiKeyId string)
 // Remove deletes a given api key by id
 func (s *ApiKeysSvcImpl) Remove(apiKeyId string) (bool, error) {
 	return s.RemoveWithContext(context.Background(), apiKeyId)
+}
+
+// UpdateWithContext updates a given api key by id based on the given params
+// https://resend.com/docs/api-reference/api-keys/update-api-key
+func (s *ApiKeysSvcImpl) UpdateWithContext(ctx context.Context, apiKeyId string, params *UpdateApiKeyRequest) (UpdateApiKeyResponse, error) {
+	path := "api-keys/" + apiKeyId
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, params)
+	if err != nil {
+		return UpdateApiKeyResponse{}, ErrFailedToCreateApiKeysUpdateRequest
+	}
+
+	// Build response recipient obj
+	apiKeysResp := new(UpdateApiKeyResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, apiKeysResp)
+
+	if err != nil {
+		return UpdateApiKeyResponse{}, err
+	}
+
+	return *apiKeysResp, nil
+}
+
+// Update updates a given api key by id
+func (s *ApiKeysSvcImpl) Update(apiKeyId string, params *UpdateApiKeyRequest) (UpdateApiKeyResponse, error) {
+	return s.UpdateWithContext(context.Background(), apiKeyId, params)
 }

--- a/api_keys.go
+++ b/api_keys.go
@@ -144,23 +144,17 @@ func (s *ApiKeysSvcImpl) Remove(apiKeyId string) (bool, error) {
 	return s.RemoveWithContext(context.Background(), apiKeyId)
 }
 
-// UpdateWithContext updates a given api key by id based on the given params
 // https://resend.com/docs/api-reference/api-keys/update-api-key
 func (s *ApiKeysSvcImpl) UpdateWithContext(ctx context.Context, apiKeyId string, params *UpdateApiKeyRequest) (UpdateApiKeyResponse, error) {
 	path := "api-keys/" + apiKeyId
 
-	// Prepare request
 	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, params)
 	if err != nil {
 		return UpdateApiKeyResponse{}, ErrFailedToCreateApiKeysUpdateRequest
 	}
 
-	// Build response recipient obj
 	apiKeysResp := new(UpdateApiKeyResponse)
-
-	// Send Request
 	_, err = s.client.Perform(req, apiKeysResp)
-
 	if err != nil {
 		return UpdateApiKeyResponse{}, err
 	}
@@ -168,7 +162,6 @@ func (s *ApiKeysSvcImpl) UpdateWithContext(ctx context.Context, apiKeyId string,
 	return *apiKeysResp, nil
 }
 
-// Update updates a given api key by id
 func (s *ApiKeysSvcImpl) Update(apiKeyId string, params *UpdateApiKeyRequest) (UpdateApiKeyResponse, error) {
 	return s.UpdateWithContext(context.Background(), apiKeyId, params)
 }

--- a/api_keys_test.go
+++ b/api_keys_test.go
@@ -1,6 +1,7 @@
 package resend
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -93,4 +94,65 @@ func TestRemoveApiKey(t *testing.T) {
 		t.Errorf("ApiKeys.Remove returned error: %v", err)
 	}
 	assert.True(t, deleted)
+}
+
+func TestUpdateApiKey(t *testing.T) {
+	setup()
+	defer teardown()
+
+	apiKeyId := "dacf4072-4119-4d88-932f-6202748ac7c8"
+
+	mux.HandleFunc(fmt.Sprintf("/api-keys/%s", apiKeyId), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "api_key",
+			"id": "dacf4072-4119-4d88-932f-6202748ac7c8"
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	req := &UpdateApiKeyRequest{
+		Name: "renamed api key",
+	}
+	resp, err := client.ApiKeys.Update(apiKeyId, req)
+	if err != nil {
+		t.Errorf("ApiKeys.Update returned error: %v", err)
+	}
+	assert.Equal(t, "api_key", resp.Object)
+	assert.Equal(t, apiKeyId, resp.Id)
+}
+
+func TestUpdateApiKeyWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	apiKeyId := "dacf4072-4119-4d88-932f-6202748ac7c8"
+
+	mux.HandleFunc(fmt.Sprintf("/api-keys/%s", apiKeyId), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "api_key",
+			"id": "dacf4072-4119-4d88-932f-6202748ac7c8"
+		}`
+		fmt.Fprintf(w, ret)
+	})
+
+	ctx := context.Background()
+	req := &UpdateApiKeyRequest{
+		Name: "renamed api key",
+	}
+	resp, err := client.ApiKeys.UpdateWithContext(ctx, apiKeyId, req)
+	if err != nil {
+		t.Errorf("ApiKeys.UpdateWithContext returned error: %v", err)
+	}
+	assert.Equal(t, "api_key", resp.Object)
+	assert.Equal(t, apiKeyId, resp.Id)
 }

--- a/errors.go
+++ b/errors.go
@@ -59,6 +59,7 @@ var (
 	ErrFailedToCreateApiKeysCreateRequest = errors.New("[ERROR]: Failed to create ApiKeys.Create request")
 	ErrFailedToCreateApiKeysListRequest   = errors.New("[ERROR]: Failed to create ApiKeys.List request")
 	ErrFailedToCreateApiKeysRemoveRequest = errors.New("[ERROR]: Failed to create ApiKeys.Remove request")
+	ErrFailedToCreateApiKeysUpdateRequest = errors.New("[ERROR]: Failed to create ApiKeys.Update request")
 )
 
 // EmailsSvc errors

--- a/examples/api_keys.go
+++ b/examples/api_keys.go
@@ -33,6 +33,16 @@ func apiKeysExample() {
 	}
 	fmt.Printf("You have %d api keys in your project\n", len(apiKeys.Data))
 
+	// Update
+	updateParams := &resend.UpdateApiKeyRequest{
+		Name: "nicer api key",
+	}
+	updateResp, err := client.ApiKeys.UpdateWithContext(ctx, resp.Id, updateParams)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Updated API Key id: " + updateResp.Id)
+
 	// Delete
 	_, err = client.ApiKeys.RemoveWithContext(ctx, resp.Id)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Adds `ApiKeysSvc.Update`/`UpdateWithContext` for the new `PATCH /api-keys/:id` endpoint — see https://resend.com/docs/api-reference/api-keys/update-api-key.
- Only `Name` is patchable. `Permission`/`DomainId` are deliberately not exposed — the endpoint doesn't accept them (prevents a leaked management key from silently widening another key's scope).

Draft — SDK rollout in progress, tracked in Linear as DEV-1219.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — passing
- [x] `golangci-lint run ./...` — issue count unchanged from baseline (all pre-existing)