### PR TITLE
feat(webhooks): add event listing endpoints

### DIFF
--- a/webhooks.go
+++ b/webhooks.go
@@ -42,6 +42,15 @@ const (
 // Default tolerance for timestamp validation (5 minutes)
 const DefaultWebhookToleranceSeconds = 300
 
+type WebhookEventStatus = string
+
+const (
+	WebhookEventStatusPending    WebhookEventStatus = "pending"
+	WebhookEventStatusAttempting WebhookEventStatus = "attempting"
+	WebhookEventStatusSuccess    WebhookEventStatus = "success"
+	WebhookEventStatusFailed     WebhookEventStatus = "failed"
+)
+
 // CreateWebhookRequest represents the parameters for creating a webhook
 type CreateWebhookRequest struct {
 	Endpoint string   `json:"endpoint"`
@@ -95,6 +104,52 @@ type WebhookInList struct {
 	Events    []string `json:"events"`
 }
 
+type ListWebhookEventsOptions struct {
+	Limit *int    `json:"limit,omitempty"`
+	After *string `json:"after,omitempty"`
+}
+
+type WebhookEventLog struct {
+	Id        string             `json:"id"`
+	Type      string             `json:"type"`
+	CreatedAt string             `json:"created_at"`
+	Status    WebhookEventStatus `json:"status"`
+}
+
+type ListWebhookEventsResponse struct {
+	Object  string            `json:"object"`
+	HasMore bool              `json:"has_more"`
+	Data    []WebhookEventLog `json:"data"`
+}
+
+type WebhookEvent struct {
+	Object        string             `json:"object"`
+	Id            string             `json:"id"`
+	Type          string             `json:"type"`
+	CreatedAt     string             `json:"created_at"`
+	Status        WebhookEventStatus `json:"status"`
+	NextAttemptAt *string            `json:"next_attempt_at"`
+	Payload       map[string]any     `json:"payload"`
+}
+
+type WebhookEventAttempt struct {
+	Id             string `json:"id"`
+	HttpStatusCode int    `json:"http_status_code"`
+	Response       string `json:"response"`
+	SentAt         string `json:"sent_at"`
+}
+
+type ListWebhookEventAttemptsOptions struct {
+	Limit *int    `json:"limit,omitempty"`
+	After *string `json:"after,omitempty"`
+}
+
+type ListWebhookEventAttemptsResponse struct {
+	Object  string                `json:"object"`
+	HasMore bool                  `json:"has_more"`
+	Data    []WebhookEventAttempt `json:"data"`
+}
+
 // DeleteWebhookResponse represents the response from deleting a webhook
 type DeleteWebhookResponse struct {
 	Object  string `json:"object"`
@@ -127,6 +182,14 @@ type WebhooksSvc interface {
 	ListWithOptions(ctx context.Context, options *ListOptions) (*ListWebhooksResponse, error)
 	ListWithContext(ctx context.Context) (*ListWebhooksResponse, error)
 	List() (*ListWebhooksResponse, error)
+	ListEventsWithOptions(ctx context.Context, webhookId string, options *ListWebhookEventsOptions) (*ListWebhookEventsResponse, error)
+	ListEventsWithContext(ctx context.Context, webhookId string) (*ListWebhookEventsResponse, error)
+	ListEvents(webhookId string) (*ListWebhookEventsResponse, error)
+	GetEventWithContext(ctx context.Context, webhookId string, eventId string) (*WebhookEvent, error)
+	GetEvent(webhookId string, eventId string) (*WebhookEvent, error)
+	ListEventAttemptsWithOptions(ctx context.Context, webhookId string, eventId string, options *ListWebhookEventAttemptsOptions) (*ListWebhookEventAttemptsResponse, error)
+	ListEventAttemptsWithContext(ctx context.Context, webhookId string, eventId string) (*ListWebhookEventAttemptsResponse, error)
+	ListEventAttempts(webhookId string, eventId string) (*ListWebhookEventAttemptsResponse, error)
 	RemoveWithContext(ctx context.Context, webhookId string) (*DeleteWebhookResponse, error)
 	Remove(webhookId string) (*DeleteWebhookResponse, error)
 	Verify(options *VerifyWebhookOptions) error
@@ -248,6 +311,87 @@ func (s *WebhooksSvcImpl) ListWithContext(ctx context.Context) (*ListWebhooksRes
 // List lists all webhooks
 func (s *WebhooksSvcImpl) List() (*ListWebhooksResponse, error) {
 	return s.ListWithContext(context.Background())
+}
+
+func (s *WebhooksSvcImpl) ListEventsWithOptions(ctx context.Context, webhookId string, options *ListWebhookEventsOptions) (*ListWebhookEventsResponse, error) {
+	paginationOptions := &ListOptions{}
+	if options != nil {
+		paginationOptions.Limit = options.Limit
+		paginationOptions.After = options.After
+	}
+	path := "webhooks/" + webhookId + "/events" + buildPaginationQuery(paginationOptions)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	response := new(ListWebhookEventsResponse)
+	_, err = s.client.Perform(req, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (s *WebhooksSvcImpl) ListEventsWithContext(ctx context.Context, webhookId string) (*ListWebhookEventsResponse, error) {
+	return s.ListEventsWithOptions(ctx, webhookId, nil)
+}
+
+func (s *WebhooksSvcImpl) ListEvents(webhookId string) (*ListWebhookEventsResponse, error) {
+	return s.ListEventsWithContext(context.Background(), webhookId)
+}
+
+func (s *WebhooksSvcImpl) GetEventWithContext(ctx context.Context, webhookId string, eventId string) (*WebhookEvent, error) {
+	path := "webhooks/" + webhookId + "/events/" + eventId
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	response := new(WebhookEvent)
+	_, err = s.client.Perform(req, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (s *WebhooksSvcImpl) GetEvent(webhookId string, eventId string) (*WebhookEvent, error) {
+	return s.GetEventWithContext(context.Background(), webhookId, eventId)
+}
+
+func (s *WebhooksSvcImpl) ListEventAttemptsWithOptions(ctx context.Context, webhookId string, eventId string, options *ListWebhookEventAttemptsOptions) (*ListWebhookEventAttemptsResponse, error) {
+	paginationOptions := &ListOptions{}
+	if options != nil {
+		paginationOptions.Limit = options.Limit
+		paginationOptions.After = options.After
+	}
+	path := "webhooks/" + webhookId + "/events/" + eventId + "/attempts" + buildPaginationQuery(paginationOptions)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	response := new(ListWebhookEventAttemptsResponse)
+	_, err = s.client.Perform(req, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (s *WebhooksSvcImpl) ListEventAttemptsWithContext(ctx context.Context, webhookId string, eventId string) (*ListWebhookEventAttemptsResponse, error) {
+	return s.ListEventAttemptsWithOptions(ctx, webhookId, eventId, nil)
+}
+
+func (s *WebhooksSvcImpl) ListEventAttempts(webhookId string, eventId string) (*ListWebhookEventAttemptsResponse, error) {
+	return s.ListEventAttemptsWithContext(context.Background(), webhookId, eventId)
 }
 
 // RemoveWithContext deletes a webhook by ID with the given context

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -312,6 +312,93 @@ func TestListWebhooksWithOptions(t *testing.T) {
 	assert.Equal(t, 1, len(resp.Data))
 }
 
+func TestListWebhookEvents(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/webhooks/webhook-id/events", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, "10", r.URL.Query().Get("limit"))
+		assert.Equal(t, "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2", r.URL.Query().Get("after"))
+		fmt.Fprint(w, `{
+			"object": "list",
+			"has_more": true,
+			"data": [{"id":"msg_1srOrx2ZWZBpBUvZwXKQmoEYga2","type":"email.sent","created_at":"2026-08-22T15:28:00.000Z","status":"success"}]
+		}`)
+	})
+
+	limit := 10
+	after := "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
+	resp, err := client.Webhooks.ListEventsWithOptions(context.Background(), "webhook-id", &ListWebhookEventsOptions{Limit: &limit, After: &after})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "list", resp.Object)
+	assert.True(t, resp.HasMore)
+	assert.Equal(t, WebhookEventLog{
+		Id:        "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2",
+		Type:      "email.sent",
+		CreatedAt: "2026-08-22T15:28:00.000Z",
+		Status:    WebhookEventStatusSuccess,
+	}, resp.Data[0])
+}
+
+func TestGetWebhookEvent(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/webhooks/webhook-id/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprint(w, `{
+			"object": "webhook_event",
+			"id": "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2",
+			"type": "email.sent",
+			"created_at": "2026-08-22T15:28:00.000Z",
+			"status": "failed",
+			"next_attempt_at": null,
+			"payload": {"type":"email.sent","data":{"email_id":"email-id"}}
+		}`)
+	})
+
+	resp, err := client.Webhooks.GetEvent("webhook-id", "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "webhook_event", resp.Object)
+	assert.Equal(t, WebhookEventStatusFailed, resp.Status)
+	assert.Nil(t, resp.NextAttemptAt)
+	assert.Equal(t, "email.sent", resp.Payload["type"])
+	assert.Equal(t, "email-id", resp.Payload["data"].(map[string]any)["email_id"])
+}
+
+func TestListWebhookEventAttempts(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/webhooks/webhook-id/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2/attempts", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		assert.Equal(t, "5", r.URL.Query().Get("limit"))
+		assert.Equal(t, "atmpt_2ZbUCwvGmIT4mLIN6d3Yz0Ainbd", r.URL.Query().Get("after"))
+		fmt.Fprint(w, `{
+			"object": "list",
+			"has_more": false,
+			"data": [{"id":"atmpt_2ZbUCwvGmIT4mLIN6d3Yz0Ainbd","http_status_code":200,"response":"{\"ok\":true}","sent_at":"2026-08-22T15:33:12.000Z"}]
+		}`)
+	})
+
+	limit := 5
+	after := "atmpt_2ZbUCwvGmIT4mLIN6d3Yz0Ainbd"
+	resp, err := client.Webhooks.ListEventAttemptsWithOptions(context.Background(), "webhook-id", "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2", &ListWebhookEventAttemptsOptions{Limit: &limit, After: &after})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "list", resp.Object)
+	assert.False(t, resp.HasMore)
+	assert.Equal(t, WebhookEventAttempt{
+		Id:             "atmpt_2ZbUCwvGmIT4mLIN6d3Yz0Ainbd",
+		HttpStatusCode: 200,
+		Response:       `{"ok":true}`,
+		SentAt:         "2026-08-22T15:33:12.000Z",
+	}, resp.Data[0])
+}
+
 func TestRemoveWebhook(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Adds webhook event listing, retrieval, and delivery-attempt listing methods with endpoint-specific pagination and response models.

Linear: https://linear.app/resend/issue/DEV-1927

Tests: full test suite, build, formatting, and live API calls.