### PR TITLE
feat: add broadcasts.Recipients() method

### DIFF
--- a/broadcasts.go
+++ b/broadcasts.go
@@ -3,7 +3,9 @@ package resend
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
+	"net/url"
 )
 
 type SendBroadcastRequest struct {
@@ -74,6 +76,81 @@ type ListBroadcastsResponse struct {
 	HasMore bool        `json:"has_more"`
 }
 
+// BroadcastRecipientEventType is the recipient event type to filter by when listing a
+// broadcast's recipients.
+type BroadcastRecipientEventType = string
+
+const (
+	BroadcastRecipientEventTypeSent         BroadcastRecipientEventType = "sent"
+	BroadcastRecipientEventTypeDelivered    BroadcastRecipientEventType = "delivered"
+	BroadcastRecipientEventTypeOpened       BroadcastRecipientEventType = "opened"
+	BroadcastRecipientEventTypeClicked      BroadcastRecipientEventType = "clicked"
+	BroadcastRecipientEventTypeBounced      BroadcastRecipientEventType = "bounced"
+	BroadcastRecipientEventTypeComplained   BroadcastRecipientEventType = "complained"
+	BroadcastRecipientEventTypeUnsubscribed BroadcastRecipientEventType = "unsubscribed"
+	BroadcastRecipientEventTypeSuppressed   BroadcastRecipientEventType = "suppressed"
+)
+
+// BroadcastRecipientBounceType is the bounce type to filter by. Only meaningful when
+// ListBroadcastRecipientsOptions.Type is BroadcastRecipientEventTypeBounced.
+type BroadcastRecipientBounceType = string
+
+const (
+	BroadcastRecipientBounceTypePermanent    BroadcastRecipientBounceType = "permanent"
+	BroadcastRecipientBounceTypeTransient    BroadcastRecipientBounceType = "transient"
+	BroadcastRecipientBounceTypeUndetermined BroadcastRecipientBounceType = "undetermined"
+)
+
+// BroadcastRecipientClickedLink is a link clicked by a recipient. Only present when Type is
+// BroadcastRecipientEventTypeClicked.
+type BroadcastRecipientClickedLink struct {
+	Url    string `json:"url"`
+	Clicks int    `json:"clicks"`
+}
+
+// BroadcastRecipient is a single recipient row for the requested event type. Count, BounceType
+// and ClickedLinks are only populated depending on ListBroadcastRecipientsOptions.Type.
+type BroadcastRecipient struct {
+	// Id is an opaque cursor identifying this row, used for pagination. It is not a real entity id.
+	Id        string  `json:"id"`
+	ContactId *string `json:"contact_id"`
+	Email     string  `json:"email"`
+
+	// Count is the number of times this recipient triggered the event. Only present when Type is
+	// BroadcastRecipientEventTypeOpened or BroadcastRecipientEventTypeClicked.
+	Count int `json:"count,omitempty"`
+
+	// BounceType is only present when Type is BroadcastRecipientEventTypeBounced.
+	BounceType BroadcastRecipientBounceType `json:"bounce_type,omitempty"`
+
+	// ClickedLinks is only present when Type is BroadcastRecipientEventTypeClicked.
+	ClickedLinks []BroadcastRecipientClickedLink `json:"clicked_links,omitempty"`
+}
+
+type ListBroadcastRecipientsResponse struct {
+	Object  string               `json:"object"`
+	HasMore bool                 `json:"has_more"`
+	Data    []BroadcastRecipient `json:"data"`
+}
+
+// ListBroadcastRecipientsOptions contains the filter and pagination parameters for listing a
+// broadcast's recipients.
+type ListBroadcastRecipientsOptions struct {
+	// Type is the recipient event type to filter by. Required.
+	Type BroadcastRecipientEventType
+
+	// Email filters recipients whose email address contains this substring.
+	Email string
+
+	// BounceType filters bounced recipients by bounce type. Only meaningful when Type is
+	// BroadcastRecipientEventTypeBounced.
+	BounceType BroadcastRecipientBounceType
+
+	Limit  *int
+	After  *string
+	Before *string
+}
+
 type Broadcast struct {
 	Object      string   `json:"object"`
 	Id          string   `json:"id"`
@@ -114,6 +191,9 @@ type BroadcastsSvc interface {
 
 	RemoveWithContext(ctx context.Context, broadcastId string) (RemoveBroadcastResponse, error)
 	Remove(broadcastId string) (RemoveBroadcastResponse, error)
+
+	RecipientsWithContext(ctx context.Context, broadcastId string, options *ListBroadcastRecipientsOptions) (ListBroadcastRecipientsResponse, error)
+	Recipients(broadcastId string, options *ListBroadcastRecipientsOptions) (ListBroadcastRecipientsResponse, error)
 }
 
 type BroadcastsSvcImpl struct {
@@ -348,4 +428,60 @@ func (s *BroadcastsSvcImpl) ListWithContext(ctx context.Context) (ListBroadcasts
 // List returns the list of all broadcasts
 func (s *BroadcastsSvcImpl) List() (ListBroadcastsResponse, error) {
 	return s.ListWithContext(context.Background())
+}
+
+// RecipientsWithContext returns a broadcast's recipients for a given event type, such as who
+// opened, clicked, or bounced.
+// https://resend.com/docs/api-reference/broadcasts/list-broadcast-recipients
+func (s *BroadcastsSvcImpl) RecipientsWithContext(ctx context.Context, broadcastId string, options *ListBroadcastRecipientsOptions) (ListBroadcastRecipientsResponse, error) {
+	if broadcastId == "" {
+		return ListBroadcastRecipientsResponse{}, errors.New("[ERROR]: broadcastId cannot be empty")
+	}
+
+	if options == nil || options.Type == "" {
+		return ListBroadcastRecipientsResponse{}, errors.New("[ERROR]: Type cannot be empty")
+	}
+
+	query := make(url.Values)
+	query.Set("type", options.Type)
+	if options.Email != "" {
+		query.Set("email", options.Email)
+	}
+	if options.BounceType != "" {
+		query.Set("bounce_type", options.BounceType)
+	}
+	if options.Limit != nil {
+		query.Set("limit", fmt.Sprintf("%d", *options.Limit))
+	}
+	if options.After != nil {
+		query.Set("after", *options.After)
+	}
+	if options.Before != nil {
+		query.Set("before", *options.Before)
+	}
+
+	path := "broadcasts/" + broadcastId + "/recipients?" + query.Encode()
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return ListBroadcastRecipientsResponse{}, ErrFailedToCreateBroadcastRecipientsRequest
+	}
+
+	recipients := new(ListBroadcastRecipientsResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, recipients)
+
+	if err != nil {
+		return ListBroadcastRecipientsResponse{}, err
+	}
+
+	return *recipients, nil
+}
+
+// Recipients returns a broadcast's recipients for a given event type, such as who opened,
+// clicked, or bounced.
+func (s *BroadcastsSvcImpl) Recipients(broadcastId string, options *ListBroadcastRecipientsOptions) (ListBroadcastRecipientsResponse, error) {
+	return s.RecipientsWithContext(context.Background(), broadcastId, options)
 }

--- a/broadcasts_test.go
+++ b/broadcasts_test.go
@@ -368,3 +368,232 @@ func TestListBroadcasts(t *testing.T) {
 	assert.Equal(t, broadcasts.Object, "list")
 
 }
+
+func TestBroadcastRecipients(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/recipients", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, "sent", r.URL.Query().Get("type"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "list",
+			"has_more": false,
+			"data": [
+				{
+					"id": "b2Zmc2V0OjA",
+					"contact_id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+					"email": "carter@example.com"
+				}
+			]
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	resp, err := client.Broadcasts.Recipients("559ac32e-9ef5-46fb-82a1-b76b840c0f7b", &ListBroadcastRecipientsOptions{
+		Type: BroadcastRecipientEventTypeSent,
+	})
+	if err != nil {
+		t.Errorf("Broadcasts.Recipients returned error: %v", err)
+	}
+
+	assert.Equal(t, "list", resp.Object)
+	assert.False(t, resp.HasMore)
+	assert.Equal(t, 1, len(resp.Data))
+	assert.Equal(t, "b2Zmc2V0OjA", resp.Data[0].Id)
+	assert.Equal(t, "carter@example.com", resp.Data[0].Email)
+	assert.NotNil(t, resp.Data[0].ContactId)
+	assert.Equal(t, "e169aa45-1ecf-4183-9955-b1499d5701d3", *resp.Data[0].ContactId)
+	assert.Equal(t, 0, resp.Data[0].Count)
+	assert.Equal(t, "", resp.Data[0].BounceType)
+	assert.Nil(t, resp.Data[0].ClickedLinks)
+}
+
+func TestBroadcastRecipientsWithFilters(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/recipients", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		q := r.URL.Query()
+		assert.Equal(t, "opened", q.Get("type"))
+		assert.Equal(t, "carter", q.Get("email"))
+		assert.Equal(t, "10", q.Get("limit"))
+		assert.Equal(t, "b2Zmc2V0OjA", q.Get("after"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "list",
+			"has_more": true,
+			"data": [
+				{
+					"id": "b2Zmc2V0OjE",
+					"contact_id": null,
+					"email": "carter@example.com",
+					"count": 3
+				}
+			]
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	limit := 10
+	after := "b2Zmc2V0OjA"
+	resp, err := client.Broadcasts.Recipients("559ac32e-9ef5-46fb-82a1-b76b840c0f7b", &ListBroadcastRecipientsOptions{
+		Type:  BroadcastRecipientEventTypeOpened,
+		Email: "carter",
+		Limit: &limit,
+		After: &after,
+	})
+	if err != nil {
+		t.Errorf("Broadcasts.Recipients returned error: %v", err)
+	}
+
+	assert.True(t, resp.HasMore)
+	assert.Equal(t, 1, len(resp.Data))
+	assert.Nil(t, resp.Data[0].ContactId)
+	assert.Equal(t, 3, resp.Data[0].Count)
+}
+
+func TestBroadcastRecipientsClicked(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/recipients", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, "clicked", r.URL.Query().Get("type"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "list",
+			"has_more": false,
+			"data": [
+				{
+					"id": "b2Zmc2V0OjA",
+					"contact_id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+					"email": "carter@example.com",
+					"count": 3,
+					"clicked_links": [
+						{"url": "https://resend.com/pricing", "clicks": 2}
+					]
+				}
+			]
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	resp, err := client.Broadcasts.Recipients("559ac32e-9ef5-46fb-82a1-b76b840c0f7b", &ListBroadcastRecipientsOptions{
+		Type: BroadcastRecipientEventTypeClicked,
+	})
+	if err != nil {
+		t.Errorf("Broadcasts.Recipients returned error: %v", err)
+	}
+
+	assert.Equal(t, 3, resp.Data[0].Count)
+	assert.Equal(t, 1, len(resp.Data[0].ClickedLinks))
+	assert.Equal(t, "https://resend.com/pricing", resp.Data[0].ClickedLinks[0].Url)
+	assert.Equal(t, 2, resp.Data[0].ClickedLinks[0].Clicks)
+}
+
+func TestBroadcastRecipientsBounced(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/recipients", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		q := r.URL.Query()
+		assert.Equal(t, "bounced", q.Get("type"))
+		assert.Equal(t, "permanent", q.Get("bounce_type"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "list",
+			"has_more": false,
+			"data": [
+				{
+					"id": "b2Zmc2V0OjA",
+					"contact_id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
+					"email": "carter@example.com",
+					"bounce_type": "permanent"
+				}
+			]
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	resp, err := client.Broadcasts.Recipients("559ac32e-9ef5-46fb-82a1-b76b840c0f7b", &ListBroadcastRecipientsOptions{
+		Type:       BroadcastRecipientEventTypeBounced,
+		BounceType: BroadcastRecipientBounceTypePermanent,
+	})
+	if err != nil {
+		t.Errorf("Broadcasts.Recipients returned error: %v", err)
+	}
+
+	assert.Equal(t, BroadcastRecipientBounceTypePermanent, resp.Data[0].BounceType)
+}
+
+func TestBroadcastRecipientsNotFound(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/broadcasts/00000000-0000-0000-0000-000000000000/recipients", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+
+		ret := `
+		{
+			"statusCode": 404,
+			"name": "not_found",
+			"message": "Broadcast not found"
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	resp, err := client.Broadcasts.Recipients("00000000-0000-0000-0000-000000000000", &ListBroadcastRecipientsOptions{
+		Type: BroadcastRecipientEventTypeSent,
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Broadcast not found")
+	assert.Equal(t, ListBroadcastRecipientsResponse{}, resp)
+}
+
+func TestBroadcastRecipientsValidations(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, err := client.Broadcasts.Recipients("", &ListBroadcastRecipientsOptions{
+		Type: BroadcastRecipientEventTypeSent,
+	})
+	assert.NotNil(t, err)
+	if err != nil {
+		assert.Equal(t, err.Error(), "[ERROR]: broadcastId cannot be empty")
+	}
+
+	_, err = client.Broadcasts.Recipients("559ac32e-9ef5-46fb-82a1-b76b840c0f7b", nil)
+	assert.NotNil(t, err)
+	if err != nil {
+		assert.Equal(t, err.Error(), "[ERROR]: Type cannot be empty")
+	}
+
+	_, err = client.Broadcasts.Recipients("559ac32e-9ef5-46fb-82a1-b76b840c0f7b", &ListBroadcastRecipientsOptions{})
+	assert.NotNil(t, err)
+	if err != nil {
+		assert.Equal(t, err.Error(), "[ERROR]: Type cannot be empty")
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -48,10 +48,11 @@ func (e *RateLimitError) Is(target error) bool {
 
 // BroadcastsSvc errors
 var (
-	ErrFailedToCreateBroadcastUpdateRequest = errors.New("[ERROR]: Failed to create Broadcasts.Update request")
-	ErrFailedToCreateBroadcastSendRequest   = errors.New("[ERROR]: Failed to create Broadcasts.Send request")
-	ErrFailedToCreateBroadcastCreateRequest = errors.New("[ERROR]: Failed to create Broadcasts.Create request")
-	ErrFailedToCreateBroadcastCancelRequest = errors.New("[ERROR]: Failed to create Broadcasts.Cancel request")
+	ErrFailedToCreateBroadcastUpdateRequest     = errors.New("[ERROR]: Failed to create Broadcasts.Update request")
+	ErrFailedToCreateBroadcastSendRequest       = errors.New("[ERROR]: Failed to create Broadcasts.Send request")
+	ErrFailedToCreateBroadcastCreateRequest     = errors.New("[ERROR]: Failed to create Broadcasts.Create request")
+	ErrFailedToCreateBroadcastCancelRequest     = errors.New("[ERROR]: Failed to create Broadcasts.Cancel request")
+	ErrFailedToCreateBroadcastRecipientsRequest = errors.New("[ERROR]: Failed to create Broadcasts.Recipients request")
 )
 
 // ApiKeySvc errors

--- a/examples/broadcasts.go
+++ b/examples/broadcasts.go
@@ -91,6 +91,18 @@ func broadcastExamples() {
 		fmt.Println("Text: " + b.Text)
 	}
 
+	// List Broadcast Recipients
+	recipientsResponse, err := client.Broadcasts.RecipientsWithContext(ctx, broadcast.Id, &resend.ListBroadcastRecipientsOptions{
+		Type: resend.BroadcastRecipientEventTypeDelivered,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	for _, recipient := range recipientsResponse.Data {
+		fmt.Println("Recipient email: " + recipient.Email)
+	}
+
 	// Remove Broadcast (Only Draft Broadcasts can be deleted)
 	removeResponse, err := client.Broadcasts.RemoveWithContext(ctx, broadcast.Id)
 	if err != nil {

--- a/examples/broadcasts.go
+++ b/examples/broadcasts.go
@@ -91,17 +91,18 @@ func broadcastExamples() {
 		fmt.Println("Text: " + b.Text)
 	}
 
-	// List Broadcast Recipients
-	recipientsResponse, err := client.Broadcasts.RecipientsWithContext(ctx, broadcast.Id, &resend.ListBroadcastRecipientsOptions{
-		Type: resend.BroadcastRecipientEventTypeDelivered,
-	})
-	if err != nil {
-		panic(err)
-	}
+	// List Broadcast Recipients (only returns rows once the broadcast has
+	// actually been sent, which is commented out above)
+	// recipientsResponse, err := client.Broadcasts.RecipientsWithContext(ctx, broadcast.Id, &resend.ListBroadcastRecipientsOptions{
+	// 	Type: resend.BroadcastRecipientEventTypeDelivered,
+	// })
+	// if err != nil {
+	// 	panic(err)
+	// }
 
-	for _, recipient := range recipientsResponse.Data {
-		fmt.Println("Recipient email: " + recipient.Email)
-	}
+	// for _, recipient := range recipientsResponse.Data {
+	// 	fmt.Println("Recipient email: " + recipient.Email)
+	// }
 
 	// Remove Broadcast (Only Draft Broadcasts can be deleted)
 	removeResponse, err := client.Broadcasts.RemoveWithContext(ctx, broadcast.Id)

--- a/examples/broadcasts.go
+++ b/examples/broadcasts.go
@@ -91,19 +91,6 @@ func broadcastExamples() {
 		fmt.Println("Text: " + b.Text)
 	}
 
-	// List Broadcast Recipients (only returns rows once the broadcast has
-	// actually been sent, which is commented out above)
-	// recipientsResponse, err := client.Broadcasts.RecipientsWithContext(ctx, broadcast.Id, &resend.ListBroadcastRecipientsOptions{
-	// 	Type: resend.BroadcastRecipientEventTypeDelivered,
-	// })
-	// if err != nil {
-	// 	panic(err)
-	// }
-
-	// for _, recipient := range recipientsResponse.Data {
-	// 	fmt.Println("Recipient email: " + recipient.Email)
-	// }
-
 	// Remove Broadcast (Only Draft Broadcasts can be deleted)
 	removeResponse, err := client.Broadcasts.RemoveWithContext(ctx, broadcast.Id)
 	if err != nil {


### PR DESCRIPTION
Adds `Recipients` / `RecipientsWithContext` for `GET /broadcasts/{id}/recipients`.

Spec: https://github.com/resend/resend-openapi/pull/97
Node reference: https://github.com/resend/resend-node/pull/1078

Tests pass. go vet / build clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `Broadcasts.Recipients`/`RecipientsWithContext` method to list a broadcast’s recipients by event type via GET /broadcasts/{id}/recipients. This enables recipient analytics with filtering and pagination; previously, this listing was not available.

- Supports event types (sent, delivered, opened, clicked, bounced, complained, unsubscribed, suppressed), email substring and bounce_type filters, and cursor pagination (limit, after, before).
- Returns per-recipient rows with conditional fields: count (opened/clicked), bounce_type (bounced), clicked_links (clicked); validates broadcastId and Type; adds ErrFailedToCreateBroadcastRecipientsRequest.
- Adds tests for filters, clicked links, bounce types, not-found, and validations; removes the stale recipients example from `examples/broadcasts.go`.

<sup>Written for commit 7b4fdd96a25976da8c0e9c9e2746e16f55283042. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

