### PR TITLE
feat: add segments.Update() method

### DIFF
--- a/examples/segments.go
+++ b/examples/segments.go
@@ -76,6 +76,15 @@ func segmentsExample() {
 	}
 	fmt.Printf("You have %d segments in your project\n", len(segments.Data))
 
+	// Rename the segment
+	renamedSegment, err := client.Segments.UpdateWithContext(ctx, segment.Id, &resend.UpdateSegmentRequest{
+		Name: "Premium Users - Updated",
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Renamed segment: %s\n", renamedSegment.Name)
+
 	// Clean up: Remove the contact from the segment
 	removeFromSegment, err := client.Contacts.Segments.RemoveWithContext(ctx, &resend.RemoveContactSegmentRequest{
 		ContactId: contact.Id,

--- a/examples/segments.go
+++ b/examples/segments.go
@@ -83,7 +83,7 @@ func segmentsExample() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("Renamed segment: %s\n", renamedSegment.Name)
+	fmt.Printf("Renamed segment: %s\n", renamedSegment.Id)
 
 	// Clean up: Remove the contact from the segment
 	removeFromSegment, err := client.Contacts.Segments.RemoveWithContext(ctx, &resend.RemoveContactSegmentRequest{

--- a/segments.go
+++ b/segments.go
@@ -198,16 +198,13 @@ func (s *SegmentsSvcImpl) UpdateWithContext(ctx context.Context, segmentId strin
 
 	path := "segments/" + segmentId
 
-	// Prepare request
 	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, params)
 	if err != nil {
 		return UpdateSegmentResponse{}, errors.New("[ERROR]: Failed to create Segments.Update request")
 	}
 
-	// Build response recipient obj
 	segmentsResp := new(UpdateSegmentResponse)
 
-	// Send Request
 	_, err = s.client.Perform(req, segmentsResp)
 
 	if err != nil {

--- a/segments.go
+++ b/segments.go
@@ -189,6 +189,14 @@ func (s *SegmentsSvcImpl) Get(segmentId string) (Segment, error) {
 // UpdateWithContext updates a segment by id
 // https://resend.com/docs/api-reference/segments/update-segment
 func (s *SegmentsSvcImpl) UpdateWithContext(ctx context.Context, segmentId string, params *UpdateSegmentRequest) (UpdateSegmentResponse, error) {
+	if segmentId == "" {
+		return UpdateSegmentResponse{}, errors.New("[ERROR]: segmentId cannot be empty")
+	}
+
+	if params == nil || params.Name == "" {
+		return UpdateSegmentResponse{}, errors.New("[ERROR]: Name cannot be empty")
+	}
+
 	path := "segments/" + segmentId
 
 	// Prepare request

--- a/segments.go
+++ b/segments.go
@@ -40,7 +40,6 @@ type UpdateSegmentRequest struct {
 
 type UpdateSegmentResponse struct {
 	Id     string `json:"id"`
-	Name   string `json:"name"`
 	Object string `json:"object"`
 }
 

--- a/segments.go
+++ b/segments.go
@@ -14,6 +14,8 @@ type SegmentsSvc interface {
 	List() (ListSegmentsResponse, error)
 	GetWithContext(ctx context.Context, segmentId string) (Segment, error)
 	Get(segmentId string) (Segment, error)
+	UpdateWithContext(ctx context.Context, segmentId string, params *UpdateSegmentRequest) (UpdateSegmentResponse, error)
+	Update(segmentId string, params *UpdateSegmentRequest) (UpdateSegmentResponse, error)
 	RemoveWithContext(ctx context.Context, segmentId string) (RemoveSegmentResponse, error)
 	Remove(segmentId string) (RemoveSegmentResponse, error)
 }
@@ -27,6 +29,16 @@ type CreateSegmentRequest struct {
 }
 
 type CreateSegmentResponse struct {
+	Id     string `json:"id"`
+	Name   string `json:"name"`
+	Object string `json:"object"`
+}
+
+type UpdateSegmentRequest struct {
+	Name string `json:"name"`
+}
+
+type UpdateSegmentResponse struct {
 	Id     string `json:"id"`
 	Name   string `json:"name"`
 	Object string `json:"object"`
@@ -172,4 +184,34 @@ func (s *SegmentsSvcImpl) GetWithContext(ctx context.Context, segmentId string) 
 // https://resend.com/docs/api-reference/segments/get-segment
 func (s *SegmentsSvcImpl) Get(segmentId string) (Segment, error) {
 	return s.GetWithContext(context.Background(), segmentId)
+}
+
+// UpdateWithContext updates a segment by id
+// https://resend.com/docs/api-reference/segments/update-segment
+func (s *SegmentsSvcImpl) UpdateWithContext(ctx context.Context, segmentId string, params *UpdateSegmentRequest) (UpdateSegmentResponse, error) {
+	path := "segments/" + segmentId
+
+	// Prepare request
+	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, params)
+	if err != nil {
+		return UpdateSegmentResponse{}, errors.New("[ERROR]: Failed to create Segments.Update request")
+	}
+
+	// Build response recipient obj
+	segmentsResp := new(UpdateSegmentResponse)
+
+	// Send Request
+	_, err = s.client.Perform(req, segmentsResp)
+
+	if err != nil {
+		return UpdateSegmentResponse{}, err
+	}
+
+	return *segmentsResp, nil
+}
+
+// Update updates a segment by id
+// https://resend.com/docs/api-reference/segments/update-segment
+func (s *SegmentsSvcImpl) Update(segmentId string, params *UpdateSegmentRequest) (UpdateSegmentResponse, error) {
+	return s.UpdateWithContext(context.Background(), segmentId, params)
 }

--- a/segments_test.go
+++ b/segments_test.go
@@ -117,8 +117,7 @@ func TestUpdateSegment(t *testing.T) {
 		ret = `
 		{
 			"object": "segment",
-			"id": "d91cd9bd-1176-453e-8fc1-35364d380206",
-			"name": "Renamed Segment"
+			"id": "d91cd9bd-1176-453e-8fc1-35364d380206"
 		}`
 
 		fmt.Fprint(w, ret)
@@ -133,7 +132,6 @@ func TestUpdateSegment(t *testing.T) {
 	}
 	assert.Equal(t, resp.Id, "d91cd9bd-1176-453e-8fc1-35364d380206")
 	assert.Equal(t, resp.Object, "segment")
-	assert.Equal(t, resp.Name, "Renamed Segment")
 }
 
 func TestUpdateSegmentWithContext(t *testing.T) {
@@ -149,8 +147,7 @@ func TestUpdateSegmentWithContext(t *testing.T) {
 		ret = `
 		{
 			"object": "segment",
-			"id": "context-update-id",
-			"name": "Context Renamed Segment"
+			"id": "context-update-id"
 		}`
 
 		fmt.Fprint(w, ret)
@@ -165,7 +162,6 @@ func TestUpdateSegmentWithContext(t *testing.T) {
 	}
 	assert.Equal(t, resp.Id, "context-update-id")
 	assert.Equal(t, resp.Object, "segment")
-	assert.Equal(t, resp.Name, "Context Renamed Segment")
 }
 
 func TestUpdateSegmentNotFound(t *testing.T) {

--- a/segments_test.go
+++ b/segments_test.go
@@ -1,6 +1,7 @@
 package resend
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -101,6 +102,98 @@ func TestRemoveSegment(t *testing.T) {
 	assert.True(t, deleted.Deleted)
 	assert.Equal(t, deleted.Id, "b6d24b8e-af0b-4c3c-be0c-359bbd97381e")
 	assert.Equal(t, deleted.Object, "segment")
+}
+
+func TestUpdateSegment(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/segments/d91cd9bd-1176-453e-8fc1-35364d380206", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		var ret any
+		ret = `
+		{
+			"object": "segment",
+			"id": "d91cd9bd-1176-453e-8fc1-35364d380206",
+			"name": "Renamed Segment"
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	req := &UpdateSegmentRequest{
+		Name: "Renamed Segment",
+	}
+	resp, err := client.Segments.Update("d91cd9bd-1176-453e-8fc1-35364d380206", req)
+	if err != nil {
+		t.Errorf("Segments.Update returned error: %v", err)
+	}
+	assert.Equal(t, resp.Id, "d91cd9bd-1176-453e-8fc1-35364d380206")
+	assert.Equal(t, resp.Object, "segment")
+	assert.Equal(t, resp.Name, "Renamed Segment")
+}
+
+func TestUpdateSegmentWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/segments/context-update-id", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		var ret any
+		ret = `
+		{
+			"object": "segment",
+			"id": "context-update-id",
+			"name": "Context Renamed Segment"
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	ctx := context.Background()
+	resp, err := client.Segments.UpdateWithContext(ctx, "context-update-id", &UpdateSegmentRequest{
+		Name: "Context Renamed Segment",
+	})
+	if err != nil {
+		t.Errorf("Segments.UpdateWithContext returned error: %v", err)
+	}
+	assert.Equal(t, resp.Id, "context-update-id")
+	assert.Equal(t, resp.Object, "segment")
+	assert.Equal(t, resp.Name, "Context Renamed Segment")
+}
+
+func TestUpdateSegmentNotFound(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/segments/00000000-0000-0000-0000-000000000000", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPatch)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+
+		var ret any
+		ret = `
+		{
+			"statusCode": 404,
+			"name": "not_found",
+			"message": "Segment not found"
+		}`
+
+		fmt.Fprint(w, ret)
+	})
+
+	resp, err := client.Segments.Update("00000000-0000-0000-0000-000000000000", &UpdateSegmentRequest{
+		Name: "Renamed Segment",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Segment not found")
+	assert.Equal(t, UpdateSegmentResponse{}, resp)
 }
 
 func TestGetSegment(t *testing.T) {

--- a/segments_test.go
+++ b/segments_test.go
@@ -196,6 +196,39 @@ func TestUpdateSegmentNotFound(t *testing.T) {
 	assert.Equal(t, UpdateSegmentResponse{}, resp)
 }
 
+func TestUpdateSegmentEmptyId(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, err := client.Segments.Update("", &UpdateSegmentRequest{Name: "Renamed Segment"})
+	assert.NotNil(t, err)
+	if err != nil {
+		assert.Equal(t, err.Error(), "[ERROR]: segmentId cannot be empty")
+	}
+}
+
+func TestUpdateSegmentNilParams(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, err := client.Segments.Update("d91cd9bd-1176-453e-8fc1-35364d380206", nil)
+	assert.NotNil(t, err)
+	if err != nil {
+		assert.Equal(t, err.Error(), "[ERROR]: Name cannot be empty")
+	}
+}
+
+func TestUpdateSegmentEmptyName(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, err := client.Segments.Update("d91cd9bd-1176-453e-8fc1-35364d380206", &UpdateSegmentRequest{})
+	assert.NotNil(t, err)
+	if err != nil {
+		assert.Equal(t, err.Error(), "[ERROR]: Name cannot be empty")
+	}
+}
+
 func TestGetSegment(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
## Usage

```go
segment, err := client.Segments.UpdateWithContext(ctx, segmentId, &resend.UpdateSegmentRequest{
	Name: "Renamed Segment",
})
```

## Params

- `name` (`string`, required) — the new segment name.

## Response

```json
{
	"object": "segment",
	"id": "78261eea-8f8b-4381-83c6-79fa7120f1c"
}
```