### PR TITLE
chore: bump version to 3.18.0

### DIFF
--- a/resend.go
+++ b/resend.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version     = "3.17.0"
+	version     = "3.18.0"
 	userAgent   = "resend-go/" + version
 	contentType = "application/json"
 )


### PR DESCRIPTION
Bumps the version for the release that ships:
- fix(contacts): properties response shape (#146)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `resend-go` to 3.18.0 to ship the contacts properties response shape fix. Updates the client user agent to reflect the new version.

- Fix: contacts properties response now matches the documented API shape; previously it returned an inconsistent shape. Clients relying on the old shape must update their parsing to the documented structure.

<sup>Written for commit 39a4596dff58d671ff1c61b8893414b50f755022. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

