### PR TITLE
chore: bump version to 3.17.0

### DIFF
--- a/resend.go
+++ b/resend.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version     = "3.12.0"
+	version     = "3.17.0"
 	userAgent   = "resend-go/" + version
 	contentType = "application/json"
 )


### PR DESCRIPTION
Bumps the version for the release that ships:
- Emails.Metrics (#152)
- broadcasts.ClickedLinks() (#153)
- broadcasts.Recipients() (#151)

Also corrects the `version` constant, which had drifted to 3.12.0 while the repo had already been tagged through v3.16.0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the client version constant to 3.17.0 so outbound requests advertise the correct `resend-go` version. Previously requests reported 3.12.0; now they report 3.17.0, aligning with the release and analytics.

**Includes**
- `Emails.Metrics`
- `broadcasts.ClickedLinks()`
- `broadcasts.Recipients()`

<sup>Written for commit 506376b1f580d4b82a1a70bbddeb0020cc6f96f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

