### PR TITLE
chore!: release v4.0.0 with the /v4 module path

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 ![Build](https://github.com/resend/resend-go/actions/workflows/go.yml/badge.svg)
 ![Release](https://img.shields.io/github/release/resend/resend-go.svg?style=flat-square)
-[![Go Reference](https://pkg.go.dev/badge/github.com/resend/resend-go/v3.svg)](https://pkg.go.dev/github.com/resend/resend-go/v3)
+[![Go Reference](https://pkg.go.dev/badge/github.com/resend/resend-go/v4.svg)](https://pkg.go.dev/github.com/resend/resend-go/v4)
 ---
 
 ## Installation
@@ -11,7 +11,7 @@
 To install the Go SDK, simply execute the following command on a terminal:
 
 ```
-go get github.com/resend/resend-go/v3
+go get github.com/resend/resend-go/v4
 ```
 
 ## Setup
@@ -25,7 +25,7 @@ package main
 
 import (
     "fmt"
-    "github.com/resend/resend-go/v3"
+    "github.com/resend/resend-go/v4"
 )
 
 func main() {

--- a/examples/api_keys.go
+++ b/examples/api_keys.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func apiKeysExample() {

--- a/examples/audiences.go
+++ b/examples/audiences.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 // audiencesExample demonstrates the deprecated Audiences API

--- a/examples/automations.go
+++ b/examples/automations.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func automationsExample() {

--- a/examples/broadcasts.go
+++ b/examples/broadcasts.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func broadcastExamples() {

--- a/examples/contact_imports.go
+++ b/examples/contact_imports.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func contactImportsExample() {

--- a/examples/contact_properties.go
+++ b/examples/contact_properties.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func contactPropertiesExample() {

--- a/examples/contact_segments.go
+++ b/examples/contact_segments.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func contactSegmentsExample() {

--- a/examples/contacts.go
+++ b/examples/contacts.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func contactsExample() {

--- a/examples/domain_claims.go
+++ b/examples/domain_claims.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func domainClaimsExample() {

--- a/examples/domains.go
+++ b/examples/domains.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func domainsExample() {

--- a/examples/events.go
+++ b/examples/events.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func eventsExample() {

--- a/examples/global_contacts.go
+++ b/examples/global_contacts.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func globalContactsExample() {

--- a/examples/handle_rate_limit.go
+++ b/examples/handle_rate_limit.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func handleRateLimitExample() {

--- a/examples/logs.go
+++ b/examples/logs.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func logsExample() {

--- a/examples/oauth_grants.go
+++ b/examples/oauth_grants.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func oauthGrantsExample() {

--- a/examples/receiving.go
+++ b/examples/receiving.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func receivingExample() {

--- a/examples/schedule_email.go
+++ b/examples/schedule_email.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func scheduleEmail() {

--- a/examples/segments.go
+++ b/examples/segments.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func segmentsExample() {

--- a/examples/send_batch_email.go
+++ b/examples/send_batch_email.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func sendBatchEmails() {

--- a/examples/send_email.go
+++ b/examples/send_email.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func sendEmailExample() {

--- a/examples/send_email_custom_client.go
+++ b/examples/send_email_custom_client.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func sendEmailCustomClientExample() {

--- a/examples/send_email_with_template.go
+++ b/examples/send_email_with_template.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func sendEmailWithTemplateExample() {

--- a/examples/suppressions.go
+++ b/examples/suppressions.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func suppressionsExample() {

--- a/examples/templates.go
+++ b/examples/templates.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func templatesExample() {

--- a/examples/topics.go
+++ b/examples/topics.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func topicsExample() {

--- a/examples/webhook_receiver.go
+++ b/examples/webhook_receiver.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 // Demonstrates how to receive and verify webhooks

--- a/examples/webhooks.go
+++ b/examples/webhooks.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func webhooksExample() {

--- a/examples/with_attachments.go
+++ b/examples/with_attachments.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func withAttachments() {

--- a/examples/with_inline_attachments.go
+++ b/examples/with_inline_attachments.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func inlineAttachmentExample() {

--- a/examples/with_pagination.go
+++ b/examples/with_pagination.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/resend/resend-go/v3"
+	"github.com/resend/resend-go/v4"
 )
 
 func withPaginationExample() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/resend/resend-go/v3
+module github.com/resend/resend-go/v4
 
 go 1.23
 

--- a/resend.go
+++ b/resend.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version     = "3.17.0"
+	version     = "4.0.0"
 	userAgent   = "resend-go/" + version
 	contentType = "application/json"
 )


### PR DESCRIPTION
## ⚠️ Major release: v4.0.0, module path moves to `/v4`

Bumps the version for the release that ships two source-breaking changes together:

- `fix(contacts): properties response shape` (#146) — `Contact.Properties` goes from `map[string]any` to `map[string]ContactPropertyValue`
- `fix: allow null contact first_name and last_name` (#148) — `Contact.FirstName` / `LastName` go from `string` to `*string`

Both break consumer compilation, and Go requires the module path to carry the major version, so this release moves `github.com/resend/resend-go/v3` → `/v4`.

**Consumers must update their import path** to pick up this or any later release.

## What is in the diff

| Change | Files |
|---|---|
| `version` → `4.0.0` | `resend.go` |
| module path → `/v4` | `go.mod` |
| import path → `/v4` | `README.md` + 30 `examples/*.go` |

No behavior changes here. This is the release commit only, stacked on #148 so that PR stays reviewable as a pure behavior change.

## Migration for consumers

```go
// before
import "github.com/resend/resend-go/v3"
tier := contact.Properties["tier"].(string)
fmt.Println(contact.FirstName)

// after
import "github.com/resend/resend-go/v4"
tier := contact.Properties["tier"].Value
if contact.FirstName != nil {
    fmt.Println(*contact.FirstName)
}
```

`go build`, `go vet`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Releases v4.0.0 and moves the module path from `/v3` to `/v4` to satisfy Go’s major-version import rules after breaking changes in contacts. Updates versioning and import paths only; no runtime behavior changes.

- Sets version to 4.0.0 and module path to `github.com/resend/resend-go/v4` in `go.mod`, `resend.go`, `README.md`, and all examples.
- Migration: update imports to `github.com/resend/resend-go/v4`; handle `Contact.FirstName`/`LastName` as `*string` and read `Contact.Properties` via `.Value`.

<sup>Written for commit c495b74215601cc5655f40200cc87858b7a7b283. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

