### PR TITLE
feat(webhooks): add event replay endpoint

### DIFF
--- a/examples/webhooks.go
+++ b/examples/webhooks.go
@@ -92,6 +92,13 @@ func webhooksExample() {
 		}
 		fmt.Printf("Webhook Event: %s (%s)\n", webhookEvent.Id, webhookEvent.Status)
 
+		// Replay Webhook Event
+		replayed, err := client.Webhooks.ReplayEventWithContext(ctx, created.Id, eventId)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("Replayed Webhook Event: %s\n", replayed.Id)
+
 		// List Webhook Event Attempts
 		attempts, err := client.Webhooks.ListEventAttemptsWithContext(ctx, created.Id, eventId)
 		if err != nil {

--- a/webhooks.go
+++ b/webhooks.go
@@ -141,6 +141,12 @@ type WebhookEvent struct {
 	Payload       map[string]any     `json:"payload"`
 }
 
+// ReplayWebhookEventResponse represents the response from replaying a webhook event.
+type ReplayWebhookEventResponse struct {
+	Object string `json:"object"`
+	Id     string `json:"id"`
+}
+
 // WebhookEventAttempt represents a delivery attempt for a webhook event.
 type WebhookEventAttempt struct {
 	Id             string `json:"id"`
@@ -199,6 +205,8 @@ type WebhooksSvc interface {
 	ListEvents(webhookId string) (*ListWebhookEventsResponse, error)
 	GetEventWithContext(ctx context.Context, webhookId string, eventId string) (*WebhookEvent, error)
 	GetEvent(webhookId string, eventId string) (*WebhookEvent, error)
+	ReplayEventWithContext(ctx context.Context, webhookId string, eventId string) (*ReplayWebhookEventResponse, error)
+	ReplayEvent(webhookId string, eventId string) (*ReplayWebhookEventResponse, error)
 	ListEventAttemptsWithOptions(ctx context.Context, webhookId string, eventId string, options *ListWebhookEventAttemptsOptions) (*ListWebhookEventAttemptsResponse, error)
 	ListEventAttemptsWithContext(ctx context.Context, webhookId string, eventId string) (*ListWebhookEventAttemptsResponse, error)
 	ListEventAttempts(webhookId string, eventId string) (*ListWebhookEventAttemptsResponse, error)
@@ -381,6 +389,30 @@ func (s *WebhooksSvcImpl) GetEventWithContext(ctx context.Context, webhookId str
 // GetEvent retrieves a webhook event by ID.
 func (s *WebhooksSvcImpl) GetEvent(webhookId string, eventId string) (*WebhookEvent, error) {
 	return s.GetEventWithContext(context.Background(), webhookId, eventId)
+}
+
+// ReplayEventWithContext queues one more delivery of a webhook event with the given context.
+// https://resend.com/docs/api-reference/webhooks/replay-event
+func (s *WebhooksSvcImpl) ReplayEventWithContext(ctx context.Context, webhookId string, eventId string) (*ReplayWebhookEventResponse, error) {
+	path := "webhooks/" + webhookId + "/events/" + eventId + "/replay"
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	response := new(ReplayWebhookEventResponse)
+	_, err = s.client.Perform(req, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+// ReplayEvent queues one more delivery of a webhook event.
+func (s *WebhooksSvcImpl) ReplayEvent(webhookId string, eventId string) (*ReplayWebhookEventResponse, error) {
+	return s.ReplayEventWithContext(context.Background(), webhookId, eventId)
 }
 
 // ListEventAttemptsWithOptions lists delivery attempts for a webhook event with pagination options.

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -369,6 +369,22 @@ func TestGetWebhookEvent(t *testing.T) {
 	assert.Equal(t, "email-id", resp.Payload["data"].(map[string]any)["email_id"])
 }
 
+func TestReplayWebhookEvent(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/webhooks/webhook-id/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2/replay", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+		fmt.Fprint(w, `{"object":"webhook_event","id":"msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"}`)
+	})
+
+	resp, err := client.Webhooks.ReplayEvent("webhook-id", "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "webhook_event", resp.Object)
+	assert.Equal(t, "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2", resp.Id)
+}
+
 func TestListWebhookEventAttempts(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
## What

Adds `POST /webhooks/{webhook_id}/events/{event_id}/replay` (`webhooks/replay-event`), which queues one more delivery of a webhook event. Placed next to `GetEvent`, same argument style.

```go
ReplayEventWithContext(ctx context.Context, webhookId string, eventId string) (*ReplayWebhookEventResponse, error)
ReplayEvent(webhookId string, eventId string) (*ReplayWebhookEventResponse, error)
```

`ReplayWebhookEventResponse` has `Object` and `Id`.

## Usage

```go
replayed, err := client.Webhooks.ReplayEvent(
	"4dd369bc-aa82-4ff3-97de-514ae3000ee0",
	"msg_1srOrx2ZWZBpBUvZwXKQmoEYga2",
)
if err != nil {
	panic(err)
}
fmt.Println(replayed.Id)
```

## References

- Spec: https://github.com/resend/resend-openapi/pull/112
- API: https://github.com/resend/resend-monorepo/pull/9535
- Docs: https://resend.com/docs/api-reference/webhooks/replay-event

## Checks

- `go build -v ./...`: pass
- `go vet ./...`: pass
- `go test ./...`: pass (includes new `TestReplayWebhookEvent` asserting `POST` on the exact path and the parsed response)
- `gofmt -l .`: clean for the files touched (`domains.go` and `examples/events.go` were already unformatted on main; left alone)

Also extends `examples/webhooks.go` with a replay call, following #160. No version bump (done in separate chore PRs). No live call made: replay is a write endpoint.

Part of DEV-2005.

Linear: https://linear.app/resend/issue/DEV-2013


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a webhook event replay endpoint that queues another delivery of a webhook event, completing DEV-2013.

**New Features**
- Adds `ReplayEventWithContext` and `ReplayEvent` methods with the new `ReplayWebhookEventResponse`.
- Updates `examples/webhooks.go` and adds test coverage for the replay path.

<sup>Written for commit 8ff4e39c4967637be978af39aae66330e8b978f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-go/pull/161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

