### PR TITLE
feat: add Emails.Metrics for account-level email metrics

### DIFF
--- a/emails.go
+++ b/emails.go
@@ -416,7 +416,7 @@ type EmailsSvc interface {
 	ListAttachmentsWithContext(ctx context.Context, emailId string) (ListEmailAttachmentsResponse, error)
 	ListAttachments(emailId string) (ListEmailAttachmentsResponse, error)
 
-	// Metrics is a beta endpoint.
+	// Metrics methods
 	MetricsWithOptions(ctx context.Context, options *MetricsOptions) (*MetricsResponse, error)
 	MetricsWithContext(ctx context.Context) (*MetricsResponse, error)
 	Metrics() (*MetricsResponse, error)
@@ -705,8 +705,6 @@ func (s *EmailsSvcImpl) ListAttachments(emailId string) (ListEmailAttachmentsRes
 }
 
 // MetricsWithOptions retrieves email metrics with the given options.
-//
-// This is a beta endpoint and its shape may change ahead of GA.
 // https://resend.com/docs/api-reference/emails/metrics
 func (s *EmailsSvcImpl) MetricsWithOptions(ctx context.Context, options *MetricsOptions) (*MetricsResponse, error) {
 	if options != nil && metricsInvolvesEmailAndBroadcast(options) {
@@ -734,16 +732,12 @@ func (s *EmailsSvcImpl) MetricsWithOptions(ctx context.Context, options *Metrics
 }
 
 // MetricsWithContext retrieves email metrics.
-//
-// This is a beta endpoint and its shape may change ahead of GA.
 // https://resend.com/docs/api-reference/emails/metrics
 func (s *EmailsSvcImpl) MetricsWithContext(ctx context.Context) (*MetricsResponse, error) {
 	return s.MetricsWithOptions(ctx, nil)
 }
 
 // Metrics retrieves email metrics.
-//
-// This is a beta endpoint and its shape may change ahead of GA.
 // https://resend.com/docs/api-reference/emails/metrics
 func (s *EmailsSvcImpl) Metrics() (*MetricsResponse, error) {
 	return s.MetricsWithContext(context.Background())

--- a/emails.go
+++ b/emails.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/url"
+	"strings"
 )
 
 type SendEmailOptions struct {
@@ -128,6 +130,193 @@ type ListEmailAttachmentsResponse struct {
 	Data    []EmailAttachment `json:"data"`
 }
 
+// MetricName identifies a metric that can be requested from the Metrics call.
+type MetricName = string
+
+const (
+	MetricReceived            MetricName = "received"
+	MetricDelivered           MetricName = "delivered"
+	MetricComplained          MetricName = "complained"
+	MetricSuppressed          MetricName = "suppressed"
+	MetricBounced             MetricName = "bounced"
+	MetricBouncedTransient    MetricName = "bounced_transient"
+	MetricBouncedPermanent    MetricName = "bounced_permanent"
+	MetricBouncedUndetermined MetricName = "bounced_undetermined"
+	MetricOpened              MetricName = "opened"
+	MetricClicked             MetricName = "clicked"
+	MetricUnsubscribed        MetricName = "unsubscribed"
+	MetricDeliveryDelayed     MetricName = "delivery_delayed"
+	MetricFailed              MetricName = "failed"
+	MetricSent                MetricName = "sent"
+	MetricUniqueOpened        MetricName = "unique_opened"
+	MetricUniqueClicked       MetricName = "unique_clicked"
+	MetricDeliveryRate        MetricName = "delivery_rate"
+	MetricOpenRate            MetricName = "open_rate"
+	MetricClickRate           MetricName = "click_rate"
+	MetricBounceRate          MetricName = "bounce_rate"
+	MetricComplaintRate       MetricName = "complaint_rate"
+	MetricUnsubscribeRate     MetricName = "unsubscribe_rate"
+)
+
+// MetricsDimension identifies a dimension to group metrics by in the Metrics call.
+type MetricsDimension = string
+
+const (
+	MetricsDimensionPeriod    MetricsDimension = "period"
+	MetricsDimensionDomain    MetricsDimension = "domain"
+	MetricsDimensionEmail     MetricsDimension = "email"
+	MetricsDimensionBroadcast MetricsDimension = "broadcast"
+)
+
+// MetricsGranularity is the bucket size used for the `period` dimension.
+type MetricsGranularity = string
+
+const (
+	MetricsGranularityHourly  MetricsGranularity = "hourly"
+	MetricsGranularityDaily   MetricsGranularity = "daily"
+	MetricsGranularityWeekly  MetricsGranularity = "weekly"
+	MetricsGranularityMonthly MetricsGranularity = "monthly"
+)
+
+// MetricsOptions contains the optional query parameters for the Metrics call.
+//
+// See also https://resend.com/docs/api-reference/emails/metrics
+type MetricsOptions struct {
+	// StartDate filters metrics to on/after this ISO 8601 date or datetime.
+	// Defaults server-side to 6 days before EndDate.
+	StartDate *string
+
+	// EndDate filters metrics to on/before this ISO 8601 date or datetime.
+	// Defaults server-side to now.
+	EndDate *string
+
+	// Timezone is an IANA timezone identifier, e.g. "America/New_York".
+	// Defaults server-side to "UTC".
+	Timezone *string
+
+	// Granularity is the bucket size used when the `period` dimension is
+	// requested. Defaults server-side to MetricsGranularityDaily.
+	Granularity *MetricsGranularity
+
+	// Metrics selects which metrics to compute. Defaults server-side to all
+	// metrics.
+	Metrics []MetricName
+
+	// Dimensions selects which dimensions to group results by. Defaults
+	// server-side to none, in which case the response only contains Totals.
+	Dimensions []MetricsDimension
+
+	// DomainId restricts results to these sending domain IDs (max 100).
+	DomainId []string
+
+	// EmailId restricts results to these email IDs (max 100). Cannot be
+	// combined with MetricsDimensionBroadcast or BroadcastId.
+	EmailId []string
+
+	// BroadcastId restricts results to these broadcast IDs (max 100). Cannot
+	// be combined with MetricsDimensionEmail or EmailId.
+	BroadcastId []string
+}
+
+// buildMetricsQuery constructs query parameters for the Metrics call
+func buildMetricsQuery(options *MetricsOptions) string {
+	if options == nil {
+		return ""
+	}
+
+	query := make(url.Values)
+	if options.StartDate != nil {
+		query.Set("start_date", *options.StartDate)
+	}
+	if options.EndDate != nil {
+		query.Set("end_date", *options.EndDate)
+	}
+	if options.Timezone != nil {
+		query.Set("timezone", *options.Timezone)
+	}
+	if options.Granularity != nil {
+		query.Set("granularity", *options.Granularity)
+	}
+	if len(options.Metrics) > 0 {
+		query.Set("metrics", strings.Join(options.Metrics, ","))
+	}
+	if len(options.Dimensions) > 0 {
+		query.Set("dimensions", strings.Join(options.Dimensions, ","))
+	}
+	if len(options.DomainId) > 0 {
+		query.Set("domain_id", strings.Join(options.DomainId, ","))
+	}
+	if len(options.EmailId) > 0 {
+		query.Set("email_id", strings.Join(options.EmailId, ","))
+	}
+	if len(options.BroadcastId) > 0 {
+		query.Set("broadcast_id", strings.Join(options.BroadcastId, ","))
+	}
+
+	if len(query) > 0 {
+		return "?" + query.Encode()
+	}
+	return ""
+}
+
+// MetricsDataPoint is a single row in MetricsResponse.Data. Which fields are
+// populated depends on the requested dimensions and metrics: dimension key
+// fields are set only when that dimension was requested, and metric fields
+// are set only when that metric was requested.
+type MetricsDataPoint struct {
+	// Period is set when MetricsDimensionPeriod is requested.
+	Period *string `json:"period,omitempty"`
+
+	// DomainId and DomainName are set when MetricsDimensionDomain is requested.
+	DomainId   *string `json:"domain_id,omitempty"`
+	DomainName *string `json:"domain_name,omitempty"`
+
+	// EmailId is set when MetricsDimensionEmail is requested.
+	EmailId *string `json:"email_id,omitempty"`
+
+	// BroadcastId and BroadcastName are set when MetricsDimensionBroadcast is requested.
+	BroadcastId   *string `json:"broadcast_id,omitempty"`
+	BroadcastName *string `json:"broadcast_name,omitempty"`
+
+	Received            *int64   `json:"received,omitempty"`
+	Delivered           *int64   `json:"delivered,omitempty"`
+	Complained          *int64   `json:"complained,omitempty"`
+	Suppressed          *int64   `json:"suppressed,omitempty"`
+	Bounced             *int64   `json:"bounced,omitempty"`
+	BouncedTransient    *int64   `json:"bounced_transient,omitempty"`
+	BouncedPermanent    *int64   `json:"bounced_permanent,omitempty"`
+	BouncedUndetermined *int64   `json:"bounced_undetermined,omitempty"`
+	Opened              *int64   `json:"opened,omitempty"`
+	Clicked             *int64   `json:"clicked,omitempty"`
+	Unsubscribed        *int64   `json:"unsubscribed,omitempty"`
+	DeliveryDelayed     *int64   `json:"delivery_delayed,omitempty"`
+	Failed              *int64   `json:"failed,omitempty"`
+	Sent                *int64   `json:"sent,omitempty"`
+	UniqueOpened        *int64   `json:"unique_opened,omitempty"`
+	UniqueClicked       *int64   `json:"unique_clicked,omitempty"`
+	DeliveryRate        *float64 `json:"delivery_rate,omitempty"`
+	OpenRate            *float64 `json:"open_rate,omitempty"`
+	ClickRate           *float64 `json:"click_rate,omitempty"`
+	BounceRate          *float64 `json:"bounce_rate,omitempty"`
+	ComplaintRate       *float64 `json:"complaint_rate,omitempty"`
+	UnsubscribeRate     *float64 `json:"unsubscribe_rate,omitempty"`
+}
+
+// MetricsResponse is the response from the Metrics call.
+//
+// See also https://resend.com/docs/api-reference/emails/metrics
+type MetricsResponse struct {
+	Object      string             `json:"object"`
+	StartDate   string             `json:"start_date"`
+	EndDate     string             `json:"end_date"`
+	Metrics     []string           `json:"metrics"`
+	Dimensions  []string           `json:"dimensions"`
+	Granularity string             `json:"granularity"`
+	Totals      map[string]float64 `json:"totals"`
+	// Data is omitted from the response when no dimensions were requested.
+	Data []MetricsDataPoint `json:"data,omitempty"`
+}
+
 // Attachment is the public struct used for adding attachments to emails
 type Attachment struct {
 	// Content is the binary content of the attachment to use when a Path
@@ -206,6 +395,11 @@ type EmailsSvc interface {
 	ListAttachmentsWithOptions(ctx context.Context, emailId string, options *ListOptions) (ListEmailAttachmentsResponse, error)
 	ListAttachmentsWithContext(ctx context.Context, emailId string) (ListEmailAttachmentsResponse, error)
 	ListAttachments(emailId string) (ListEmailAttachmentsResponse, error)
+
+	// Metrics is a beta endpoint.
+	MetricsWithOptions(ctx context.Context, options *MetricsOptions) (*MetricsResponse, error)
+	MetricsWithContext(ctx context.Context) (*MetricsResponse, error)
+	Metrics() (*MetricsResponse, error)
 }
 
 type EmailsSvcImpl struct {
@@ -488,4 +682,45 @@ func (s *EmailsSvcImpl) ListAttachmentsWithContext(ctx context.Context, emailId 
 // https://resend.com/docs/api-reference/attachments/list-sent-email-attachments
 func (s *EmailsSvcImpl) ListAttachments(emailId string) (ListEmailAttachmentsResponse, error) {
 	return s.ListAttachmentsWithContext(context.Background(), emailId)
+}
+
+// MetricsWithOptions retrieves email metrics with the given options.
+//
+// This is a beta endpoint and its shape may change ahead of GA.
+// https://resend.com/docs/api-reference/emails/metrics
+func (s *EmailsSvcImpl) MetricsWithOptions(ctx context.Context, options *MetricsOptions) (*MetricsResponse, error) {
+	path := "emails/metrics" + buildMetricsQuery(options)
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, ErrFailedToCreateEmailsMetricsRequest
+	}
+
+	// Build response recipient obj
+	metricsResponse := new(MetricsResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, metricsResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return metricsResponse, nil
+}
+
+// MetricsWithContext retrieves email metrics.
+//
+// This is a beta endpoint and its shape may change ahead of GA.
+// https://resend.com/docs/api-reference/emails/metrics
+func (s *EmailsSvcImpl) MetricsWithContext(ctx context.Context) (*MetricsResponse, error) {
+	return s.MetricsWithOptions(ctx, nil)
+}
+
+// Metrics retrieves email metrics.
+//
+// This is a beta endpoint and its shape may change ahead of GA.
+// https://resend.com/docs/api-reference/emails/metrics
+func (s *EmailsSvcImpl) Metrics() (*MetricsResponse, error) {
+	return s.MetricsWithContext(context.Background())
 }

--- a/emails.go
+++ b/emails.go
@@ -181,7 +181,7 @@ const (
 
 // MetricsOptions contains the optional query parameters for the Metrics call.
 //
-// See also https://resend.com/docs/api-reference/emails/metrics
+// See also https://resend.com/docs/api-reference/emails/get-metrics
 type MetricsOptions struct {
 	// StartDate filters metrics to on/after this ISO 8601 date or datetime.
 	// Defaults server-side to 6 days before EndDate.
@@ -324,7 +324,7 @@ type MetricsDataPoint struct {
 
 // MetricsResponse is the response from the Metrics call.
 //
-// See also https://resend.com/docs/api-reference/emails/metrics
+// See also https://resend.com/docs/api-reference/emails/get-metrics
 type MetricsResponse struct {
 	Object      string             `json:"object"`
 	StartDate   string             `json:"start_date"`
@@ -705,7 +705,7 @@ func (s *EmailsSvcImpl) ListAttachments(emailId string) (ListEmailAttachmentsRes
 }
 
 // MetricsWithOptions retrieves email metrics with the given options.
-// https://resend.com/docs/api-reference/emails/metrics
+// https://resend.com/docs/api-reference/emails/get-metrics
 func (s *EmailsSvcImpl) MetricsWithOptions(ctx context.Context, options *MetricsOptions) (*MetricsResponse, error) {
 	if options != nil && metricsInvolvesEmailAndBroadcast(options) {
 		return nil, errors.New("[ERROR]: The `email` dimension/EmailId cannot be combined with the `broadcast` dimension/BroadcastId.")
@@ -732,13 +732,13 @@ func (s *EmailsSvcImpl) MetricsWithOptions(ctx context.Context, options *Metrics
 }
 
 // MetricsWithContext retrieves email metrics.
-// https://resend.com/docs/api-reference/emails/metrics
+// https://resend.com/docs/api-reference/emails/get-metrics
 func (s *EmailsSvcImpl) MetricsWithContext(ctx context.Context) (*MetricsResponse, error) {
 	return s.MetricsWithOptions(ctx, nil)
 }
 
 // Metrics retrieves email metrics.
-// https://resend.com/docs/api-reference/emails/metrics
+// https://resend.com/docs/api-reference/emails/get-metrics
 func (s *EmailsSvcImpl) Metrics() (*MetricsResponse, error) {
 	return s.MetricsWithContext(context.Background())
 }

--- a/emails.go
+++ b/emails.go
@@ -3,6 +3,7 @@ package resend
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/url"
 	"strings"
@@ -216,6 +217,25 @@ type MetricsOptions struct {
 	// BroadcastId restricts results to these broadcast IDs (max 100). Cannot
 	// be combined with MetricsDimensionEmail or EmailId.
 	BroadcastId []string
+}
+
+// metricsHasDimension reports whether dimensions includes the given dimension.
+func metricsHasDimension(dimensions []MetricsDimension, dimension MetricsDimension) bool {
+	for _, d := range dimensions {
+		if d == dimension {
+			return true
+		}
+	}
+	return false
+}
+
+// metricsInvolvesEmailAndBroadcast reports whether options combines the
+// `email` dimension/EmailId with the `broadcast` dimension/BroadcastId,
+// which the Metrics endpoint rejects.
+func metricsInvolvesEmailAndBroadcast(options *MetricsOptions) bool {
+	involvesEmail := len(options.EmailId) > 0 || metricsHasDimension(options.Dimensions, MetricsDimensionEmail)
+	involvesBroadcast := len(options.BroadcastId) > 0 || metricsHasDimension(options.Dimensions, MetricsDimensionBroadcast)
+	return involvesEmail && involvesBroadcast
 }
 
 // buildMetricsQuery constructs query parameters for the Metrics call
@@ -689,6 +709,10 @@ func (s *EmailsSvcImpl) ListAttachments(emailId string) (ListEmailAttachmentsRes
 // This is a beta endpoint and its shape may change ahead of GA.
 // https://resend.com/docs/api-reference/emails/metrics
 func (s *EmailsSvcImpl) MetricsWithOptions(ctx context.Context, options *MetricsOptions) (*MetricsResponse, error) {
+	if options != nil && metricsInvolvesEmailAndBroadcast(options) {
+		return nil, errors.New("[ERROR]: The `email` dimension/EmailId cannot be combined with the `broadcast` dimension/BroadcastId.")
+	}
+
 	path := "emails/metrics" + buildMetricsQuery(options)
 
 	// Prepare request

--- a/emails_test.go
+++ b/emails_test.go
@@ -1378,6 +1378,40 @@ func TestEmailsMetricsWithMultipleBroadcastIdFilter(t *testing.T) {
 	}
 }
 
+func TestEmailsMetricsRejectsEmailAndBroadcastCombinations(t *testing.T) {
+	setup()
+	defer teardown()
+
+	const wantErr = "[ERROR]: The `email` dimension/EmailId cannot be combined with the `broadcast` dimension/BroadcastId."
+
+	_, err := client.Emails.MetricsWithOptions(context.Background(), &MetricsOptions{
+		Dimensions: []MetricsDimension{MetricsDimensionEmail, MetricsDimensionBroadcast},
+	})
+	assert.Error(t, err)
+	assert.Equal(t, wantErr, err.Error())
+
+	_, err = client.Emails.MetricsWithOptions(context.Background(), &MetricsOptions{
+		Dimensions: []MetricsDimension{MetricsDimensionBroadcast},
+		EmailId:    []string{"4dd369bc-aa82-4ff3-97de-514ae3000ee0"},
+	})
+	assert.Error(t, err)
+	assert.Equal(t, wantErr, err.Error())
+
+	_, err = client.Emails.MetricsWithOptions(context.Background(), &MetricsOptions{
+		Dimensions:  []MetricsDimension{MetricsDimensionEmail},
+		BroadcastId: []string{"5a5a3b1e-3b1a-4b1a-8b1a-3b1a4b1a8b1a"},
+	})
+	assert.Error(t, err)
+	assert.Equal(t, wantErr, err.Error())
+
+	_, err = client.Emails.MetricsWithOptions(context.Background(), &MetricsOptions{
+		EmailId:     []string{"4dd369bc-aa82-4ff3-97de-514ae3000ee0"},
+		BroadcastId: []string{"5a5a3b1e-3b1a-4b1a-8b1a-3b1a4b1a8b1a"},
+	})
+	assert.Error(t, err)
+	assert.Equal(t, wantErr, err.Error())
+}
+
 func TestEmailsMetricsWithMetricsGranularityAndTimezone(t *testing.T) {
 	setup()
 	defer teardown()

--- a/emails_test.go
+++ b/emails_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -983,4 +984,440 @@ func TestSendEmailWithTopicId(t *testing.T) {
 		t.Errorf("Emails.Send returned error: %v", err)
 	}
 	assert.Equal(t, "topic-email-001", resp.Id)
+}
+
+func TestEmailsMetrics(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/emails/metrics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, "", r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"object": "metrics",
+			"start_date": "2026-07-01T00:00:00.000Z",
+			"end_date": "2026-07-08T00:00:00.000Z",
+			"metrics": ["delivered", "opened"],
+			"dimensions": [],
+			"granularity": "daily",
+			"totals": {"delivered": 100, "opened": 40}
+		}`)
+	})
+
+	resp, err := client.Emails.Metrics()
+	if err != nil {
+		t.Fatalf("Emails.Metrics returned error: %v", err)
+	}
+	assert.Equal(t, "metrics", resp.Object)
+	assert.Equal(t, "2026-07-01T00:00:00.000Z", resp.StartDate)
+	assert.Equal(t, "2026-07-08T00:00:00.000Z", resp.EndDate)
+	assert.Equal(t, []string{"delivered", "opened"}, resp.Metrics)
+	assert.Equal(t, "daily", resp.Granularity)
+	assert.Equal(t, float64(100), resp.Totals["delivered"])
+	assert.Equal(t, float64(40), resp.Totals["opened"])
+	assert.Nil(t, resp.Data)
+}
+
+func TestEmailsMetricsWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/emails/metrics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"object": "metrics",
+			"start_date": "2026-07-01T00:00:00.000Z",
+			"end_date": "2026-07-08T00:00:00.000Z",
+			"metrics": ["delivered"],
+			"dimensions": [],
+			"granularity": "daily",
+			"totals": {"delivered": 5}
+		}`)
+	})
+
+	resp, err := client.Emails.MetricsWithContext(context.Background())
+	if err != nil {
+		t.Fatalf("Emails.MetricsWithContext returned error: %v", err)
+	}
+	assert.Equal(t, float64(5), resp.Totals["delivered"])
+}
+
+func TestEmailsMetricsWithPeriodDimension(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/emails/metrics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, "period", r.URL.Query().Get("dimensions"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"object": "metrics",
+			"start_date": "2026-07-01T00:00:00.000Z",
+			"end_date": "2026-07-08T00:00:00.000Z",
+			"metrics": ["delivered"],
+			"dimensions": ["period"],
+			"granularity": "daily",
+			"totals": {"delivered": 10},
+			"data": [
+				{"period": "2026-07-01", "delivered": 10}
+			]
+		}`)
+	})
+
+	resp, err := client.Emails.MetricsWithOptions(context.Background(), &MetricsOptions{
+		Dimensions: []MetricsDimension{MetricsDimensionPeriod},
+	})
+	if err != nil {
+		t.Fatalf("Emails.MetricsWithOptions returned error: %v", err)
+	}
+	assert.Equal(t, 1, len(resp.Data))
+	assert.NotNil(t, resp.Data[0].Period)
+	assert.Equal(t, "2026-07-01", *resp.Data[0].Period)
+	assert.NotNil(t, resp.Data[0].Delivered)
+	assert.Equal(t, int64(10), *resp.Data[0].Delivered)
+}
+
+func TestEmailsMetricsWithDomainDimension(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/emails/metrics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, "domain", r.URL.Query().Get("dimensions"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"object": "metrics",
+			"start_date": "2026-07-01T00:00:00.000Z",
+			"end_date": "2026-07-08T00:00:00.000Z",
+			"metrics": ["delivered"],
+			"dimensions": ["domain"],
+			"granularity": "daily",
+			"totals": {"delivered": 10},
+			"data": [
+				{"domain_id": "d1a2b3c4-0000-4000-8000-000000000001", "domain_name": "example.com", "delivered": 10}
+			]
+		}`)
+	})
+
+	resp, err := client.Emails.MetricsWithOptions(context.Background(), &MetricsOptions{
+		Dimensions: []MetricsDimension{MetricsDimensionDomain},
+	})
+	if err != nil {
+		t.Fatalf("Emails.MetricsWithOptions returned error: %v", err)
+	}
+	assert.Equal(t, 1, len(resp.Data))
+	assert.NotNil(t, resp.Data[0].DomainId)
+	assert.Equal(t, "d1a2b3c4-0000-4000-8000-000000000001", *resp.Data[0].DomainId)
+	assert.NotNil(t, resp.Data[0].DomainName)
+	assert.Equal(t, "example.com", *resp.Data[0].DomainName)
+}
+
+func TestEmailsMetricsWithEmailDimension(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/emails/metrics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, "email", r.URL.Query().Get("dimensions"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"object": "metrics",
+			"start_date": "2026-07-01T00:00:00.000Z",
+			"end_date": "2026-07-08T00:00:00.000Z",
+			"metrics": ["delivered"],
+			"dimensions": ["email"],
+			"granularity": "daily",
+			"totals": {"delivered": 1},
+			"data": [
+				{"email_id": "e1a2b3c4-0000-4000-8000-000000000002", "delivered": 1}
+			]
+		}`)
+	})
+
+	resp, err := client.Emails.MetricsWithOptions(context.Background(), &MetricsOptions{
+		Dimensions: []MetricsDimension{MetricsDimensionEmail},
+	})
+	if err != nil {
+		t.Fatalf("Emails.MetricsWithOptions returned error: %v", err)
+	}
+	assert.Equal(t, 1, len(resp.Data))
+	assert.NotNil(t, resp.Data[0].EmailId)
+	assert.Equal(t, "e1a2b3c4-0000-4000-8000-000000000002", *resp.Data[0].EmailId)
+}
+
+func TestEmailsMetricsWithBroadcastDimension(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/emails/metrics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, "broadcast", r.URL.Query().Get("dimensions"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"object": "metrics",
+			"start_date": "2026-07-01T00:00:00.000Z",
+			"end_date": "2026-07-08T00:00:00.000Z",
+			"metrics": ["delivered", "opened"],
+			"dimensions": ["broadcast"],
+			"granularity": "daily",
+			"totals": {"delivered": 10, "opened": 4},
+			"data": [
+				{"broadcast_id": "b1a2b3c4-0000-4000-8000-000000000003", "broadcast_name": "July Newsletter", "delivered": 10, "opened": 4}
+			]
+		}`)
+	})
+
+	resp, err := client.Emails.MetricsWithOptions(context.Background(), &MetricsOptions{
+		Dimensions: []MetricsDimension{MetricsDimensionBroadcast},
+	})
+	if err != nil {
+		t.Fatalf("Emails.MetricsWithOptions returned error: %v", err)
+	}
+	assert.Equal(t, 1, len(resp.Data))
+	assert.NotNil(t, resp.Data[0].BroadcastId)
+	assert.Equal(t, "b1a2b3c4-0000-4000-8000-000000000003", *resp.Data[0].BroadcastId)
+	assert.NotNil(t, resp.Data[0].BroadcastName)
+	assert.Equal(t, "July Newsletter", *resp.Data[0].BroadcastName)
+	assert.Equal(t, int64(4), *resp.Data[0].Opened)
+}
+
+func TestEmailsMetricsWithSingleDomainIdFilter(t *testing.T) {
+	setup()
+	defer teardown()
+
+	domainId := "d1a2b3c4-0000-4000-8000-000000000001"
+
+	mux.HandleFunc("/emails/metrics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, domainId, r.URL.Query().Get("domain_id"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"object": "metrics",
+			"start_date": "2026-07-01T00:00:00.000Z",
+			"end_date": "2026-07-08T00:00:00.000Z",
+			"metrics": ["delivered"],
+			"dimensions": [],
+			"granularity": "daily",
+			"totals": {"delivered": 3}
+		}`)
+	})
+
+	_, err := client.Emails.MetricsWithOptions(context.Background(), &MetricsOptions{
+		DomainId: []string{domainId},
+	})
+	if err != nil {
+		t.Fatalf("Emails.MetricsWithOptions returned error: %v", err)
+	}
+}
+
+func TestEmailsMetricsWithMultipleDomainIdFilter(t *testing.T) {
+	setup()
+	defer teardown()
+
+	domainIds := []string{
+		"d1a2b3c4-0000-4000-8000-000000000001",
+		"d1a2b3c4-0000-4000-8000-000000000002",
+	}
+
+	mux.HandleFunc("/emails/metrics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, strings.Join(domainIds, ","), r.URL.Query().Get("domain_id"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"object": "metrics",
+			"start_date": "2026-07-01T00:00:00.000Z",
+			"end_date": "2026-07-08T00:00:00.000Z",
+			"metrics": ["delivered"],
+			"dimensions": [],
+			"granularity": "daily",
+			"totals": {"delivered": 6}
+		}`)
+	})
+
+	_, err := client.Emails.MetricsWithOptions(context.Background(), &MetricsOptions{
+		DomainId: domainIds,
+	})
+	if err != nil {
+		t.Fatalf("Emails.MetricsWithOptions returned error: %v", err)
+	}
+}
+
+func TestEmailsMetricsWithSingleEmailIdFilter(t *testing.T) {
+	setup()
+	defer teardown()
+
+	emailId := "e1a2b3c4-0000-4000-8000-000000000001"
+
+	mux.HandleFunc("/emails/metrics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, emailId, r.URL.Query().Get("email_id"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"object": "metrics",
+			"start_date": "2026-07-01T00:00:00.000Z",
+			"end_date": "2026-07-08T00:00:00.000Z",
+			"metrics": ["delivered"],
+			"dimensions": [],
+			"granularity": "daily",
+			"totals": {"delivered": 1}
+		}`)
+	})
+
+	_, err := client.Emails.MetricsWithOptions(context.Background(), &MetricsOptions{
+		EmailId: []string{emailId},
+	})
+	if err != nil {
+		t.Fatalf("Emails.MetricsWithOptions returned error: %v", err)
+	}
+}
+
+func TestEmailsMetricsWithMultipleEmailIdFilter(t *testing.T) {
+	setup()
+	defer teardown()
+
+	emailIds := []string{
+		"e1a2b3c4-0000-4000-8000-000000000001",
+		"e1a2b3c4-0000-4000-8000-000000000002",
+	}
+
+	mux.HandleFunc("/emails/metrics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, strings.Join(emailIds, ","), r.URL.Query().Get("email_id"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"object": "metrics",
+			"start_date": "2026-07-01T00:00:00.000Z",
+			"end_date": "2026-07-08T00:00:00.000Z",
+			"metrics": ["delivered"],
+			"dimensions": [],
+			"granularity": "daily",
+			"totals": {"delivered": 2}
+		}`)
+	})
+
+	_, err := client.Emails.MetricsWithOptions(context.Background(), &MetricsOptions{
+		EmailId: emailIds,
+	})
+	if err != nil {
+		t.Fatalf("Emails.MetricsWithOptions returned error: %v", err)
+	}
+}
+
+func TestEmailsMetricsWithSingleBroadcastIdFilter(t *testing.T) {
+	setup()
+	defer teardown()
+
+	broadcastId := "b1a2b3c4-0000-4000-8000-000000000001"
+
+	mux.HandleFunc("/emails/metrics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, broadcastId, r.URL.Query().Get("broadcast_id"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"object": "metrics",
+			"start_date": "2026-07-01T00:00:00.000Z",
+			"end_date": "2026-07-08T00:00:00.000Z",
+			"metrics": ["delivered"],
+			"dimensions": [],
+			"granularity": "daily",
+			"totals": {"delivered": 12}
+		}`)
+	})
+
+	_, err := client.Emails.MetricsWithOptions(context.Background(), &MetricsOptions{
+		BroadcastId: []string{broadcastId},
+	})
+	if err != nil {
+		t.Fatalf("Emails.MetricsWithOptions returned error: %v", err)
+	}
+}
+
+func TestEmailsMetricsWithMultipleBroadcastIdFilter(t *testing.T) {
+	setup()
+	defer teardown()
+
+	broadcastIds := []string{
+		"b1a2b3c4-0000-4000-8000-000000000001",
+		"b1a2b3c4-0000-4000-8000-000000000002",
+	}
+
+	mux.HandleFunc("/emails/metrics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, strings.Join(broadcastIds, ","), r.URL.Query().Get("broadcast_id"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"object": "metrics",
+			"start_date": "2026-07-01T00:00:00.000Z",
+			"end_date": "2026-07-08T00:00:00.000Z",
+			"metrics": ["delivered"],
+			"dimensions": [],
+			"granularity": "daily",
+			"totals": {"delivered": 20}
+		}`)
+	})
+
+	_, err := client.Emails.MetricsWithOptions(context.Background(), &MetricsOptions{
+		BroadcastId: broadcastIds,
+	})
+	if err != nil {
+		t.Fatalf("Emails.MetricsWithOptions returned error: %v", err)
+	}
+}
+
+func TestEmailsMetricsWithMetricsGranularityAndTimezone(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/emails/metrics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		query := r.URL.Query()
+		assert.Equal(t, "delivered,opened,clicked", query.Get("metrics"))
+		assert.Equal(t, "hourly", query.Get("granularity"))
+		assert.Equal(t, "America/New_York", query.Get("timezone"))
+		assert.Equal(t, "2026-07-01", query.Get("start_date"))
+		assert.Equal(t, "2026-07-08", query.Get("end_date"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"object": "metrics",
+			"start_date": "2026-07-01T00:00:00.000Z",
+			"end_date": "2026-07-08T00:00:00.000Z",
+			"metrics": ["delivered", "opened", "clicked"],
+			"dimensions": [],
+			"granularity": "hourly",
+			"totals": {"delivered": 10, "opened": 4, "clicked": 2}
+		}`)
+	})
+
+	startDate := "2026-07-01"
+	endDate := "2026-07-08"
+	timezone := "America/New_York"
+	granularity := MetricsGranularityHourly
+
+	resp, err := client.Emails.MetricsWithOptions(context.Background(), &MetricsOptions{
+		StartDate:   &startDate,
+		EndDate:     &endDate,
+		Timezone:    &timezone,
+		Granularity: &granularity,
+		Metrics:     []MetricName{MetricDelivered, MetricOpened, MetricClicked},
+	})
+	if err != nil {
+		t.Fatalf("Emails.MetricsWithOptions returned error: %v", err)
+	}
+	assert.Equal(t, "hourly", resp.Granularity)
+	assert.Equal(t, []string{"delivered", "opened", "clicked"}, resp.Metrics)
 }

--- a/errors.go
+++ b/errors.go
@@ -71,6 +71,7 @@ var (
 	ErrFailedToCreateEmailsGetAttachmentRequest   = errors.New("[ERROR]: Failed to create Emails.GetAttachment request")
 	ErrFailedToCreateEmailsListAttachmentsRequest = errors.New("[ERROR]: Failed to create Emails.ListAttachments request")
 	ErrFailedToCreateEmailsShareRequest           = errors.New("[ERROR]: Failed to create Emails.Share request")
+	ErrFailedToCreateEmailsMetricsRequest         = errors.New("[ERROR]: Failed to create Emails.Metrics request")
 )
 
 // TemplatesSvc errors


### PR DESCRIPTION
Adds `Emails.MetricsWithOptions` for account-level email metrics via `GET /emails/metrics` — `period`/`domain`/`email`/`broadcast` dimensions, `domain_id`/`email_id`/`broadcast_id` filters (`broadcast` and `email` mutually exclusive), `hourly`/`daily`/`weekly`/`monthly` granularity.

Mirrors https://github.com/resend/resend-node/pull/1079. Spec: https://github.com/resend/resend-openapi/pull/96