### PR TITLE
chore: bump version to 4.2.0

### DIFF
--- a/resend.go
+++ b/resend.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version     = "4.0.0"
+	version     = "4.2.0"
 	userAgent   = "resend-go/" + version
 	contentType = "application/json"
 )


### PR DESCRIPTION
Bump the client version to 4.2.0. Minor release covering #157 (webhook event listing endpoints).

Linear: https://linear.app/resend/issue/DEV-1927

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the Go client version from 4.0.0 to 4.2.0 to cover the webhook event listing endpoints added in DEV-1927.

<sup>Written for commit 8ce8ab6df346ccda694a13ccf7c91d661d237436. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

