### PR TITLE
feat: add broadcasts.ClickedLinks() method

### DIFF
--- a/broadcasts.go
+++ b/broadcasts.go
@@ -151,6 +151,21 @@ type ListBroadcastRecipientsOptions struct {
 	Before *string
 }
 
+type ListBroadcastClickedLinksResponse struct {
+	Object  string                 `json:"object"`
+	Data    []BroadcastClickedLink `json:"data"`
+	HasMore bool                   `json:"has_more"`
+}
+
+type BroadcastClickedLink struct {
+	// Id is an opaque cursor for this row, used only for pagination. It does
+	// not identify any entity in Resend.
+	Id           string `json:"id"`
+	Url          string `json:"url"`
+	Clicks       int    `json:"clicks"`
+	UniqueClicks int    `json:"unique_clicks"`
+}
+
 type Broadcast struct {
 	Object      string   `json:"object"`
 	Id          string   `json:"id"`
@@ -179,6 +194,10 @@ type BroadcastsSvc interface {
 	ListWithOptions(ctx context.Context, options *ListOptions) (ListBroadcastsResponse, error)
 	ListWithContext(ctx context.Context) (ListBroadcastsResponse, error)
 	List() (ListBroadcastsResponse, error)
+
+	ClickedLinksWithOptions(ctx context.Context, broadcastId string, options *ListOptions) (ListBroadcastClickedLinksResponse, error)
+	ClickedLinksWithContext(ctx context.Context, broadcastId string) (ListBroadcastClickedLinksResponse, error)
+	ClickedLinks(broadcastId string) (ListBroadcastClickedLinksResponse, error)
 
 	GetWithContext(ctx context.Context, broadcastId string) (Broadcast, error)
 	Get(broadcastId string) (Broadcast, error)
@@ -484,4 +503,42 @@ func (s *BroadcastsSvcImpl) RecipientsWithContext(ctx context.Context, broadcast
 // clicked, or bounced.
 func (s *BroadcastsSvcImpl) Recipients(broadcastId string, options *ListBroadcastRecipientsOptions) (ListBroadcastRecipientsResponse, error) {
 	return s.RecipientsWithContext(context.Background(), broadcastId, options)
+}
+
+// ClickedLinksWithOptions returns the clicked links for a broadcast with pagination options
+// https://resend.com/docs/api-reference/broadcasts/list-broadcast-clicked-links
+func (s *BroadcastsSvcImpl) ClickedLinksWithOptions(ctx context.Context, broadcastId string, options *ListOptions) (ListBroadcastClickedLinksResponse, error) {
+	if broadcastId == "" {
+		return ListBroadcastClickedLinksResponse{}, errors.New("[ERROR]: broadcastId cannot be empty")
+	}
+
+	path := "broadcasts/" + broadcastId + "/clicked-links" + buildPaginationQuery(options)
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return ListBroadcastClickedLinksResponse{}, errors.New("[ERROR]: Failed to create Broadcasts.ClickedLinks request")
+	}
+
+	clickedLinks := new(ListBroadcastClickedLinksResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, clickedLinks)
+
+	if err != nil {
+		return ListBroadcastClickedLinksResponse{}, err
+	}
+
+	return *clickedLinks, nil
+}
+
+// ClickedLinksWithContext returns the clicked links for a broadcast
+// https://resend.com/docs/api-reference/broadcasts/list-broadcast-clicked-links
+func (s *BroadcastsSvcImpl) ClickedLinksWithContext(ctx context.Context, broadcastId string) (ListBroadcastClickedLinksResponse, error) {
+	return s.ClickedLinksWithOptions(ctx, broadcastId, nil)
+}
+
+// ClickedLinks returns the clicked links for a broadcast
+func (s *BroadcastsSvcImpl) ClickedLinks(broadcastId string) (ListBroadcastClickedLinksResponse, error) {
+	return s.ClickedLinksWithContext(context.Background(), broadcastId)
 }

--- a/broadcasts_test.go
+++ b/broadcasts_test.go
@@ -1,6 +1,7 @@
 package resend
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -595,5 +596,100 @@ func TestBroadcastRecipientsValidations(t *testing.T) {
 	assert.NotNil(t, err)
 	if err != nil {
 		assert.Equal(t, err.Error(), "[ERROR]: Type cannot be empty")
+	}
+}
+
+func TestBroadcastsClickedLinks(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/clicked-links", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "list",
+			"has_more": false,
+			"data": [
+				{
+					"id": "b2Zmc2V0OjA",
+					"url": "https://resend.com/pricing",
+					"clicks": 42,
+					"unique_clicks": 30
+				},
+				{
+					"id": "b2Zmc2V0OjE",
+					"url": "https://resend.com/docs",
+					"clicks": 17,
+					"unique_clicks": 15
+				}
+			]
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	clickedLinks, err := client.Broadcasts.ClickedLinks("559ac32e-9ef5-46fb-82a1-b76b840c0f7b")
+	if err != nil {
+		t.Errorf("Broadcasts.ClickedLinks returned error: %v", err)
+	}
+
+	assert.Equal(t, clickedLinks.Object, "list")
+	assert.Equal(t, len(clickedLinks.Data), 2)
+	assert.Equal(t, clickedLinks.Data[0].Url, "https://resend.com/pricing")
+	assert.Equal(t, clickedLinks.Data[0].Clicks, 42)
+	assert.Equal(t, clickedLinks.Data[0].UniqueClicks, 30)
+}
+
+func TestBroadcastsClickedLinksWithOptions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/clicked-links", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, r.URL.Query().Get("limit"), "1")
+		assert.Equal(t, r.URL.Query().Get("after"), "cursor-value")
+		w.WriteHeader(http.StatusOK)
+
+		ret := `
+		{
+			"object": "list",
+			"has_more": true,
+			"data": [
+				{
+					"id": "b2Zmc2V0OjA",
+					"url": "https://resend.com/pricing",
+					"clicks": 42,
+					"unique_clicks": 30
+				}
+			]
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	limit := 1
+	after := "cursor-value"
+	clickedLinks, err := client.Broadcasts.ClickedLinksWithOptions(context.Background(), "559ac32e-9ef5-46fb-82a1-b76b840c0f7b", &ListOptions{
+		Limit: &limit,
+		After: &after,
+	})
+	if err != nil {
+		t.Errorf("Broadcasts.ClickedLinksWithOptions returned error: %v", err)
+	}
+
+	assert.Equal(t, clickedLinks.HasMore, true)
+	assert.Equal(t, len(clickedLinks.Data), 1)
+}
+
+func TestBroadcastsClickedLinksValidations(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, err := client.Broadcasts.ClickedLinks("")
+	assert.NotNil(t, err)
+	if err != nil {
+		assert.Equal(t, err.Error(), "[ERROR]: broadcastId cannot be empty")
 	}
 }


### PR DESCRIPTION
Adds `GET /broadcasts/{id}/clicked-links` — paginated list of a broadcast's clicked links (`url`, `clicks`, `unique_clicks`).

Spec: resend/resend-openapi#95
Reference implementation: resend/resend-node#1077

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GET `/broadcasts/{id}/clicked-links` to fetch a broadcast’s clicked links with pagination. Previously the client could not fetch clicked links; now it supports per-link analytics and validates empty `broadcastId`.

- Defines `ListBroadcastClickedLinksResponse` and `BroadcastClickedLink` with `id` (opaque pagination cursor), `url`, `clicks`, and `unique_clicks`.
- Adds `BroadcastsSvc` methods: `ClickedLinks`, `ClickedLinksWithContext`, and `ClickedLinksWithOptions`; pagination via `ListOptions` (`limit`, `after`); returns "[ERROR]: broadcastId cannot be empty" if missing.
- Tests cover default retrieval, pagination query params, and validation.
- Migration: if you implement `BroadcastsSvc`, add the three new methods.

<sup>Written for commit 98756e206f89942e9d5c4fd6d8c19a3baefa8e48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

